### PR TITLE
feat: add native reader+writer, HTML reader, LaTeX writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         # One entry per reader fuzz target (see fuzz/Cargo.toml). Add new readers here.
-        target: [commonmark, json]
+        target: [commonmark, json, native, html]
     steps:
       - uses: actions/checkout@v6
       - name: Install nightly toolchain

--- a/.typos.toml
+++ b/.typos.toml
@@ -17,3 +17,8 @@ extend-exclude = [
 [default.extend-words]
 # Document-format vocabulary that is not a typo
 fb2 = "fb2"
+# LaTeX enumerate counter names emitted by the LaTeX writer (\alph, \Alph).
+alph = "alph"
+Alph = "Alph"
+# Left when "café" renders with its accented byte as an octal escape ("caf\233").
+caf = "caf"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,16 @@ fine — CommonMark's "link reference definition" and "character reference", Rus
 the word.
 
 - The root AST type is `Document`, never `Pandoc`.
-- The JSON interchange format requires a literal `pandoc-api-version` key. Confine that one string
-  to a single named constant in `oxidoc-ast` and treat it as an opaque external protocol identifier
-  — it is the lone unavoidable occurrence; do not let the name spread.
+- A few external formats embed the upstream name in their own wire vocabulary. Those literals are
+  unavoidable for interoperability and are the **only** sanctioned occurrences in product source.
+  Treat each as an opaque external-format token, confined to the single site that emits or parses it
+  — never let the name spread beyond these:
+  - `pandoc-api-version` — the JSON interchange root key; a single named constant in `oxidoc-ast`.
+  - `Pandoc` — the native format's top-level constructor; a parse literal in the native reader.
+  - `\pandocbounded` — a LaTeX macro emitted to bound oversized images; a literal in the LaTeX writer.
+
+  Sanctioning a new such literal takes the same justification: it is part of an external format's
+  published wire form and cannot be expressed any other way.
 - Commit messages are history, not files, but keep them provenance-neutral too.
 
 ## Code style

--- a/crates/oxidoc-ast/src/ast.rs
+++ b/crates/oxidoc-ast/src/ast.rs
@@ -292,3 +292,35 @@ pub struct Cell {
     pub col_span: i32,
     pub content: Vec<Block>,
 }
+
+/// Flatten an inline sequence to plain text, discarding markup: textual content
+/// ([`Inline::Str`], [`Inline::Code`], [`Inline::Math`]) is kept, breaks and spaces become a single
+/// space, container inlines are walked through, and raw passthrough and notes contribute nothing.
+#[must_use]
+pub fn to_plain_text(inlines: &[Inline]) -> String {
+    let mut out = String::new();
+    push_plain_text(inlines, &mut out);
+    out
+}
+
+fn push_plain_text(inlines: &[Inline], out: &mut String) {
+    for inline in inlines {
+        match inline {
+            Inline::Str(text) | Inline::Code(_, text) | Inline::Math(_, text) => out.push_str(text),
+            Inline::Space | Inline::SoftBreak | Inline::LineBreak => out.push(' '),
+            Inline::Emph(xs)
+            | Inline::Underline(xs)
+            | Inline::Strong(xs)
+            | Inline::Strikeout(xs)
+            | Inline::Superscript(xs)
+            | Inline::Subscript(xs)
+            | Inline::SmallCaps(xs)
+            | Inline::Quoted(_, xs)
+            | Inline::Cite(_, xs)
+            | Inline::Link(_, xs, _)
+            | Inline::Image(_, xs, _)
+            | Inline::Span(_, xs) => push_plain_text(xs, out),
+            Inline::RawInline(..) | Inline::Note(_) => {}
+        }
+    }
+}

--- a/crates/oxidoc-readers/Cargo.toml
+++ b/crates/oxidoc-readers/Cargo.toml
@@ -12,9 +12,11 @@ publish.workspace = true
 workspace = true
 
 [features]
-default = ["commonmark", "json"]
+default = ["commonmark", "json", "html", "native"]
 commonmark = ["dep:unicode-general-category", "dep:caseless"]
 json = []
+html = []
+native = []
 
 [dependencies]
 oxidoc-ast = { workspace = true }

--- a/crates/oxidoc-readers/src/html.rs
+++ b/crates/oxidoc-readers/src/html.rs
@@ -1,0 +1,1555 @@
+//! HTML reader.
+//!
+//! Parsing runs in three stages: a tokenizer ([`tokenize`]) turns the source into a flat stream of
+//! start tags, end tags and text; a tree builder ([`build_tree`]) assembles that stream into a node
+//! tree, applying void-element and implied-end-tag rules; and a [`Converter`] walks the tree into a
+//! [`Document`]. Document metadata is read from a `<head>` element when present.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+
+use oxidoc_ast::{
+    Alignment, Attr, Block, Caption, Cell, ColSpec, ColWidth, Document, Inline, ListAttributes,
+    ListNumberDelim, ListNumberStyle, MetaValue, QuoteType, Row, Table, TableBody, TableFoot,
+    TableHead, Target, to_plain_text,
+};
+use oxidoc_core::{Reader, ReaderOptions, Result};
+
+include!(concat!(env!("OUT_DIR"), "/entities_table.rs"));
+
+/// Parses HTML text into the document model.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HtmlReader;
+
+impl Reader for HtmlReader {
+    fn read(&self, input: &str, _options: &ReaderOptions) -> Result<Document> {
+        Ok(parse(input))
+    }
+}
+
+fn parse(input: &str) -> Document {
+    let normalized = normalize(input);
+    let chars: Vec<char> = normalized.chars().collect();
+    let tokens = tokenize(&chars);
+    let roots = build_tree(tokens);
+    let (head, body) = locate(&roots);
+
+    let mut converter = Converter::default();
+    let meta = head.map(extract_meta).unwrap_or_default();
+    let blocks = converter.blocks(&body, false);
+    Document {
+        meta,
+        blocks,
+        ..Document::default()
+    }
+}
+
+/// Normalize line endings to `\n` and strip a leading byte-order mark.
+fn normalize(input: &str) -> Cow<'_, str> {
+    let without_bom = input.strip_prefix('\u{feff}').unwrap_or(input);
+    if !without_bom.contains('\r') {
+        return Cow::Borrowed(without_bom);
+    }
+    let mut out = String::with_capacity(without_bom.len());
+    let mut chars = without_bom.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                out.push('\n');
+            }
+            other => out.push(other),
+        }
+    }
+    Cow::Owned(out)
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+enum Token {
+    Start {
+        name: String,
+        attrs: Vec<(String, String)>,
+        self_closing: bool,
+    },
+    End(String),
+    Text(String),
+}
+
+/// Elements whose content is read verbatim up to the matching end tag. Entities are still resolved
+/// in the text-only group; the script-like group is passed through untouched.
+fn raw_text_mode(name: &str) -> Option<bool> {
+    match name {
+        "script" | "style" => Some(false),
+        "title" | "textarea" => Some(true),
+        _ => None,
+    }
+}
+
+fn tokenize(chars: &[char]) -> Vec<Token> {
+    let mut tokens = Vec::new();
+    let mut pos = 0;
+    while pos < chars.len() {
+        if chars.get(pos) == Some(&'<')
+            && let Some(next) = read_markup(chars, pos, &mut tokens)
+        {
+            pos = next;
+            continue;
+        }
+        pos = read_text(chars, pos, &mut tokens);
+    }
+    tokens
+}
+
+/// Consume one `<…>` construct. Returns the position past it, or `None` when the `<` does not begin
+/// a tag and should be treated as literal text.
+fn read_markup(chars: &[char], pos: usize, tokens: &mut Vec<Token>) -> Option<usize> {
+    match chars.get(pos + 1)? {
+        '!' => Some(skip_declaration(chars, pos)),
+        '?' => Some(skip_to_gt(chars, pos + 1)),
+        '/' => read_end_tag(chars, pos, tokens),
+        c if c.is_ascii_alphabetic() => Some(read_start_tag(chars, pos, tokens)),
+        _ => None,
+    }
+}
+
+/// Skip `<!-- … -->`, `<![CDATA[ … ]]>` or a `<!doctype …>` declaration.
+fn skip_declaration(chars: &[char], pos: usize) -> usize {
+    if chars.get(pos + 2) == Some(&'-') && chars.get(pos + 3) == Some(&'-') {
+        let mut i = pos + 4;
+        while i < chars.len() {
+            if chars.get(i) == Some(&'-')
+                && chars.get(i + 1) == Some(&'-')
+                && chars.get(i + 2) == Some(&'>')
+            {
+                return i + 3;
+            }
+            i += 1;
+        }
+        return chars.len();
+    }
+    skip_to_gt(chars, pos)
+}
+
+fn skip_to_gt(chars: &[char], pos: usize) -> usize {
+    let mut i = pos + 1;
+    while i < chars.len() {
+        if chars.get(i) == Some(&'>') {
+            return i + 1;
+        }
+        i += 1;
+    }
+    chars.len()
+}
+
+fn read_end_tag(chars: &[char], pos: usize, tokens: &mut Vec<Token>) -> Option<usize> {
+    let start = pos + 2;
+    if !chars.get(start).copied()?.is_ascii_alphabetic() {
+        return None;
+    }
+    let mut i = start;
+    while let Some(&c) = chars.get(i) {
+        if c.is_ascii_whitespace() || c == '>' {
+            break;
+        }
+        i += 1;
+    }
+    let name: String = collect_lower(chars, start, i);
+    tokens.push(Token::End(name));
+    Some(skip_to_gt(chars, i - 1))
+}
+
+fn read_start_tag(chars: &[char], pos: usize, tokens: &mut Vec<Token>) -> usize {
+    let start = pos + 1;
+    let mut i = start;
+    while let Some(&c) = chars.get(i) {
+        if c.is_ascii_whitespace() || c == '>' || c == '/' {
+            break;
+        }
+        i += 1;
+    }
+    let name = collect_lower(chars, start, i);
+    let (attrs, next, self_closing) = read_attributes(chars, i);
+
+    if let Some(decode) = raw_text_mode(&name) {
+        let (text, after) = read_raw_text(chars, next, &name, decode);
+        tokens.push(Token::Start {
+            name: name.clone(),
+            attrs,
+            self_closing: false,
+        });
+        if !text.is_empty() {
+            tokens.push(Token::Text(text));
+        }
+        tokens.push(Token::End(name));
+        return after;
+    }
+
+    tokens.push(Token::Start {
+        name,
+        attrs,
+        self_closing,
+    });
+    next
+}
+
+/// Parse a start tag's attribute list. `pos` points just after the tag name; the result position is
+/// just past the closing `>`.
+fn read_attributes(chars: &[char], pos: usize) -> (Vec<(String, String)>, usize, bool) {
+    let mut attrs = Vec::new();
+    let mut i = pos;
+    let mut self_closing = false;
+    loop {
+        i = skip_whitespace(chars, i);
+        match chars.get(i) {
+            None => break,
+            Some('>') => {
+                i += 1;
+                break;
+            }
+            Some('/') => {
+                if chars.get(i + 1) == Some(&'>') {
+                    self_closing = true;
+                    i += 2;
+                    break;
+                }
+                i += 1;
+            }
+            Some(_) => {
+                let (name, after_name) = read_attr_name(chars, i);
+                i = skip_whitespace(chars, after_name);
+                if chars.get(i) == Some(&'=') {
+                    i = skip_whitespace(chars, i + 1);
+                    let (value, after_value) = read_attr_value(chars, i);
+                    i = after_value;
+                    if !name.is_empty() {
+                        attrs.push((name, value));
+                    }
+                } else if !name.is_empty() {
+                    attrs.push((name, String::new()));
+                }
+            }
+        }
+    }
+    (attrs, i, self_closing)
+}
+
+fn read_attr_name(chars: &[char], pos: usize) -> (String, usize) {
+    let mut i = pos;
+    while let Some(&c) = chars.get(i) {
+        if c.is_ascii_whitespace() || c == '=' || c == '>' || c == '/' {
+            break;
+        }
+        i += 1;
+    }
+    (collect_lower(chars, pos, i), i)
+}
+
+fn read_attr_value(chars: &[char], pos: usize) -> (String, usize) {
+    if let Some(&quote @ ('"' | '\'')) = chars.get(pos) {
+        let mut i = pos + 1;
+        let value_start = i;
+        while let Some(&c) = chars.get(i) {
+            if c == quote {
+                break;
+            }
+            i += 1;
+        }
+        let raw: String = slice(chars, value_start, i);
+        (decode_entities(raw), i + 1)
+    } else {
+        let mut i = pos;
+        while let Some(&c) = chars.get(i) {
+            if c.is_ascii_whitespace() || c == '>' {
+                break;
+            }
+            i += 1;
+        }
+        let raw: String = slice(chars, pos, i);
+        (decode_entities(raw), i)
+    }
+}
+
+fn read_raw_text(chars: &[char], pos: usize, name: &str, decode: bool) -> (String, usize) {
+    let mut i = pos;
+    while i < chars.len() {
+        if chars.get(i) == Some(&'<')
+            && chars.get(i + 1) == Some(&'/')
+            && matches_name(chars, i + 2, name)
+        {
+            let raw: String = slice(chars, pos, i);
+            let text = if decode { decode_entities(raw) } else { raw };
+            return (text, skip_to_gt(chars, i + 1));
+        }
+        i += 1;
+    }
+    let raw: String = slice(chars, pos, chars.len());
+    let text = if decode { decode_entities(raw) } else { raw };
+    (text, chars.len())
+}
+
+fn read_text(chars: &[char], pos: usize, tokens: &mut Vec<Token>) -> usize {
+    let start = pos;
+    let mut i = pos;
+    while let Some(&c) = chars.get(i) {
+        if c == '<' && begins_markup(chars, i) {
+            break;
+        }
+        i += 1;
+    }
+    let next = if i == start { start + 1 } else { i };
+    let raw: String = slice(chars, start, next);
+    tokens.push(Token::Text(decode_entities(raw)));
+    next
+}
+
+fn begins_markup(chars: &[char], pos: usize) -> bool {
+    match chars.get(pos + 1) {
+        Some('!' | '?' | '/') => true,
+        Some(c) => c.is_ascii_alphabetic(),
+        None => false,
+    }
+}
+
+fn matches_name(chars: &[char], pos: usize, name: &str) -> bool {
+    let candidate = name.chars().enumerate().all(|(offset, expected)| {
+        chars
+            .get(pos + offset)
+            .is_some_and(|&c| c.eq_ignore_ascii_case(&expected))
+    });
+    if !candidate {
+        return false;
+    }
+    match chars.get(pos + name.chars().count()) {
+        None => true,
+        Some(&c) => c.is_ascii_whitespace() || c == '>' || c == '/',
+    }
+}
+
+fn skip_whitespace(chars: &[char], pos: usize) -> usize {
+    let mut i = pos;
+    while chars.get(i).is_some_and(char::is_ascii_whitespace) {
+        i += 1;
+    }
+    i
+}
+
+fn slice(chars: &[char], start: usize, end: usize) -> String {
+    chars
+        .get(start..end)
+        .map(|s| s.iter().collect())
+        .unwrap_or_default()
+}
+
+fn collect_lower(chars: &[char], start: usize, end: usize) -> String {
+    chars
+        .get(start..end)
+        .map(|s| s.iter().flat_map(|c| c.to_lowercase()).collect())
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Entity decoding
+// ---------------------------------------------------------------------------
+
+fn decode_entities(text: String) -> String {
+    if !text.contains('&') {
+        return text;
+    }
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while let Some(&c) = chars.get(i) {
+        if c == '&'
+            && let Some((decoded, next)) = scan_char_ref(&chars, i)
+        {
+            out.push_str(&decoded);
+            i = next;
+            continue;
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
+
+/// Resolve a character reference beginning at `start` (a `&`). Named references decode without a
+/// trailing `;` only when the whole alphanumeric run names a known entity.
+fn scan_char_ref(chars: &[char], start: usize) -> Option<(String, usize)> {
+    if chars.get(start + 1) == Some(&'#') {
+        return scan_numeric_ref(chars, start);
+    }
+    let mut i = start + 1;
+    while chars.get(i).is_some_and(char::is_ascii_alphanumeric) {
+        i += 1;
+    }
+    if i == start + 1 {
+        return None;
+    }
+    let name: String = slice(chars, start + 1, i);
+    if chars.get(i) == Some(&';') {
+        let decoded = lookup_named(&name)?;
+        return Some((decoded.to_string(), i + 1));
+    }
+    let decoded = lookup_named(&name)?;
+    Some((decoded.to_string(), i))
+}
+
+fn scan_numeric_ref(chars: &[char], start: usize) -> Option<(String, usize)> {
+    let hex = matches!(chars.get(start + 2), Some('x' | 'X'));
+    let digits_start = if hex { start + 3 } else { start + 2 };
+    let mut i = digits_start;
+    let radix = if hex { 16 } else { 10 };
+    while chars.get(i).is_some_and(|c| c.is_digit(radix)) {
+        i += 1;
+    }
+    if i == digits_start {
+        return None;
+    }
+    let digits: String = slice(chars, digits_start, i);
+    let code = u32::from_str_radix(&digits, radix).ok()?;
+    let end = if chars.get(i) == Some(&';') { i + 1 } else { i };
+    Some((code_point(code), end))
+}
+
+fn code_point(code: u32) -> String {
+    if code == 0 {
+        return '\u{fffd}'.to_string();
+    }
+    char::from_u32(code).unwrap_or('\u{fffd}').to_string()
+}
+
+fn lookup_named(name: &str) -> Option<&'static str> {
+    ENTITIES
+        .binary_search_by(|(candidate, _)| (*candidate).cmp(name))
+        .ok()
+        .and_then(|index| ENTITIES.get(index))
+        .map(|(_, characters)| *characters)
+}
+
+// ---------------------------------------------------------------------------
+// Tree builder
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+enum Node {
+    Element(Element),
+    Text(String),
+}
+
+#[derive(Debug)]
+struct Element {
+    name: String,
+    attrs: Vec<(String, String)>,
+    children: Vec<Node>,
+}
+
+fn is_void(name: &str) -> bool {
+    matches!(
+        name,
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "param"
+            | "source"
+            | "track"
+            | "wbr"
+    )
+}
+
+fn build_tree(tokens: Vec<Token>) -> Vec<Node> {
+    let mut stack: Vec<Element> = vec![Element {
+        name: String::new(),
+        attrs: Vec::new(),
+        children: Vec::new(),
+    }];
+
+    for token in tokens {
+        match token {
+            Token::Text(text) => push_child(&mut stack, Node::Text(text)),
+            Token::Start {
+                name,
+                attrs,
+                self_closing,
+            } => {
+                close_implied(&mut stack, &name);
+                let void = self_closing || is_void(&name);
+                let element = Element {
+                    name,
+                    attrs,
+                    children: Vec::new(),
+                };
+                if void {
+                    push_child(&mut stack, Node::Element(element));
+                } else {
+                    stack.push(element);
+                }
+            }
+            Token::End(name) => {
+                if is_void(&name) {
+                    continue;
+                }
+                close_to(&mut stack, &name);
+            }
+        }
+    }
+
+    while stack.len() > 1 {
+        fold_top(&mut stack);
+    }
+    stack
+        .into_iter()
+        .next()
+        .map(|root| root.children)
+        .unwrap_or_default()
+}
+
+fn push_child(stack: &mut [Element], node: Node) {
+    if let Some(top) = stack.last_mut() {
+        top.children.push(node);
+    }
+}
+
+fn fold_top(stack: &mut Vec<Element>) {
+    if let Some(top) = stack.pop() {
+        push_child(stack, Node::Element(top));
+    }
+}
+
+fn current_name(stack: &[Element]) -> Option<&str> {
+    stack
+        .last()
+        .filter(|e| !e.name.is_empty())
+        .map(|e| e.name.as_str())
+}
+
+/// Pop open elements that the start tag `name` implicitly closes (an unterminated `<li>`, table
+/// cell, paragraph, …).
+fn close_implied(stack: &mut Vec<Element>, name: &str) {
+    loop {
+        let Some(open) = current_name(stack) else {
+            return;
+        };
+        let close = match name {
+            "li" => open == "li",
+            "dt" | "dd" => open == "dt" || open == "dd",
+            "option" => open == "option",
+            "tr" => matches!(open, "td" | "th" | "tr"),
+            "td" | "th" => matches!(open, "td" | "th"),
+            "thead" | "tbody" | "tfoot" => {
+                matches!(open, "td" | "th" | "tr" | "thead" | "tbody" | "tfoot")
+            }
+            _ => open == "p" && closes_paragraph(name),
+        };
+        if close {
+            fold_top(stack);
+        } else {
+            return;
+        }
+    }
+}
+
+fn closes_paragraph(name: &str) -> bool {
+    matches!(
+        name,
+        "address"
+            | "article"
+            | "aside"
+            | "blockquote"
+            | "details"
+            | "div"
+            | "dl"
+            | "fieldset"
+            | "figcaption"
+            | "figure"
+            | "footer"
+            | "form"
+            | "h1"
+            | "h2"
+            | "h3"
+            | "h4"
+            | "h5"
+            | "h6"
+            | "header"
+            | "hr"
+            | "main"
+            | "menu"
+            | "nav"
+            | "ol"
+            | "p"
+            | "pre"
+            | "section"
+            | "table"
+            | "ul"
+    )
+}
+
+fn close_to(stack: &mut Vec<Element>, name: &str) {
+    if !stack.iter().any(|e| e.name == name) {
+        return;
+    }
+    while let Some(open) = current_name(stack) {
+        let matched = open == name;
+        fold_top(stack);
+        if matched {
+            return;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Document structure
+// ---------------------------------------------------------------------------
+
+/// Locate the metadata `<head>` and the block-content nodes, descending through a wrapping
+/// `<html>`. Without an explicit `<body>`, every top-level node except the head contributes blocks.
+fn locate(nodes: &[Node]) -> (Option<&Element>, Vec<&Node>) {
+    if let Some(html) = find_element(nodes, "html") {
+        return locate(&html.children);
+    }
+    let head = find_element(nodes, "head");
+    let body = find_element(nodes, "body");
+    let content = if let Some(body) = body {
+        body.children.iter().collect()
+    } else {
+        nodes
+            .iter()
+            .filter(|node| !is_named_element(node, "head"))
+            .collect()
+    };
+    (head, content)
+}
+
+fn find_element<'a>(nodes: &'a [Node], name: &str) -> Option<&'a Element> {
+    nodes.iter().find_map(|node| match node {
+        Node::Element(e) if e.name == name => Some(e),
+        _ => None,
+    })
+}
+
+fn is_named_element(node: &Node, name: &str) -> bool {
+    matches!(node, Node::Element(e) if e.name == name)
+}
+
+fn extract_meta(head: &Element) -> BTreeMap<String, MetaValue> {
+    let mut meta = BTreeMap::new();
+    for child in &head.children {
+        let Node::Element(e) = child else { continue };
+        match e.name.as_str() {
+            "title" => {
+                meta.insert("title".to_string(), MetaValue::MetaInlines(text_inlines(e)));
+            }
+            "meta" => {
+                let name = attr_value(e, "name");
+                let content = attr_value(e, "content");
+                if let (Some(name), Some(content)) = (name, content)
+                    && !name.is_empty()
+                {
+                    meta.insert(name, MetaValue::MetaInlines(inlines_from_text(&content)));
+                }
+            }
+            _ => {}
+        }
+    }
+    meta
+}
+
+fn attr_value(e: &Element, key: &str) -> Option<String> {
+    e.attrs
+        .iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.clone())
+}
+
+fn text_inlines(e: &Element) -> Vec<Inline> {
+    let mut out = Vec::new();
+    for child in &e.children {
+        if let Node::Text(text) = child {
+            push_text(&mut out, text);
+        }
+    }
+    trim_inlines(out)
+}
+
+// ---------------------------------------------------------------------------
+// Conversion
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct Converter {
+    used_ids: BTreeSet<String>,
+}
+
+impl Converter {
+    fn blocks(&mut self, nodes: &[&Node], in_list: bool) -> Vec<Block> {
+        let mut out = Vec::new();
+        let mut pending = Vec::new();
+        self.process(nodes.iter().copied(), &mut out, &mut pending);
+        flush(&mut pending, &mut out);
+        fix_plains(out, in_list)
+    }
+
+    fn child_blocks(&mut self, children: &[Node], in_list: bool) -> Vec<Block> {
+        let refs: Vec<&Node> = children.iter().collect();
+        self.blocks(&refs, in_list)
+    }
+
+    fn process<'a>(
+        &mut self,
+        nodes: impl Iterator<Item = &'a Node>,
+        out: &mut Vec<Block>,
+        pending: &mut Vec<Inline>,
+    ) {
+        for node in nodes {
+            match node {
+                Node::Text(text) => push_text(pending, text),
+                Node::Element(e) => {
+                    if matches!(e.name.as_str(), "script" | "style" | "head") {
+                        continue;
+                    }
+                    if let Some(kind) = block_kind(&e.name) {
+                        flush(pending, out);
+                        self.emit_block(kind, e, out);
+                    } else if is_inline_element(&e.name) {
+                        self.append_inline(pending, node);
+                    } else {
+                        self.process(e.children.iter(), out, pending);
+                    }
+                }
+            }
+        }
+    }
+
+    fn emit_block(&mut self, kind: BlockKind, e: &Element, out: &mut Vec<Block>) {
+        match kind {
+            BlockKind::Para => out.push(Block::Para(trim_inlines(self.build_inlines(&e.children)))),
+            BlockKind::Header(level) => {
+                let inlines = trim_inlines(self.build_inlines(&e.children));
+                let attr = self.header_attr(e, &inlines);
+                out.push(Block::Header(level, attr, inlines));
+            }
+            BlockKind::BulletList => out.push(Block::BulletList(self.list_items(e))),
+            BlockKind::OrderedList => {
+                out.push(Block::OrderedList(list_attributes(e), self.list_items(e)));
+            }
+            BlockKind::BlockQuote => {
+                out.push(Block::BlockQuote(self.child_blocks(&e.children, false)));
+            }
+            BlockKind::Pre => out.push(Self::code_block(e)),
+            BlockKind::HorizontalRule => out.push(Block::HorizontalRule),
+            BlockKind::Div { sectioning } => {
+                let attr = div_attr(e, sectioning);
+                out.push(Block::Div(attr, self.child_blocks(&e.children, false)));
+            }
+            BlockKind::DefinitionList => out.push(self.definition_list(e)),
+            BlockKind::Table => out.push(self.table(e)),
+            BlockKind::Figure => out.push(self.figure(e)),
+        }
+    }
+
+    fn list_items(&mut self, e: &Element) -> Vec<Vec<Block>> {
+        e.children
+            .iter()
+            .filter_map(|node| match node {
+                Node::Element(item) if item.name == "li" => {
+                    Some(self.child_blocks(&item.children, true))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn definition_list(&mut self, e: &Element) -> Block {
+        let mut items: Vec<(Vec<Inline>, Vec<Vec<Block>>)> = Vec::new();
+        let mut current: Option<(Vec<Inline>, Vec<Vec<Block>>)> = None;
+        for child in &e.children {
+            let Node::Element(item) = child else { continue };
+            match item.name.as_str() {
+                "dt" => {
+                    if let Some(done) = current.take() {
+                        items.push(done);
+                    }
+                    current = Some((trim_inlines(self.build_inlines(&item.children)), Vec::new()));
+                }
+                "dd" => {
+                    let definition = self.child_blocks(&item.children, true);
+                    current
+                        .get_or_insert_with(|| (Vec::new(), Vec::new()))
+                        .1
+                        .push(definition);
+                }
+                _ => {}
+            }
+        }
+        if let Some(done) = current {
+            items.push(done);
+        }
+        Block::DefinitionList(items)
+    }
+
+    fn figure(&mut self, e: &Element) -> Block {
+        let attr = extract_attr(e, &[]);
+        let mut caption = Caption::default();
+        let mut content_nodes: Vec<&Node> = Vec::new();
+        for child in &e.children {
+            if let Node::Element(inner) = child
+                && inner.name == "figcaption"
+            {
+                caption = Caption {
+                    short: None,
+                    long: self.child_blocks(&inner.children, false),
+                };
+                continue;
+            }
+            content_nodes.push(child);
+        }
+        Block::Figure(attr, caption, self.blocks(&content_nodes, false))
+    }
+
+    fn code_block(e: &Element) -> Block {
+        let mut attr = extract_attr(e, &[]);
+        let inner_code = e.children.iter().find_map(|node| match node {
+            Node::Element(inner) if inner.name == "code" => Some(inner),
+            _ => None,
+        });
+        let content_source = if let Some(code) = inner_code {
+            let mut code_attr = extract_attr(code, &[]);
+            for class in &mut code_attr.classes {
+                if let Some(rest) = class.strip_prefix("language-") {
+                    *class = rest.to_string();
+                }
+            }
+            merge_attr(&mut attr, code_attr);
+            code
+        } else {
+            e
+        };
+        let mut text = collect_text(content_source);
+        if text.ends_with('\n') {
+            text.pop();
+        }
+        Block::CodeBlock(attr, text)
+    }
+
+    fn table(&mut self, e: &Element) -> Block {
+        let attr = extract_attr(e, &[]);
+        let mut caption = Caption::default();
+        let mut col_widths: Vec<ColWidth> = Vec::new();
+        let mut head_rows = Vec::new();
+        let mut body_rows = Vec::new();
+        let mut foot_rows = Vec::new();
+        for child in &e.children {
+            let Node::Element(section) = child else {
+                continue;
+            };
+            match section.name.as_str() {
+                "caption" => {
+                    caption = Caption {
+                        short: None,
+                        long: self.child_blocks(&section.children, false),
+                    };
+                }
+                "colgroup" => col_widths = column_widths(section),
+                "thead" => head_rows.extend(self.rows(section)),
+                "tbody" => body_rows.extend(self.rows(section)),
+                "tfoot" => foot_rows.extend(self.rows(section)),
+                "tr" => body_rows.push(self.row(section)),
+                _ => {}
+            }
+        }
+
+        let columns = table_width(&head_rows, &body_rows, &foot_rows, col_widths.len());
+        let aligns = column_alignments(body_rows.first().or_else(|| head_rows.first()), columns);
+        let col_specs = (0..columns)
+            .map(|i| ColSpec {
+                align: aligns.get(i).cloned().unwrap_or(Alignment::AlignDefault),
+                width: col_widths
+                    .get(i)
+                    .cloned()
+                    .unwrap_or(ColWidth::ColWidthDefault),
+            })
+            .collect();
+
+        Block::Table(Box::new(Table {
+            attr,
+            caption,
+            col_specs,
+            head: TableHead {
+                attr: Attr::default(),
+                rows: head_rows,
+            },
+            bodies: vec![TableBody {
+                attr: Attr::default(),
+                row_head_columns: 0,
+                head: Vec::new(),
+                body: body_rows,
+            }],
+            foot: TableFoot {
+                attr: Attr::default(),
+                rows: foot_rows,
+            },
+        }))
+    }
+
+    fn rows(&mut self, section: &Element) -> Vec<Row> {
+        section
+            .children
+            .iter()
+            .filter_map(|node| match node {
+                Node::Element(tr) if tr.name == "tr" => Some(self.row(tr)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn row(&mut self, tr: &Element) -> Row {
+        let cells = tr
+            .children
+            .iter()
+            .filter_map(|node| match node {
+                Node::Element(cell) if cell.name == "td" || cell.name == "th" => {
+                    Some(self.cell(cell))
+                }
+                _ => None,
+            })
+            .collect();
+        Row {
+            attr: Attr::default(),
+            cells,
+        }
+    }
+
+    fn cell(&mut self, cell: &Element) -> Cell {
+        Cell {
+            attr: Attr::default(),
+            align: cell_alignment(cell),
+            row_span: span_attr(cell, "rowspan"),
+            col_span: span_attr(cell, "colspan"),
+            content: self.child_blocks(&cell.children, false),
+        }
+    }
+
+    fn header_attr(&mut self, e: &Element, inlines: &[Inline]) -> Attr {
+        let mut attr = extract_attr(e, &[]);
+        if attr.id.is_empty() {
+            let base = slug(&to_plain_text(inlines));
+            let base = if base.is_empty() {
+                "section".to_string()
+            } else {
+                base
+            };
+            attr.id = self.unique_id(base);
+        } else {
+            self.used_ids.insert(attr.id.clone());
+        }
+        attr
+    }
+
+    fn unique_id(&mut self, base: String) -> String {
+        if self.used_ids.insert(base.clone()) {
+            return base;
+        }
+        let mut n = 1;
+        loop {
+            let candidate = format!("{base}-{n}");
+            if self.used_ids.insert(candidate.clone()) {
+                return candidate;
+            }
+            n += 1;
+        }
+    }
+
+    fn build_inlines(&self, nodes: &[Node]) -> Vec<Inline> {
+        let mut out = Vec::new();
+        for node in nodes {
+            self.append_inline(&mut out, node);
+        }
+        out
+    }
+
+    fn append_inline(&self, out: &mut Vec<Inline>, node: &Node) {
+        let e = match node {
+            Node::Text(text) => {
+                push_text(out, text);
+                return;
+            }
+            Node::Element(e) => e,
+        };
+        match inline_kind(&e.name) {
+            InlineKind::Emph => out.push(Inline::Emph(self.build_inlines(&e.children))),
+            InlineKind::Strong => out.push(Inline::Strong(self.build_inlines(&e.children))),
+            InlineKind::Strikeout => out.push(Inline::Strikeout(self.build_inlines(&e.children))),
+            InlineKind::Underline => out.push(Inline::Underline(self.build_inlines(&e.children))),
+            InlineKind::Superscript => {
+                out.push(Inline::Superscript(self.build_inlines(&e.children)));
+            }
+            InlineKind::Subscript => out.push(Inline::Subscript(self.build_inlines(&e.children))),
+            InlineKind::Quoted => {
+                out.push(Inline::Quoted(
+                    QuoteType::DoubleQuote,
+                    self.build_inlines(&e.children),
+                ));
+            }
+            InlineKind::LineBreak => out.push(Inline::LineBreak),
+            InlineKind::Span => {
+                out.push(Inline::Span(
+                    extract_attr(e, &[]),
+                    self.build_inlines(&e.children),
+                ));
+            }
+            InlineKind::SpanClass => {
+                let mut attr = extract_attr(e, &[]);
+                attr.classes.insert(0, e.name.clone());
+                out.push(Inline::Span(attr, self.build_inlines(&e.children)));
+            }
+            InlineKind::Code(class) => out.push(Self::code_inline(e, class)),
+            InlineKind::Anchor => out.push(self.anchor(e)),
+            InlineKind::Image => out.push(image(e)),
+            InlineKind::Transparent => {
+                for child in &e.children {
+                    self.append_inline(out, child);
+                }
+            }
+        }
+    }
+
+    fn code_inline(e: &Element, forced_class: Option<&str>) -> Inline {
+        let mut attr = extract_attr(e, &[]);
+        if let Some(class) = forced_class {
+            attr.classes = vec![class.to_string()];
+        }
+        Inline::Code(attr, collect_text(e))
+    }
+
+    fn anchor(&self, e: &Element) -> Inline {
+        let inner = self.build_inlines(&e.children);
+        if let Some(href) = attr_value(e, "href") {
+            let title = attr_value(e, "title").unwrap_or_default();
+            let attr = extract_attr(e, &["href", "title"]);
+            return Inline::Link(attr, inner, Target { url: href, title });
+        }
+        let mut attr = extract_attr(e, &["name"]);
+        if attr.id.is_empty()
+            && let Some(name) = attr_value(e, "name")
+        {
+            attr.id = name;
+        }
+        Inline::Span(attr, inner)
+    }
+}
+
+fn image(e: &Element) -> Inline {
+    let url = attr_value(e, "src").unwrap_or_default();
+    let title = attr_value(e, "title").unwrap_or_default();
+    let alt = attr_value(e, "alt").unwrap_or_default();
+    let attr = extract_attr(e, &["src", "title", "alt"]);
+    Inline::Image(attr, inlines_from_text(&alt), Target { url, title })
+}
+
+// ---------------------------------------------------------------------------
+// Element classification
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+enum BlockKind {
+    Para,
+    Header(i32),
+    BulletList,
+    OrderedList,
+    BlockQuote,
+    Pre,
+    HorizontalRule,
+    Div { sectioning: bool },
+    DefinitionList,
+    Table,
+    Figure,
+}
+
+fn block_kind(name: &str) -> Option<BlockKind> {
+    Some(match name {
+        "p" => BlockKind::Para,
+        "h1" => BlockKind::Header(1),
+        "h2" => BlockKind::Header(2),
+        "h3" => BlockKind::Header(3),
+        "h4" => BlockKind::Header(4),
+        "h5" => BlockKind::Header(5),
+        "h6" => BlockKind::Header(6),
+        "ul" | "menu" => BlockKind::BulletList,
+        "ol" => BlockKind::OrderedList,
+        "blockquote" => BlockKind::BlockQuote,
+        "pre" => BlockKind::Pre,
+        "hr" => BlockKind::HorizontalRule,
+        "div" => BlockKind::Div { sectioning: false },
+        "section" | "header" | "aside" => BlockKind::Div { sectioning: true },
+        "dl" => BlockKind::DefinitionList,
+        "table" => BlockKind::Table,
+        "figure" => BlockKind::Figure,
+        _ => return None,
+    })
+}
+
+enum InlineKind {
+    Emph,
+    Strong,
+    Strikeout,
+    Underline,
+    Superscript,
+    Subscript,
+    Quoted,
+    LineBreak,
+    Span,
+    SpanClass,
+    Code(Option<&'static str>),
+    Anchor,
+    Image,
+    Transparent,
+}
+
+fn inline_kind(name: &str) -> InlineKind {
+    match name {
+        "em" | "i" => InlineKind::Emph,
+        "strong" | "b" => InlineKind::Strong,
+        "del" | "s" | "strike" => InlineKind::Strikeout,
+        "ins" | "u" => InlineKind::Underline,
+        "sup" => InlineKind::Superscript,
+        "sub" => InlineKind::Subscript,
+        "q" => InlineKind::Quoted,
+        "br" => InlineKind::LineBreak,
+        "span" => InlineKind::Span,
+        "mark" | "small" | "abbr" | "kbd" | "dfn" => InlineKind::SpanClass,
+        "code" | "tt" => InlineKind::Code(None),
+        "samp" => InlineKind::Code(Some("sample")),
+        "var" => InlineKind::Code(Some("variable")),
+        "a" => InlineKind::Anchor,
+        "img" => InlineKind::Image,
+        _ => InlineKind::Transparent,
+    }
+}
+
+fn is_inline_element(name: &str) -> bool {
+    !matches!(inline_kind(name), InlineKind::Transparent)
+}
+
+// ---------------------------------------------------------------------------
+// Attributes
+// ---------------------------------------------------------------------------
+
+fn extract_attr(e: &Element, exclude: &[&str]) -> Attr {
+    let mut attr = Attr::default();
+    for (key, value) in &e.attrs {
+        if exclude.contains(&key.as_str()) {
+            continue;
+        }
+        match key.as_str() {
+            "id" => attr.id.clone_from(value),
+            "class" => attr.classes = value.split_whitespace().map(str::to_string).collect(),
+            _ => {
+                let name = key.strip_prefix("data-").unwrap_or(key).to_string();
+                attr.attributes.push((name, value.clone()));
+            }
+        }
+    }
+    attr
+}
+
+fn div_attr(e: &Element, sectioning: bool) -> Attr {
+    let mut attr = extract_attr(e, &[]);
+    if sectioning {
+        attr.classes.insert(0, e.name.clone());
+    }
+    attr
+}
+
+fn merge_attr(base: &mut Attr, other: Attr) {
+    if base.id.is_empty() {
+        base.id = other.id;
+    }
+    base.classes.extend(other.classes);
+    base.attributes.extend(other.attributes);
+}
+
+fn list_attributes(e: &Element) -> ListAttributes {
+    let start = attr_value(e, "start")
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .unwrap_or(1);
+    let style = match attr_value(e, "type").as_deref() {
+        Some("1") => ListNumberStyle::Decimal,
+        Some("a") => ListNumberStyle::LowerAlpha,
+        Some("A") => ListNumberStyle::UpperAlpha,
+        Some("i") => ListNumberStyle::LowerRoman,
+        Some("I") => ListNumberStyle::UpperRoman,
+        _ => ListNumberStyle::DefaultStyle,
+    };
+    ListAttributes {
+        start,
+        style,
+        delim: ListNumberDelim::DefaultDelim,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tables
+// ---------------------------------------------------------------------------
+
+fn span_attr(cell: &Element, key: &str) -> i32 {
+    attr_value(cell, key)
+        .and_then(|v| v.trim().parse::<i32>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(1)
+}
+
+fn cell_alignment(cell: &Element) -> Alignment {
+    if let Some(align) = attr_value(cell, "align")
+        && let Some(parsed) = parse_alignment(&align)
+    {
+        return parsed;
+    }
+    if let Some(style) = attr_value(cell, "style")
+        && let Some(value) = style_property(&style, "text-align")
+        && let Some(parsed) = parse_alignment(&value)
+    {
+        return parsed;
+    }
+    Alignment::AlignDefault
+}
+
+fn parse_alignment(value: &str) -> Option<Alignment> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "left" => Some(Alignment::AlignLeft),
+        "right" => Some(Alignment::AlignRight),
+        "center" => Some(Alignment::AlignCenter),
+        _ => None,
+    }
+}
+
+fn style_property(style: &str, property: &str) -> Option<String> {
+    style.split(';').find_map(|decl| {
+        let (key, value) = decl.split_once(':')?;
+        if key.trim().eq_ignore_ascii_case(property) {
+            Some(value.trim().to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn column_widths(colgroup: &Element) -> Vec<ColWidth> {
+    let mut widths = Vec::new();
+    for child in &colgroup.children {
+        let Node::Element(col) = child else { continue };
+        if col.name != "col" {
+            continue;
+        }
+        let span = span_attr(col, "span");
+        let width = attr_value(col, "style")
+            .and_then(|style| style_property(&style, "width"))
+            .and_then(|value| {
+                value
+                    .strip_suffix('%')
+                    .and_then(|n| n.trim().parse::<f64>().ok())
+            })
+            .map_or(ColWidth::ColWidthDefault, |percent| {
+                ColWidth::ColWidth(percent / 100.0)
+            });
+        for _ in 0..span {
+            widths.push(width.clone());
+        }
+    }
+    widths
+}
+
+fn row_width(row: &Row) -> usize {
+    row.cells
+        .iter()
+        .map(|cell| usize::try_from(cell.col_span.max(1)).unwrap_or(1))
+        .sum()
+}
+
+fn table_width(head: &[Row], body: &[Row], foot: &[Row], colgroup_width: usize) -> usize {
+    head.iter()
+        .chain(body)
+        .chain(foot)
+        .map(row_width)
+        .max()
+        .unwrap_or(0)
+        .max(colgroup_width)
+}
+
+fn column_alignments(row: Option<&Row>, columns: usize) -> Vec<Alignment> {
+    let mut aligns = vec![Alignment::AlignDefault; columns];
+    let Some(row) = row else { return aligns };
+    let mut index = 0;
+    for cell in &row.cells {
+        for _ in 0..cell.col_span.max(1) {
+            if let Some(slot) = aligns.get_mut(index) {
+                *slot = cell.align.clone();
+            }
+            index += 1;
+        }
+    }
+    aligns
+}
+
+// ---------------------------------------------------------------------------
+// Inline text and whitespace
+// ---------------------------------------------------------------------------
+
+fn inlines_from_text(text: &str) -> Vec<Inline> {
+    let mut out = Vec::new();
+    push_text(&mut out, text);
+    out
+}
+
+/// Append `text` to an inline run, collapsing each whitespace span to a single break: a span that
+/// spans a line is a soft break, otherwise a space. Non-whitespace merges into the trailing string.
+fn push_text(out: &mut Vec<Inline>, text: &str) {
+    let mut chars = text.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_whitespace() {
+            let mut newline = false;
+            while let Some(&w) = chars.peek() {
+                if !w.is_ascii_whitespace() {
+                    break;
+                }
+                newline |= w == '\n';
+                chars.next();
+            }
+            push_break(out, newline);
+        } else {
+            let mut word = String::new();
+            while let Some(&w) = chars.peek() {
+                if w.is_ascii_whitespace() {
+                    break;
+                }
+                word.push(w);
+                chars.next();
+            }
+            push_str(out, &word);
+        }
+    }
+}
+
+fn push_str(out: &mut Vec<Inline>, word: &str) {
+    if let Some(Inline::Str(existing)) = out.last_mut() {
+        existing.push_str(word);
+    } else {
+        out.push(Inline::Str(word.to_string()));
+    }
+}
+
+fn push_break(out: &mut Vec<Inline>, newline: bool) {
+    match out.last() {
+        Some(Inline::SoftBreak) => {}
+        Some(Inline::Space) => {
+            if newline {
+                out.pop();
+                out.push(Inline::SoftBreak);
+            }
+        }
+        _ => out.push(if newline {
+            Inline::SoftBreak
+        } else {
+            Inline::Space
+        }),
+    }
+}
+
+fn trim_inlines(mut inlines: Vec<Inline>) -> Vec<Inline> {
+    while matches!(inlines.first(), Some(Inline::Space | Inline::SoftBreak)) {
+        inlines.remove(0);
+    }
+    while matches!(inlines.last(), Some(Inline::Space | Inline::SoftBreak)) {
+        inlines.pop();
+    }
+    inlines
+}
+
+/// Flush a loose inline run as a `Plain` block, dropping it when only whitespace remains.
+fn flush(pending: &mut Vec<Inline>, out: &mut Vec<Block>) {
+    let trimmed = trim_inlines(std::mem::take(pending));
+    if !trimmed.is_empty() {
+        out.push(Block::Plain(trimmed));
+    }
+}
+
+/// A loose inline run is a `Plain` block until a paragraph-like sibling promotes the whole group to
+/// `Para`. Nested lists do not promote runs inside an enclosing list item.
+fn fix_plains(blocks: Vec<Block>, in_list: bool) -> Vec<Block> {
+    if !blocks.iter().any(|block| is_paraish(block, in_list)) {
+        return blocks;
+    }
+    blocks
+        .into_iter()
+        .map(|block| match block {
+            Block::Plain(inlines) => Block::Para(inlines),
+            other => other,
+        })
+        .collect()
+}
+
+fn is_paraish(block: &Block, in_list: bool) -> bool {
+    match block {
+        Block::Para(_) | Block::Header(..) | Block::BlockQuote(_) | Block::CodeBlock(..) => true,
+        Block::BulletList(_) | Block::OrderedList(..) => !in_list,
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Text gathering and identifier slugs
+// ---------------------------------------------------------------------------
+
+fn collect_text(e: &Element) -> String {
+    let mut out = String::new();
+    gather_text(&e.children, &mut out);
+    out
+}
+
+fn gather_text(nodes: &[Node], out: &mut String) {
+    for node in nodes {
+        match node {
+            Node::Text(text) => out.push_str(text),
+            Node::Element(e) => gather_text(&e.children, out),
+        }
+    }
+}
+
+/// Derive an ASCII-ish anchor identifier: keep letters, digits, spaces and `_-.`, lowercase, join
+/// words with hyphens, then drop any leading characters before the first letter.
+fn slug(text: &str) -> String {
+    let mut filtered = String::new();
+    for ch in text.chars() {
+        let ch = if ch == '\u{a0}' { ' ' } else { ch };
+        if ch.is_alphanumeric() || ch.is_whitespace() || ch == '_' || ch == '-' || ch == '.' {
+            filtered.extend(ch.to_lowercase());
+        }
+    }
+    let joined = filtered.split_whitespace().collect::<Vec<_>>().join("-");
+    joined.chars().skip_while(|c| !c.is_alphabetic()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HtmlReader;
+    use oxidoc_ast::{Block, Inline};
+    use oxidoc_core::{Reader, ReaderOptions};
+
+    fn blocks(input: &str) -> Vec<Block> {
+        HtmlReader
+            .read(input, &ReaderOptions::default())
+            .expect("reader should not fail")
+            .blocks
+    }
+
+    #[test]
+    fn paragraph_with_emphasis() {
+        let result = blocks("<p>a <em>b</em></p>");
+        assert!(matches!(result.as_slice(), [Block::Para(_)]));
+    }
+
+    #[test]
+    fn loose_text_is_plain() {
+        assert!(matches!(blocks("hello").as_slice(), [Block::Plain(_)]));
+    }
+
+    #[test]
+    fn paragraph_sibling_promotes_loose_text() {
+        let result = blocks("loose<p>para</p>");
+        assert!(matches!(
+            result.as_slice(),
+            [Block::Para(_), Block::Para(_)]
+        ));
+    }
+
+    #[test]
+    fn horizontal_rule_does_not_promote() {
+        let result = blocks("loose<hr>");
+        assert!(matches!(
+            result.as_slice(),
+            [Block::Plain(_), Block::HorizontalRule]
+        ));
+    }
+
+    #[test]
+    fn nested_list_inside_item_stays_tight() {
+        let result = blocks("<ul><li>a<ul><li>b</li></ul></li></ul>");
+        let Some(Block::BulletList(items)) = result.first() else {
+            panic!("expected bullet list");
+        };
+        let Some(item) = items.first() else {
+            panic!("expected one item");
+        };
+        assert!(matches!(item.first(), Some(Block::Plain(_))));
+    }
+
+    #[test]
+    fn heading_generates_identifier() {
+        let result = blocks("<h1>Hello World</h1>");
+        let Some(Block::Header(level, attr, _)) = result.first() else {
+            panic!("expected header");
+        };
+        assert_eq!(*level, 1);
+        assert_eq!(attr.id, "hello-world");
+    }
+
+    #[test]
+    fn duplicate_identifiers_are_disambiguated() {
+        let result = blocks("<h1>Sec</h1><h2>Sec</h2>");
+        let ids: Vec<&str> = result
+            .iter()
+            .filter_map(|block| match block {
+                Block::Header(_, attr, _) => Some(attr.id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(ids, vec!["sec", "sec-1"]);
+    }
+
+    #[test]
+    fn entities_are_decoded() {
+        let result = blocks("<p>a &amp; b &copy; c</p>");
+        let Some(Block::Para(inlines)) = result.first() else {
+            panic!("expected paragraph");
+        };
+        assert!(inlines.contains(&Inline::Str("&".to_string())));
+        assert!(inlines.contains(&Inline::Str("\u{a9}".to_string())));
+    }
+
+    #[test]
+    fn comment_joins_surrounding_text() {
+        let result = blocks("<p>a<!-- c -->b</p>");
+        let Some(Block::Para(inlines)) = result.first() else {
+            panic!("expected paragraph");
+        };
+        assert_eq!(inlines.as_slice(), [Inline::Str("ab".to_string())]);
+    }
+
+    #[test]
+    fn script_content_is_dropped() {
+        assert!(blocks("<script>var x = 1;</script><p>p</p>").len() == 1);
+    }
+
+    #[test]
+    fn head_metadata_is_extracted() {
+        let document = HtmlReader
+            .read(
+                "<head><title>T</title><meta name=\"author\" content=\"A\"></head><body><p>b</p></body>",
+                &ReaderOptions::default(),
+            )
+            .expect("reader should not fail");
+        assert!(document.meta.contains_key("title"));
+        assert!(document.meta.contains_key("author"));
+    }
+}

--- a/crates/oxidoc-readers/src/lib.rs
+++ b/crates/oxidoc-readers/src/lib.rs
@@ -3,10 +3,18 @@
 
 #[cfg(feature = "commonmark")]
 pub mod commonmark;
+#[cfg(feature = "html")]
+pub mod html;
 #[cfg(feature = "json")]
 pub mod json;
+#[cfg(feature = "native")]
+pub mod native;
 
 #[cfg(feature = "commonmark")]
 pub use commonmark::CommonmarkReader;
+#[cfg(feature = "html")]
+pub use html::HtmlReader;
 #[cfg(feature = "json")]
 pub use json::JsonReader;
+#[cfg(feature = "native")]
+pub use native::NativeReader;

--- a/crates/oxidoc-readers/src/native.rs
+++ b/crates/oxidoc-readers/src/native.rs
@@ -1,0 +1,1003 @@
+//! Native reader: parses the document model's printed textual form back into the model.
+//!
+//! The native format is the human-readable rendering of the AST — constructor names applied to
+//! their arguments, with strings, tuples, lists, and records written in a small constructor-
+//! application value syntax (`Para [ Str "x" ]`, `("id", ["class"], [("k","v")])`). Parsing has two
+//! stages: a
+//! lexer ([`tokenize`]) splits the source into [`Token`]s, and a recursive-descent [`Parser`]
+//! consumes them type-directedly — each AST shape has a dedicated method, so the same `(…, …, …)`
+//! tuple is read as the type the position calls for.
+//!
+//! Top level accepts, in order of preference, a whole document (`Pandoc <meta> <blocks>`), a block
+//! list, a single block, an inline list, or a single inline; the last three are wrapped to form a
+//! document (a lone inline or inline list becomes a `Plain` block).
+
+use std::collections::BTreeMap;
+
+use oxidoc_ast::{
+    Alignment, Attr, Block, Caption, Cell, Citation, CitationMode, ColSpec, ColWidth, Document,
+    Format, Inline, ListAttributes, ListNumberDelim, ListNumberStyle, MathType, MetaValue,
+    QuoteType, Row, Table, TableBody, TableFoot, TableHead, Target,
+};
+use oxidoc_core::{Error, Reader, ReaderOptions, Result};
+
+/// Parses the document model's printed textual form into the document model.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NativeReader;
+
+impl Reader for NativeReader {
+    fn read(&self, input: &str, _options: &ReaderOptions) -> Result<Document> {
+        let tokens = tokenize(input)?;
+        let mut parser = Parser { tokens, pos: 0 };
+        let document = parser.parse_document()?;
+        if parser.pos != parser.tokens.len() {
+            return Err(syntax_error("unexpected trailing input"));
+        }
+        Ok(document)
+    }
+}
+
+fn syntax_error(message: impl Into<String>) -> Error {
+    Error::Io(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        message.into(),
+    ))
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    LBrace,
+    RBrace,
+    Comma,
+    Equals,
+    Ident(String),
+    Str(String),
+    Num(String),
+}
+
+fn tokenize(input: &str) -> Result<Vec<Token>> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut pos = 0;
+    let mut tokens = Vec::new();
+    while let Some(&c) = chars.get(pos) {
+        if c.is_whitespace() {
+            pos += 1;
+            continue;
+        }
+        match c {
+            '(' => push_punct(&mut tokens, &mut pos, Token::LParen),
+            ')' => push_punct(&mut tokens, &mut pos, Token::RParen),
+            '[' => push_punct(&mut tokens, &mut pos, Token::LBracket),
+            ']' => push_punct(&mut tokens, &mut pos, Token::RBracket),
+            '{' => push_punct(&mut tokens, &mut pos, Token::LBrace),
+            '}' => push_punct(&mut tokens, &mut pos, Token::RBrace),
+            ',' => push_punct(&mut tokens, &mut pos, Token::Comma),
+            '=' => push_punct(&mut tokens, &mut pos, Token::Equals),
+            '"' => {
+                let (text, next) = lex_string(&chars, pos)?;
+                tokens.push(Token::Str(text));
+                pos = next;
+            }
+            '-' => {
+                let (number, next) = lex_number(&chars, pos)?;
+                tokens.push(Token::Num(number));
+                pos = next;
+            }
+            _ if c.is_ascii_digit() => {
+                let (number, next) = lex_number(&chars, pos)?;
+                tokens.push(Token::Num(number));
+                pos = next;
+            }
+            _ if c.is_alphabetic() || c == '_' => {
+                let (ident, next) = lex_ident(&chars, pos);
+                tokens.push(Token::Ident(ident));
+                pos = next;
+            }
+            _ => return Err(syntax_error(format!("unexpected character '{c}'"))),
+        }
+    }
+    Ok(tokens)
+}
+
+fn push_punct(tokens: &mut Vec<Token>, pos: &mut usize, token: Token) {
+    tokens.push(token);
+    *pos += 1;
+}
+
+fn lex_ident(chars: &[char], start: usize) -> (String, usize) {
+    let mut pos = start;
+    let mut ident = String::new();
+    while let Some(&c) = chars.get(pos) {
+        if c.is_alphanumeric() || c == '_' || c == '\'' {
+            ident.push(c);
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+    (ident, pos)
+}
+
+fn lex_number(chars: &[char], start: usize) -> Result<(String, usize)> {
+    let mut pos = start;
+    let mut number = String::new();
+    if chars.get(pos) == Some(&'-') {
+        number.push('-');
+        pos += 1;
+    }
+    let digits_start = pos;
+    pos = consume_digits(chars, pos, &mut number);
+    if pos == digits_start {
+        return Err(syntax_error("expected a digit"));
+    }
+    if chars.get(pos) == Some(&'.') {
+        number.push('.');
+        pos += 1;
+        pos = consume_digits(chars, pos, &mut number);
+    }
+    if matches!(chars.get(pos), Some('e' | 'E')) {
+        if let Some(&exp) = chars.get(pos) {
+            number.push(exp);
+        }
+        pos += 1;
+        if matches!(chars.get(pos), Some('+' | '-')) {
+            if let Some(&sign) = chars.get(pos) {
+                number.push(sign);
+            }
+            pos += 1;
+        }
+        pos = consume_digits(chars, pos, &mut number);
+    }
+    Ok((number, pos))
+}
+
+fn consume_digits(chars: &[char], start: usize, out: &mut String) -> usize {
+    let mut pos = start;
+    while let Some(&c) = chars.get(pos) {
+        if c.is_ascii_digit() {
+            out.push(c);
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+    pos
+}
+
+/// ASCII control-code mnemonics as emitted for non-printable characters (`\ESC`, `\SOH`, …),
+/// longest first so maximal-munch matching prefers `SOH` over `SO`.
+const CONTROL_MNEMONICS: &[(&str, u32)] = &[
+    ("NUL", 0),
+    ("SOH", 1),
+    ("STX", 2),
+    ("ETX", 3),
+    ("EOT", 4),
+    ("ENQ", 5),
+    ("ACK", 6),
+    ("BEL", 7),
+    ("DLE", 16),
+    ("DC1", 17),
+    ("DC2", 18),
+    ("DC3", 19),
+    ("DC4", 20),
+    ("NAK", 21),
+    ("SYN", 22),
+    ("ETB", 23),
+    ("CAN", 24),
+    ("SUB", 26),
+    ("ESC", 27),
+    ("DEL", 127),
+    ("BS", 8),
+    ("HT", 9),
+    ("LF", 10),
+    ("VT", 11),
+    ("FF", 12),
+    ("CR", 13),
+    ("SO", 14),
+    ("SI", 15),
+    ("EM", 25),
+    ("FS", 28),
+    ("GS", 29),
+    ("RS", 30),
+    ("US", 31),
+    ("SP", 32),
+];
+
+fn lex_string(chars: &[char], start: usize) -> Result<(String, usize)> {
+    let mut pos = start + 1;
+    let mut text = String::new();
+    loop {
+        match chars.get(pos) {
+            None => return Err(syntax_error("unterminated string literal")),
+            Some('"') => return Ok((text, pos + 1)),
+            Some('\\') => pos = lex_escape(chars, pos, &mut text)?,
+            Some(&c) => {
+                text.push(c);
+                pos += 1;
+            }
+        }
+    }
+}
+
+/// Decodes one escape sequence starting at the backslash at `pos`, appending its character (if
+/// any) to `text`, and returns the index just past the sequence.
+fn lex_escape(chars: &[char], pos: usize, text: &mut String) -> Result<usize> {
+    let escaped = chars
+        .get(pos + 1)
+        .copied()
+        .ok_or_else(|| syntax_error("dangling escape at end of string"))?;
+    match escaped {
+        'n' => Ok(push_char(text, '\n', pos + 2)),
+        't' => Ok(push_char(text, '\t', pos + 2)),
+        'r' => Ok(push_char(text, '\r', pos + 2)),
+        'f' => Ok(push_char(text, '\u{0C}', pos + 2)),
+        'v' => Ok(push_char(text, '\u{0B}', pos + 2)),
+        'a' => Ok(push_char(text, '\u{07}', pos + 2)),
+        'b' => Ok(push_char(text, '\u{08}', pos + 2)),
+        '\\' => Ok(push_char(text, '\\', pos + 2)),
+        '"' => Ok(push_char(text, '"', pos + 2)),
+        '\'' => Ok(push_char(text, '\'', pos + 2)),
+        '&' => Ok(pos + 2),
+        '^' => {
+            let control = chars
+                .get(pos + 2)
+                .copied()
+                .ok_or_else(|| syntax_error("dangling control escape"))?;
+            let code = (control as u32)
+                .checked_sub(64)
+                .ok_or_else(|| syntax_error("invalid control escape"))?;
+            Ok(push_char(text, code_to_char(code)?, pos + 3))
+        }
+        'x' => lex_radix_escape(chars, pos + 2, 16, text),
+        'o' => lex_radix_escape(chars, pos + 2, 8, text),
+        d if d.is_ascii_digit() => lex_decimal_escape(chars, pos + 1, text),
+        w if w.is_whitespace() => lex_gap(chars, pos + 1),
+        u if u.is_ascii_uppercase() => lex_mnemonic_escape(chars, pos + 1, text),
+        other => Err(syntax_error(format!("unknown string escape '\\{other}'"))),
+    }
+}
+
+fn push_char(text: &mut String, c: char, next: usize) -> usize {
+    text.push(c);
+    next
+}
+
+fn code_to_char(code: u32) -> Result<char> {
+    char::from_u32(code).ok_or_else(|| syntax_error(format!("invalid character code {code}")))
+}
+
+fn lex_decimal_escape(chars: &[char], start: usize, text: &mut String) -> Result<usize> {
+    let mut pos = start;
+    let mut code: u32 = 0;
+    while let Some(&c) = chars.get(pos) {
+        if let Some(digit) = c.to_digit(10) {
+            code = code
+                .checked_mul(10)
+                .and_then(|value| value.checked_add(digit))
+                .ok_or_else(|| syntax_error("character code out of range"))?;
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+    Ok(push_char(text, code_to_char(code)?, pos))
+}
+
+fn lex_radix_escape(chars: &[char], start: usize, radix: u32, text: &mut String) -> Result<usize> {
+    let mut pos = start;
+    let mut code: u32 = 0;
+    let mut seen = false;
+    while let Some(&c) = chars.get(pos) {
+        if let Some(digit) = c.to_digit(radix) {
+            code = code
+                .checked_mul(radix)
+                .and_then(|value| value.checked_add(digit))
+                .ok_or_else(|| syntax_error("character code out of range"))?;
+            seen = true;
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+    if !seen {
+        return Err(syntax_error("empty numeric escape"));
+    }
+    Ok(push_char(text, code_to_char(code)?, pos))
+}
+
+fn lex_mnemonic_escape(chars: &[char], start: usize, text: &mut String) -> Result<usize> {
+    for &(name, code) in CONTROL_MNEMONICS {
+        if mnemonic_matches(chars, start, name) {
+            return Ok(push_char(text, code_to_char(code)?, start + name.len()));
+        }
+    }
+    Err(syntax_error("unknown control-code escape"))
+}
+
+fn mnemonic_matches(chars: &[char], start: usize, name: &str) -> bool {
+    name.chars()
+        .enumerate()
+        .all(|(offset, expected)| chars.get(start + offset) == Some(&expected))
+}
+
+/// A string gap (`\<whitespace>\`) carries no character; skip the whitespace run and its closing
+/// backslash.
+fn lex_gap(chars: &[char], start: usize) -> Result<usize> {
+    let mut pos = start;
+    while let Some(&c) = chars.get(pos) {
+        if c.is_whitespace() {
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+    if chars.get(pos) == Some(&'\\') {
+        Ok(pos + 1)
+    } else {
+        Err(syntax_error("unterminated string gap"))
+    }
+}
+
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn peek_ident(&self) -> Option<&str> {
+        match self.peek() {
+            Some(Token::Ident(name)) => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    fn advance(&mut self) -> Result<Token> {
+        match self.tokens.get(self.pos) {
+            Some(token) => {
+                let token = token.clone();
+                self.pos += 1;
+                Ok(token)
+            }
+            None => Err(syntax_error("unexpected end of input")),
+        }
+    }
+
+    /// Consume the current token by moving it out of the stream, leaving a cheap placeholder behind.
+    /// Used where the token owns heap data (idents, strings, numbers) that the caller takes ownership
+    /// of; consumed positions are never revisited.
+    fn take(&mut self) -> Result<Token> {
+        match self.tokens.get_mut(self.pos) {
+            Some(slot) => {
+                let token = std::mem::replace(slot, Token::Comma);
+                self.pos += 1;
+                Ok(token)
+            }
+            None => Err(syntax_error("unexpected end of input")),
+        }
+    }
+
+    fn eat(&mut self, expected: &Token) -> Result<()> {
+        match self.tokens.get(self.pos) {
+            Some(found) if found == expected => {
+                self.pos += 1;
+                Ok(())
+            }
+            Some(found) => Err(syntax_error(format!(
+                "expected {expected:?}, found {found:?}"
+            ))),
+            None => Err(syntax_error("unexpected end of input")),
+        }
+    }
+
+    fn eat_ident(&mut self, name: &str) -> Result<()> {
+        match self.tokens.get(self.pos) {
+            Some(Token::Ident(found)) if found == name => {
+                self.pos += 1;
+                Ok(())
+            }
+            Some(found) => Err(syntax_error(format!("expected '{name}', found {found:?}"))),
+            None => Err(syntax_error("unexpected end of input")),
+        }
+    }
+
+    fn constructor(&mut self) -> Result<String> {
+        match self.take()? {
+            Token::Ident(name) => Ok(name),
+            found => Err(syntax_error(format!(
+                "expected a constructor, found {found:?}"
+            ))),
+        }
+    }
+
+    fn open_paren(&mut self) -> bool {
+        if self.peek() == Some(&Token::LParen) {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn close_if(&mut self, opened: bool) -> Result<()> {
+        if opened {
+            self.eat(&Token::RParen)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn parse_list<T>(&mut self, element: fn(&mut Self) -> Result<T>) -> Result<Vec<T>> {
+        self.eat(&Token::LBracket)?;
+        let mut items = Vec::new();
+        if self.peek() == Some(&Token::RBracket) {
+            self.pos += 1;
+            return Ok(items);
+        }
+        loop {
+            items.push(element(self)?);
+            match self.advance()? {
+                Token::Comma => {}
+                Token::RBracket => break,
+                found => {
+                    return Err(syntax_error(format!(
+                        "expected ',' or ']', found {found:?}"
+                    )));
+                }
+            }
+        }
+        Ok(items)
+    }
+
+    fn parse_string(&mut self) -> Result<String> {
+        match self.take()? {
+            Token::Str(text) => Ok(text),
+            found => Err(syntax_error(format!("expected a string, found {found:?}"))),
+        }
+    }
+
+    fn parse_i32(&mut self) -> Result<i32> {
+        let opened = self.open_paren();
+        let value = match self.take()? {
+            Token::Num(number) => number
+                .parse::<i32>()
+                .map_err(|error| syntax_error(format!("invalid integer '{number}': {error}")))?,
+            found => {
+                return Err(syntax_error(format!(
+                    "expected an integer, found {found:?}"
+                )));
+            }
+        };
+        self.close_if(opened)?;
+        Ok(value)
+    }
+
+    fn parse_f64(&mut self) -> Result<f64> {
+        let opened = self.open_paren();
+        let value = match self.take()? {
+            Token::Num(number) => number
+                .parse::<f64>()
+                .map_err(|error| syntax_error(format!("invalid number '{number}': {error}")))?,
+            found => return Err(syntax_error(format!("expected a number, found {found:?}"))),
+        };
+        self.close_if(opened)?;
+        Ok(value)
+    }
+
+    fn parse_document(&mut self) -> Result<Document> {
+        if self.peek_ident() == Some("Pandoc") {
+            self.pos += 1;
+            let meta = self.parse_meta()?;
+            let blocks = self.parse_block_list()?;
+            return Ok(Document {
+                meta,
+                blocks,
+                ..Default::default()
+            });
+        }
+        if self.peek() == Some(&Token::LBracket) {
+            let blocks = match self.tokens.get(self.pos + 1) {
+                Some(Token::RBracket) => self.parse_block_list()?,
+                Some(Token::Ident(name)) if is_block_tag(name) => self.parse_block_list()?,
+                Some(Token::Ident(name)) if is_inline_tag(name) => {
+                    vec![Block::Plain(self.parse_inline_list()?)]
+                }
+                _ => return Err(syntax_error("unrecognized list element")),
+            };
+            return Ok(Document {
+                blocks,
+                ..Default::default()
+            });
+        }
+        match self.peek_ident() {
+            Some(name) if is_block_tag(name) => {
+                let block = self.parse_block()?;
+                Ok(Document {
+                    blocks: vec![block],
+                    ..Default::default()
+                })
+            }
+            Some(name) if is_inline_tag(name) => {
+                let inline = self.parse_inline()?;
+                Ok(Document {
+                    blocks: vec![Block::Plain(vec![inline])],
+                    ..Default::default()
+                })
+            }
+            _ => Err(syntax_error("input is not a recognized native document")),
+        }
+    }
+
+    fn parse_meta(&mut self) -> Result<BTreeMap<String, MetaValue>> {
+        let opened = self.open_paren();
+        self.eat_ident("Meta")?;
+        self.eat(&Token::LBrace)?;
+        self.eat_ident("unMeta")?;
+        self.eat(&Token::Equals)?;
+        let map = self.parse_from_list()?;
+        self.eat(&Token::RBrace)?;
+        self.close_if(opened)?;
+        Ok(map)
+    }
+
+    fn parse_from_list(&mut self) -> Result<BTreeMap<String, MetaValue>> {
+        let opened = self.open_paren();
+        self.eat_ident("fromList")?;
+        let pairs = self.parse_list(Self::parse_meta_pair)?;
+        self.close_if(opened)?;
+        Ok(pairs.into_iter().collect())
+    }
+
+    fn parse_meta_pair(&mut self) -> Result<(String, MetaValue)> {
+        self.eat(&Token::LParen)?;
+        let key = self.parse_string()?;
+        self.eat(&Token::Comma)?;
+        let value = self.parse_meta_value()?;
+        self.eat(&Token::RParen)?;
+        Ok((key, value))
+    }
+
+    fn parse_meta_value(&mut self) -> Result<MetaValue> {
+        let name = self.constructor()?;
+        match name.as_str() {
+            "MetaMap" => Ok(MetaValue::MetaMap(self.parse_from_list()?)),
+            "MetaList" => Ok(MetaValue::MetaList(
+                self.parse_list(Self::parse_meta_value)?,
+            )),
+            "MetaBool" => Ok(MetaValue::MetaBool(self.parse_bool()?)),
+            "MetaString" => Ok(MetaValue::MetaString(self.parse_string()?)),
+            "MetaInlines" => Ok(MetaValue::MetaInlines(self.parse_inline_list()?)),
+            "MetaBlocks" => Ok(MetaValue::MetaBlocks(self.parse_block_list()?)),
+            other => Err(syntax_error(format!("unknown metadata value '{other}'"))),
+        }
+    }
+
+    fn parse_bool(&mut self) -> Result<bool> {
+        match self.constructor()?.as_str() {
+            "True" => Ok(true),
+            "False" => Ok(false),
+            other => Err(syntax_error(format!("expected a boolean, found '{other}'"))),
+        }
+    }
+
+    fn parse_block_list(&mut self) -> Result<Vec<Block>> {
+        self.parse_list(Self::parse_block)
+    }
+
+    fn parse_inline_list(&mut self) -> Result<Vec<Inline>> {
+        self.parse_list(Self::parse_inline)
+    }
+
+    fn parse_block(&mut self) -> Result<Block> {
+        let name = self.constructor()?;
+        match name.as_str() {
+            "Plain" => Ok(Block::Plain(self.parse_inline_list()?)),
+            "Para" => Ok(Block::Para(self.parse_inline_list()?)),
+            "LineBlock" => Ok(Block::LineBlock(self.parse_list(Self::parse_inline_list)?)),
+            "CodeBlock" => {
+                let attr = self.parse_attr()?;
+                let text = self.parse_string()?;
+                Ok(Block::CodeBlock(attr, text))
+            }
+            "RawBlock" => {
+                let format = self.parse_format()?;
+                let text = self.parse_string()?;
+                Ok(Block::RawBlock(format, text))
+            }
+            "BlockQuote" => Ok(Block::BlockQuote(self.parse_block_list()?)),
+            "OrderedList" => {
+                let attributes = self.parse_list_attributes()?;
+                let items = self.parse_list(Self::parse_block_list)?;
+                Ok(Block::OrderedList(attributes, items))
+            }
+            "BulletList" => Ok(Block::BulletList(self.parse_list(Self::parse_block_list)?)),
+            "DefinitionList" => Ok(Block::DefinitionList(
+                self.parse_list(Self::parse_definition_item)?,
+            )),
+            "Header" => {
+                let level = self.parse_i32()?;
+                let attr = self.parse_attr()?;
+                let inlines = self.parse_inline_list()?;
+                Ok(Block::Header(level, attr, inlines))
+            }
+            "HorizontalRule" => Ok(Block::HorizontalRule),
+            "Table" => Ok(Block::Table(Box::new(self.parse_table()?))),
+            "Figure" => {
+                let attr = self.parse_attr()?;
+                let caption = self.parse_caption()?;
+                let blocks = self.parse_block_list()?;
+                Ok(Block::Figure(attr, caption, blocks))
+            }
+            "Div" => {
+                let attr = self.parse_attr()?;
+                let blocks = self.parse_block_list()?;
+                Ok(Block::Div(attr, blocks))
+            }
+            other => Err(syntax_error(format!("unknown block '{other}'"))),
+        }
+    }
+
+    fn parse_inline(&mut self) -> Result<Inline> {
+        let name = self.constructor()?;
+        match name.as_str() {
+            "Str" => Ok(Inline::Str(self.parse_string()?)),
+            "Emph" => Ok(Inline::Emph(self.parse_inline_list()?)),
+            "Underline" => Ok(Inline::Underline(self.parse_inline_list()?)),
+            "Strong" => Ok(Inline::Strong(self.parse_inline_list()?)),
+            "Strikeout" => Ok(Inline::Strikeout(self.parse_inline_list()?)),
+            "Superscript" => Ok(Inline::Superscript(self.parse_inline_list()?)),
+            "Subscript" => Ok(Inline::Subscript(self.parse_inline_list()?)),
+            "SmallCaps" => Ok(Inline::SmallCaps(self.parse_inline_list()?)),
+            "Quoted" => {
+                let quote = self.parse_quote_type()?;
+                let inlines = self.parse_inline_list()?;
+                Ok(Inline::Quoted(quote, inlines))
+            }
+            "Cite" => {
+                let citations = self.parse_list(Self::parse_citation)?;
+                let inlines = self.parse_inline_list()?;
+                Ok(Inline::Cite(citations, inlines))
+            }
+            "Code" => {
+                let attr = self.parse_attr()?;
+                let text = self.parse_string()?;
+                Ok(Inline::Code(attr, text))
+            }
+            "Space" => Ok(Inline::Space),
+            "SoftBreak" => Ok(Inline::SoftBreak),
+            "LineBreak" => Ok(Inline::LineBreak),
+            "Math" => {
+                let math = self.parse_math_type()?;
+                let text = self.parse_string()?;
+                Ok(Inline::Math(math, text))
+            }
+            "RawInline" => {
+                let format = self.parse_format()?;
+                let text = self.parse_string()?;
+                Ok(Inline::RawInline(format, text))
+            }
+            "Link" => {
+                let attr = self.parse_attr()?;
+                let inlines = self.parse_inline_list()?;
+                let target = self.parse_target()?;
+                Ok(Inline::Link(attr, inlines, target))
+            }
+            "Image" => {
+                let attr = self.parse_attr()?;
+                let inlines = self.parse_inline_list()?;
+                let target = self.parse_target()?;
+                Ok(Inline::Image(attr, inlines, target))
+            }
+            "Note" => Ok(Inline::Note(self.parse_block_list()?)),
+            "Span" => {
+                let attr = self.parse_attr()?;
+                let inlines = self.parse_inline_list()?;
+                Ok(Inline::Span(attr, inlines))
+            }
+            other => Err(syntax_error(format!("unknown inline '{other}'"))),
+        }
+    }
+
+    fn parse_attr(&mut self) -> Result<Attr> {
+        self.eat(&Token::LParen)?;
+        let id = self.parse_string()?;
+        self.eat(&Token::Comma)?;
+        let classes = self.parse_list(Self::parse_string)?;
+        self.eat(&Token::Comma)?;
+        let attributes = self.parse_list(Self::parse_string_pair)?;
+        self.eat(&Token::RParen)?;
+        Ok(Attr {
+            id,
+            classes,
+            attributes,
+        })
+    }
+
+    fn parse_string_pair(&mut self) -> Result<(String, String)> {
+        self.eat(&Token::LParen)?;
+        let key = self.parse_string()?;
+        self.eat(&Token::Comma)?;
+        let value = self.parse_string()?;
+        self.eat(&Token::RParen)?;
+        Ok((key, value))
+    }
+
+    fn parse_target(&mut self) -> Result<Target> {
+        self.eat(&Token::LParen)?;
+        let url = self.parse_string()?;
+        self.eat(&Token::Comma)?;
+        let title = self.parse_string()?;
+        self.eat(&Token::RParen)?;
+        Ok(Target { url, title })
+    }
+
+    fn parse_format(&mut self) -> Result<Format> {
+        let opened = self.open_paren();
+        self.eat_ident("Format")?;
+        let name = self.parse_string()?;
+        self.close_if(opened)?;
+        Ok(Format(name))
+    }
+
+    fn parse_list_attributes(&mut self) -> Result<ListAttributes> {
+        self.eat(&Token::LParen)?;
+        let start = self.parse_i32()?;
+        self.eat(&Token::Comma)?;
+        let style = self.parse_list_number_style()?;
+        self.eat(&Token::Comma)?;
+        let delim = self.parse_list_number_delim()?;
+        self.eat(&Token::RParen)?;
+        Ok(ListAttributes {
+            start,
+            style,
+            delim,
+        })
+    }
+
+    fn parse_definition_item(&mut self) -> Result<(Vec<Inline>, Vec<Vec<Block>>)> {
+        self.eat(&Token::LParen)?;
+        let term = self.parse_inline_list()?;
+        self.eat(&Token::Comma)?;
+        let definitions = self.parse_list(Self::parse_block_list)?;
+        self.eat(&Token::RParen)?;
+        Ok((term, definitions))
+    }
+
+    fn parse_quote_type(&mut self) -> Result<QuoteType> {
+        match self.constructor()?.as_str() {
+            "SingleQuote" => Ok(QuoteType::SingleQuote),
+            "DoubleQuote" => Ok(QuoteType::DoubleQuote),
+            other => Err(syntax_error(format!("unknown quote type '{other}'"))),
+        }
+    }
+
+    fn parse_math_type(&mut self) -> Result<MathType> {
+        match self.constructor()?.as_str() {
+            "InlineMath" => Ok(MathType::InlineMath),
+            "DisplayMath" => Ok(MathType::DisplayMath),
+            other => Err(syntax_error(format!("unknown math type '{other}'"))),
+        }
+    }
+
+    fn parse_list_number_style(&mut self) -> Result<ListNumberStyle> {
+        match self.constructor()?.as_str() {
+            "DefaultStyle" => Ok(ListNumberStyle::DefaultStyle),
+            "Example" => Ok(ListNumberStyle::Example),
+            "Decimal" => Ok(ListNumberStyle::Decimal),
+            "LowerRoman" => Ok(ListNumberStyle::LowerRoman),
+            "UpperRoman" => Ok(ListNumberStyle::UpperRoman),
+            "LowerAlpha" => Ok(ListNumberStyle::LowerAlpha),
+            "UpperAlpha" => Ok(ListNumberStyle::UpperAlpha),
+            other => Err(syntax_error(format!("unknown list number style '{other}'"))),
+        }
+    }
+
+    fn parse_list_number_delim(&mut self) -> Result<ListNumberDelim> {
+        match self.constructor()?.as_str() {
+            "DefaultDelim" => Ok(ListNumberDelim::DefaultDelim),
+            "Period" => Ok(ListNumberDelim::Period),
+            "OneParen" => Ok(ListNumberDelim::OneParen),
+            "TwoParens" => Ok(ListNumberDelim::TwoParens),
+            other => Err(syntax_error(format!(
+                "unknown list number delimiter '{other}'"
+            ))),
+        }
+    }
+
+    fn parse_citation_mode(&mut self) -> Result<CitationMode> {
+        match self.constructor()?.as_str() {
+            "AuthorInText" => Ok(CitationMode::AuthorInText),
+            "SuppressAuthor" => Ok(CitationMode::SuppressAuthor),
+            "NormalCitation" => Ok(CitationMode::NormalCitation),
+            other => Err(syntax_error(format!("unknown citation mode '{other}'"))),
+        }
+    }
+
+    fn parse_alignment(&mut self) -> Result<Alignment> {
+        match self.constructor()?.as_str() {
+            "AlignLeft" => Ok(Alignment::AlignLeft),
+            "AlignRight" => Ok(Alignment::AlignRight),
+            "AlignCenter" => Ok(Alignment::AlignCenter),
+            "AlignDefault" => Ok(Alignment::AlignDefault),
+            other => Err(syntax_error(format!("unknown alignment '{other}'"))),
+        }
+    }
+
+    fn parse_col_width(&mut self) -> Result<ColWidth> {
+        match self.constructor()?.as_str() {
+            "ColWidthDefault" => Ok(ColWidth::ColWidthDefault),
+            "ColWidth" => Ok(ColWidth::ColWidth(self.parse_f64()?)),
+            other => Err(syntax_error(format!("unknown column width '{other}'"))),
+        }
+    }
+
+    fn parse_col_spec(&mut self) -> Result<ColSpec> {
+        self.eat(&Token::LParen)?;
+        let align = self.parse_alignment()?;
+        self.eat(&Token::Comma)?;
+        let width = self.parse_col_width()?;
+        self.eat(&Token::RParen)?;
+        Ok(ColSpec { align, width })
+    }
+
+    fn parse_citation(&mut self) -> Result<Citation> {
+        let opened = self.open_paren();
+        self.eat_ident("Citation")?;
+        self.eat(&Token::LBrace)?;
+        let mut citation = Citation {
+            id: String::new(),
+            prefix: Vec::new(),
+            suffix: Vec::new(),
+            mode: CitationMode::NormalCitation,
+            note_num: 0,
+            hash: 0,
+        };
+        loop {
+            let field = self.constructor()?;
+            self.eat(&Token::Equals)?;
+            match field.as_str() {
+                "citationId" => citation.id = self.parse_string()?,
+                "citationPrefix" => citation.prefix = self.parse_inline_list()?,
+                "citationSuffix" => citation.suffix = self.parse_inline_list()?,
+                "citationMode" => citation.mode = self.parse_citation_mode()?,
+                "citationNoteNum" => citation.note_num = self.parse_i32()?,
+                "citationHash" => citation.hash = self.parse_i32()?,
+                other => return Err(syntax_error(format!("unknown citation field '{other}'"))),
+            }
+            match self.advance()? {
+                Token::Comma => {}
+                Token::RBrace => break,
+                found => {
+                    return Err(syntax_error(format!(
+                        "expected ',' or '}}', found {found:?}"
+                    )));
+                }
+            }
+        }
+        self.close_if(opened)?;
+        Ok(citation)
+    }
+
+    fn parse_caption(&mut self) -> Result<Caption> {
+        let opened = self.open_paren();
+        self.eat_ident("Caption")?;
+        let short = self.parse_maybe_inlines()?;
+        let long = self.parse_block_list()?;
+        self.close_if(opened)?;
+        Ok(Caption { short, long })
+    }
+
+    fn parse_maybe_inlines(&mut self) -> Result<Option<Vec<Inline>>> {
+        let opened = self.open_paren();
+        let result = if self.peek_ident() == Some("Nothing") {
+            self.pos += 1;
+            None
+        } else {
+            self.eat_ident("Just")?;
+            Some(self.parse_inline_list()?)
+        };
+        self.close_if(opened)?;
+        Ok(result)
+    }
+
+    fn parse_table(&mut self) -> Result<Table> {
+        let attr = self.parse_attr()?;
+        let caption = self.parse_caption()?;
+        let col_specs = self.parse_list(Self::parse_col_spec)?;
+        let head = self.parse_table_head()?;
+        let bodies = self.parse_list(Self::parse_table_body)?;
+        let foot = self.parse_table_foot()?;
+        Ok(Table {
+            attr,
+            caption,
+            col_specs,
+            head,
+            bodies,
+            foot,
+        })
+    }
+
+    fn parse_table_head(&mut self) -> Result<TableHead> {
+        let opened = self.open_paren();
+        self.eat_ident("TableHead")?;
+        let attr = self.parse_attr()?;
+        let rows = self.parse_list(Self::parse_row)?;
+        self.close_if(opened)?;
+        Ok(TableHead { attr, rows })
+    }
+
+    fn parse_table_foot(&mut self) -> Result<TableFoot> {
+        let opened = self.open_paren();
+        self.eat_ident("TableFoot")?;
+        let attr = self.parse_attr()?;
+        let rows = self.parse_list(Self::parse_row)?;
+        self.close_if(opened)?;
+        Ok(TableFoot { attr, rows })
+    }
+
+    fn parse_table_body(&mut self) -> Result<TableBody> {
+        let opened = self.open_paren();
+        self.eat_ident("TableBody")?;
+        let attr = self.parse_attr()?;
+        let row_head_columns = self.parse_int_newtype("RowHeadColumns")?;
+        let head = self.parse_list(Self::parse_row)?;
+        let body = self.parse_list(Self::parse_row)?;
+        self.close_if(opened)?;
+        Ok(TableBody {
+            attr,
+            row_head_columns,
+            head,
+            body,
+        })
+    }
+
+    fn parse_row(&mut self) -> Result<Row> {
+        let opened = self.open_paren();
+        self.eat_ident("Row")?;
+        let attr = self.parse_attr()?;
+        let cells = self.parse_list(Self::parse_cell)?;
+        self.close_if(opened)?;
+        Ok(Row { attr, cells })
+    }
+
+    fn parse_cell(&mut self) -> Result<Cell> {
+        let opened = self.open_paren();
+        self.eat_ident("Cell")?;
+        let attr = self.parse_attr()?;
+        let align = self.parse_alignment()?;
+        let row_span = self.parse_int_newtype("RowSpan")?;
+        let col_span = self.parse_int_newtype("ColSpan")?;
+        let content = self.parse_block_list()?;
+        self.close_if(opened)?;
+        Ok(Cell {
+            attr,
+            align,
+            row_span,
+            col_span,
+            content,
+        })
+    }
+
+    fn parse_int_newtype(&mut self, name: &str) -> Result<i32> {
+        let opened = self.open_paren();
+        self.eat_ident(name)?;
+        let value = self.parse_i32()?;
+        self.close_if(opened)?;
+        Ok(value)
+    }
+}
+
+fn is_block_tag(name: &str) -> bool {
+    oxidoc_ast::BLOCK_TAGS.contains(&name)
+}
+
+fn is_inline_tag(name: &str) -> bool {
+    oxidoc_ast::INLINE_TAGS.contains(&name)
+}

--- a/crates/oxidoc-testkit/src/differential.rs
+++ b/crates/oxidoc-testkit/src/differential.rs
@@ -113,11 +113,13 @@ pub fn reader_json(from: &str, input: &str) -> std::io::Result<Diff> {
 }
 
 /// Oracle arguments that neutralize target-specific nondeterminism the writer does not reproduce.
-/// HTML output suppresses syntax highlighting and renders TeX math as `MathJax`; other targets need
-/// no normalization yet. This is the seam to extend as each new writer is verified.
+/// HTML output suppresses syntax highlighting and renders TeX math as `MathJax`; LaTeX suppresses
+/// syntax highlighting; other targets need no normalization yet. This is the seam to extend as each
+/// new writer is verified.
 fn oracle_normalization(to: &str) -> &'static [&'static str] {
     match to {
         "html" | "html5" => &["--syntax-highlighting=none", "--mathjax"],
+        "latex" => &["--syntax-highlighting=none"],
         _ => &[],
     }
 }

--- a/crates/oxidoc-testkit/tests/html_reader.rs
+++ b/crates/oxidoc-testkit/tests/html_reader.rs
@@ -1,0 +1,164 @@
+//! Reader-parity tests for the HTML reader. Each case feeds a small HTML fragment through the oracle
+//! to mint the expected JSON AST, then diffs the AST our reader produces byte-for-byte. The corpus is
+//! chosen to exercise every block and inline node the reader builds — paragraphs, headers, lists,
+//! quotes, code, rules, divs, definition lists, tables, figures, the inline emphasis family, links,
+//! images, raw spans, entities and head metadata. Expected values are minted at run time, never
+//! committed; the oracle is hard-required (its absence fails with provisioning instructions rather
+//! than skipping).
+
+// This whole file is test code, where panicking on a known case is the idiomatic assertion.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use oxidoc_testkit::differential::{self, Diff};
+use oxidoc_testkit::pandoc_bin;
+
+/// A reader-parity case: a human label and the HTML source text.
+struct Case {
+    label: &'static str,
+    input: &'static str,
+}
+
+const fn html(label: &'static str, input: &'static str) -> Case {
+    Case { label, input }
+}
+
+#[allow(clippy::too_many_lines)]
+fn cases() -> Vec<Case> {
+    vec![
+        html("paragraph", "<p>a plain paragraph</p>"),
+        html("loose-text", "bare text without a block wrapper"),
+        html(
+            "headers",
+            "<h1>One</h1><h2>Two</h2><h3>Three</h3><h4>Four</h4><h5>Five</h5><h6>Six</h6>",
+        ),
+        html("header-with-id", "<h2 id=\"anchor\">Titled</h2>"),
+        html("header-duplicate-ids", "<h1>Sec</h1><h2>Sec</h2>"),
+        html("header-classes", "<h1 class=\"a b\">Classed heading</h1>"),
+        html("bullet-list", "<ul><li>a</li><li>b</li><li>c</li></ul>"),
+        html("ordered-list-default", "<ol><li>one</li><li>two</li></ol>"),
+        html(
+            "ordered-list-start",
+            "<ol start=\"5\"><li>five</li><li>six</li></ol>",
+        ),
+        html(
+            "ordered-list-lower-alpha",
+            "<ol type=\"a\"><li>one</li><li>two</li></ol>",
+        ),
+        html(
+            "ordered-list-upper-roman",
+            "<ol type=\"I\"><li>one</li><li>two</li></ol>",
+        ),
+        html("nested-list", "<ul><li>a<ul><li>b</li></ul></li></ul>"),
+        html("loose-list", "<ul><li><p>a</p></li><li><p>b</p></li></ul>"),
+        html("blockquote", "<blockquote><p>quoted</p></blockquote>"),
+        html("pre-code-block", "<pre>let x = 1;\nx &lt; y</pre>"),
+        html(
+            "pre-code-lang",
+            "<pre><code class=\"language-rust\">let s = 1;</code></pre>",
+        ),
+        html("horizontal-rule", "<p>above</p><hr><p>below</p>"),
+        html("div", "<div id=\"d\" class=\"note\"><p>body</p></div>"),
+        html("section", "<section><p>body</p></section>"),
+        html(
+            "definition-list",
+            "<dl><dt>Term</dt><dd>Definition one</dd><dd>Definition two</dd></dl>",
+        ),
+        html(
+            "figure",
+            "<figure><img src=\"pic.png\"><figcaption>cap</figcaption></figure>",
+        ),
+        html(
+            "table-simple",
+            "<table><thead><tr><th>h1</th><th>h2</th></tr></thead><tbody><tr><td>a</td><td>b</td></tr></tbody></table>",
+        ),
+        html(
+            "table-aligned",
+            "<table><tr><td align=\"left\">l</td><td align=\"right\">r</td><td align=\"center\">c</td></tr></table>",
+        ),
+        html(
+            "table-colspan",
+            "<table><tr><td colspan=\"2\">wide</td></tr><tr><td>a</td><td>b</td></tr></table>",
+        ),
+        html(
+            "table-rowspan",
+            "<table><tr><td rowspan=\"2\">tall</td><td>a</td></tr><tr><td>b</td></tr></table>",
+        ),
+        html(
+            "table-caption",
+            "<table><caption>A caption</caption><tr><td>v</td></tr></table>",
+        ),
+        html("emphasis", "<p><em>emph</em> <i>also emph</i></p>"),
+        html(
+            "strong",
+            "<p><strong>strong</strong> <b>also strong</b></p>",
+        ),
+        html(
+            "strikeout",
+            "<p><del>del</del> <s>s</s> <strike>strike</strike></p>",
+        ),
+        html("underline", "<p><ins>ins</ins> <u>u</u></p>"),
+        html("super-sub", "<p>x<sup>2</sup> y<sub>3</sub></p>"),
+        html("quoted", "<p><q>quoted text</q></p>"),
+        html("line-break", "<p>a<br>b</p>"),
+        html(
+            "span",
+            "<p>a <span id=\"s\" class=\"c\">styled</span> word</p>",
+        ),
+        html(
+            "span-class-elements",
+            "<p><mark>m</mark> <small>s</small> <abbr>a</abbr> <kbd>k</kbd> <dfn>d</dfn></p>",
+        ),
+        html("inline-code", "<p>a <code>let x = 1;</code> b</p>"),
+        html("code-tt", "<p><tt>tt</tt></p>"),
+        html("samp-var", "<p><samp>out</samp> <var>x</var></p>"),
+        html(
+            "link",
+            "<p><a href=\"http://example.com\" title=\"t\">text</a></p>",
+        ),
+        html(
+            "link-attr",
+            "<p><a href=\"u\" id=\"l\" class=\"ext\">text</a></p>",
+        ),
+        html("anchor-name", "<p><a name=\"target\">label</a></p>"),
+        html(
+            "image",
+            "<p><img src=\"pic.png\" title=\"t\" alt=\"alt text\"></p>",
+        ),
+        html("entities-named", "<p>a &amp; b &copy; c</p>"),
+        html("entities-numeric", "<p>&#65; &#x41;</p>"),
+        html("comment", "<p>a<!-- c -->b</p>"),
+        html("script-dropped", "<script>var x = 1;</script><p>p</p>"),
+        html(
+            "head-metadata",
+            "<head><title>T</title><meta name=\"author\" content=\"A\"></head><body><p>b</p></body>",
+        ),
+    ]
+}
+
+#[test]
+fn reader_matches_oracle_html_across_the_model() {
+    assert!(
+        pandoc_bin().is_file(),
+        "pinned pandoc binary not found at {}.\nRun tools/install-pandoc.sh.",
+        pandoc_bin().display()
+    );
+
+    let mut failures = Vec::new();
+    for case in cases() {
+        match differential::reader_json("html", case.input).expect("run reader surface") {
+            Diff::Match | Diff::OracleRejected { .. } => {}
+            Diff::Mismatch { detail } => failures.push(format!("{}: {detail}", case.label)),
+            Diff::OxidocError { detail } => {
+                failures.push(format!("{}: error: {detail}", case.label));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{}/{} reader cases diverged:\n{}",
+        failures.len(),
+        cases().len(),
+        failures.join("\n")
+    );
+}

--- a/crates/oxidoc-testkit/tests/latex_writer.rs
+++ b/crates/oxidoc-testkit/tests/latex_writer.rs
@@ -1,0 +1,156 @@
+//! Writer-parity tests exercising the LaTeX writer across every document node it renders. Each case
+//! feeds a small source through the oracle to mint both the AST (as JSON our writer consumes) and the
+//! expected LaTeX output, then diffs our writer's output byte-for-byte. Expected values are minted at
+//! run time, never committed; the oracle is hard-required (its absence fails with provisioning
+//! instructions rather than skipping). Tables are excluded: the LaTeX writer does not yet render them.
+
+// This whole file is test code, where panicking on a known case is the idiomatic assertion.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use oxidoc_testkit::differential::{self, Diff};
+use oxidoc_testkit::pandoc_bin;
+
+/// A writer-parity case: a human label, the oracle source format, and the source text.
+struct Case {
+    label: &'static str,
+    from: &'static str,
+    input: &'static str,
+}
+
+const fn md(label: &'static str, input: &'static str) -> Case {
+    Case {
+        label,
+        from: "markdown",
+        input,
+    }
+}
+
+/// Cases chosen to cover every node the LaTeX writer handles. Markdown reaches the whole supported
+/// model; tables are omitted because the writer does not render them yet.
+fn cases() -> Vec<Case> {
+    vec![
+        md("paragraph", "a simple paragraph with words"),
+        md("soft-break", "first line\nsecond line"),
+        md("hard-break", "first line\\\nsecond line"),
+        md(
+            "emphasis-family",
+            "*emph* **strong** ~~struck~~ super^2^ sub~3~",
+        ),
+        md(
+            "underline-smallcaps",
+            "[under]{.underline} [small]{.smallcaps}",
+        ),
+        md("inline-code", "a `let x = 1;` b"),
+        md(
+            "inline-code-specials",
+            "before `a & b ~ c \\ d % e # f $ g _ h { i } j ^ k | l < m > n` after",
+        ),
+        md("escape-specials", "a & b % c # d _ e $ f { g } h ^ i ~ j"),
+        md(
+            "escape-brackets-backslash",
+            "use [a] and \\ and | and < and >",
+        ),
+        md("escape-dashes-quote", "a -- b and it's mine"),
+        md(
+            "code-block",
+            "``` rust\nlet s = \"hi\";\nx < y && y > z\n```",
+        ),
+        md("code-block-id", "``` {#snippet}\nplain code\n```"),
+        md(
+            "headers",
+            "# One\n\n## Two\n\n#### Four\n\n##### Five\n\n###### Six",
+        ),
+        md("header-attr", "# Titled {#anchor .cls}"),
+        md("header-unnumbered", "# Hidden {.unnumbered}"),
+        md("header-texorpdfstring", "## A *fancy* heading"),
+        md("blockquote", "> quoted\n>\n> more lines here"),
+        md("bullet-list-tight", "- a\n- b\n- c"),
+        md("bullet-list-loose", "- a\n\n- b\n\n- c"),
+        md("bullet-nested", "- outer\n    - inner one\n    - inner two"),
+        md("ordered-start", "5. five\n6. six"),
+        md("ordered-period", "1. one\n2. two"),
+        md("ordered-one-paren", "1) one\n2) two"),
+        md("ordered-two-parens", "(1) one\n(2) two"),
+        md("ordered-lower-alpha", "a. one\nb. two"),
+        md("ordered-upper-alpha", "A. one\nB. two"),
+        md("ordered-lower-roman", "i. one\nii. two"),
+        md("ordered-upper-roman", "I. one\nII. two"),
+        md("ordered-example", "(@) first\n(@) second"),
+        md(
+            "ordered-nested",
+            "1. outer\n    1. inner one\n    2. inner two",
+        ),
+        md(
+            "definition-list-tight",
+            "Term\n:   Definition one\n:   Definition two",
+        ),
+        md(
+            "definition-list-loose",
+            "Term\n\n:   Definition one\n\n:   Definition two",
+        ),
+        md("line-block", "| first line\n| second line"),
+        md("horizontal-rule", "above\n\n---\n\nbelow"),
+        md("raw-html-block-dropped", "<div class=\"x\">raw block</div>"),
+        md("raw-html-inline-dropped", "text <cite>raw</cite> more"),
+        md("raw-latex-block", "```{=latex}\n\\macro{value}\n```"),
+        md("raw-latex-inline", "a `\\emph{x}`{=latex} b"),
+        md("math-inline", "an equation $a^2 + b^2 = c^2$ inline"),
+        md("math-display", "$$\\int_0^1 x \\, dx$$"),
+        md("citation", "see [@knuth1984] for details"),
+        md("span-plain", "a [styled]{.c data-k=\"v\"} word"),
+        md("span-id", "a [styled]{#s} word"),
+        md("div-plain", "::: {.note}\nbody paragraph\n:::"),
+        md("div-id", "::: {#d}\nbody paragraph\n:::"),
+        md("quoted-smart", "She said \"hello\" and 'hi'."),
+        md("link-text", "see [the text](http://example.com \"t\") now"),
+        md("link-autolink", "<http://example.com>"),
+        md("link-url-specials", "[x](http://example.com/a%20b#frag)"),
+        md("image-implicit-figure", "![alt text](pic.png \"t\")"),
+        md("image-inline", "an ![alt words](pic.png) inline"),
+        md("image-no-alt", "![](pic.png)"),
+        md("footnote-simple", "ref[^a]\n\n[^a]: the note body"),
+        md(
+            "footnote-multipara",
+            "ref[^a]\n\n[^a]: first paragraph\n\n    second paragraph",
+        ),
+        md("footnote-two", "x[^a] y[^b]\n\n[^a]: first\n\n[^b]: second"),
+        md(
+            "wide-and-combining-wrap",
+            "This is a deliberately long paragraph with wide 中文字符 glyphs and a combining mark e\u{0301} so the writer measures column widths while wrapping at the fill column boundary.",
+        ),
+        md(
+            "smart-ellipsis-dashes",
+            "wait... an en--dash and an em---dash",
+        ),
+    ]
+}
+
+#[test]
+fn latex_writer_matches_oracle_across_the_model() {
+    assert!(
+        pandoc_bin().is_file(),
+        "pinned pandoc binary not found at {}.\nRun tools/install-pandoc.sh.",
+        pandoc_bin().display()
+    );
+
+    let cases = cases();
+    let total = cases.len();
+    let mut failures = Vec::new();
+    for case in cases {
+        match differential::writer("latex", case.from, case.input).expect("run writer surface") {
+            Diff::Match | Diff::OracleRejected { .. } => {}
+            Diff::Mismatch { detail } => failures.push(format!("{}: {detail}", case.label)),
+            Diff::OxidocError { detail } => {
+                failures.push(format!("{}: error: {detail}", case.label));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{}/{} LaTeX writer cases diverged:\n{}",
+        failures.len(),
+        total,
+        failures.join("\n")
+    );
+}

--- a/crates/oxidoc-testkit/tests/native_reader.rs
+++ b/crates/oxidoc-testkit/tests/native_reader.rs
@@ -1,0 +1,173 @@
+//! Reader-parity tests for the native reader: each case is a small native-format source exercising
+//! one or more AST node kinds the reader handles. The reader's output (as JSON) is diffed against
+//! `pandoc -f native -t json`, minted at run time; expected values are never committed. The oracle
+//! is hard-required (its absence fails with provisioning instructions rather than skipping).
+
+// This whole file is test code, where panicking on a known case is the idiomatic assertion.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use oxidoc_testkit::differential::{self, Diff};
+use oxidoc_testkit::pandoc_bin;
+
+/// A reader-parity case: a human label and the native-format source text.
+struct Case {
+    label: &'static str,
+    input: &'static str,
+}
+
+const fn case(label: &'static str, input: &'static str) -> Case {
+    Case { label, input }
+}
+
+/// Cases chosen to cover every node path the native reader parses: the four top-level document
+/// forms, every block and inline constructor, the metadata value kinds, and the lexer's string
+/// escapes and numeric literals.
+#[allow(clippy::too_many_lines)]
+fn cases() -> Vec<Case> {
+    vec![
+        // Top-level document forms.
+        case("empty-block-list", "[]"),
+        case("bare-block", r#"Para [ Str "hi" ]"#),
+        case("bare-inline", r#"Str "lone""#),
+        case("inline-list", r#"[ Str "a" , Space , Str "b" ]"#),
+        case(
+            "pandoc-wrapper-empty-meta",
+            r#"Pandoc (Meta {unMeta = fromList []}) [ Para [ Str "hi" ] ]"#,
+        ),
+        // Metadata value kinds.
+        case(
+            "meta-all-kinds",
+            r#"Pandoc (Meta {unMeta = fromList [("title", MetaInlines [Str "T"]), ("flag", MetaBool True), ("off", MetaBool False), ("s", MetaString "x"), ("lst", MetaList [MetaString "a", MetaString "b"]), ("m", MetaMap (fromList [("k", MetaString "v")])), ("blk", MetaBlocks [Para [Str "p"]])]}) [ Para [ Str "body" ] ]"#,
+        ),
+        // Inline constructors.
+        case(
+            "emphasis-family",
+            r#"[ Para [ Emph [ Str "e" ] , Strong [ Str "s" ] , Underline [ Str "u" ] , Strikeout [ Str "k" ] , Superscript [ Str "2" ] , Subscript [ Str "3" ] , SmallCaps [ Str "c" ] ] ]"#,
+        ),
+        case(
+            "quoted",
+            r#"[ Para [ Quoted SingleQuote [ Str "a" ] , Quoted DoubleQuote [ Str "b" ] ] ]"#,
+        ),
+        case(
+            "breaks-and-space",
+            r#"[ Para [ Str "a" , Space , SoftBreak , LineBreak , Str "b" ] ]"#,
+        ),
+        case(
+            "code-inline",
+            r#"[ Para [ Code ( "i" , [ "lang" ] , [ ( "k" , "v" ) ] ) "x = 1" ] ]"#,
+        ),
+        case(
+            "math",
+            r#"[ Para [ Math InlineMath "a^2" , Math DisplayMath "b" ] ]"#,
+        ),
+        case(
+            "raw-inline",
+            r#"[ Para [ RawInline (Format "html") "<b>" ] ]"#,
+        ),
+        case(
+            "link-image",
+            r#"[ Para [ Link ( "l" , [ "c" ] , [] ) [ Str "t" ] ( "http://x" , "ti" ) , Image ( "" , [] , [] ) [ Str "alt" ] ( "p.png" , "" ) ] ]"#,
+        ),
+        case(
+            "note",
+            r#"[ Para [ Str "x" , Note [ Para [ Str "n" ] ] ] ]"#,
+        ),
+        case(
+            "span",
+            r#"[ Para [ Span ( "s" , [ "c" ] , [] ) [ Str "inner" ] ] ]"#,
+        ),
+        case(
+            "cite",
+            r#"[ Para [ Cite [ Citation { citationId = "k" , citationPrefix = [ Str "see" ] , citationSuffix = [ Str "p5" ] , citationMode = NormalCitation , citationNoteNum = 1 , citationHash = 0 } ] [ Str "[@k]" ] ] ]"#,
+        ),
+        case(
+            "cite-modes",
+            r#"[ Para [ Cite [ Citation { citationId = "a" , citationPrefix = [] , citationSuffix = [] , citationMode = AuthorInText , citationNoteNum = 0 , citationHash = 0 } , Citation { citationId = "b" , citationPrefix = [] , citationSuffix = [] , citationMode = SuppressAuthor , citationNoteNum = 0 , citationHash = 0 } ] [ Str "x" ] ] ]"#,
+        ),
+        // Block constructors.
+        case("plain", r#"[ Plain [ Str "p" ] ]"#),
+        case(
+            "line-block",
+            r#"[ LineBlock [ [ Str "one" ] , [ Str "two" ] ] ]"#,
+        ),
+        case(
+            "code-block",
+            r#"[ CodeBlock ( "" , [ "rust" ] , [] ) "let x = 1;" ]"#,
+        ),
+        case("raw-block", r#"[ RawBlock (Format "html") "<div>" ]"#),
+        case("block-quote", r#"[ BlockQuote [ Para [ Str "q" ] ] ]"#),
+        case(
+            "ordered-list",
+            r#"[ OrderedList ( 5 , Decimal , Period ) [ [ Plain [ Str "a" ] ] , [ Plain [ Str "b" ] ] ] ]"#,
+        ),
+        case(
+            "ordered-list-styles",
+            r#"[ OrderedList ( 1 , LowerRoman , OneParen ) [ [ Plain [ Str "a" ] ] ] , OrderedList ( 1 , UpperAlpha , TwoParens ) [ [ Plain [ Str "b" ] ] ] , OrderedList ( 1 , Example , DefaultDelim ) [ [ Plain [ Str "c" ] ] ] , OrderedList ( 1 , DefaultStyle , Period ) [ [ Plain [ Str "d" ] ] ] , OrderedList ( 1 , LowerAlpha , Period ) [ [ Plain [ Str "e" ] ] ] , OrderedList ( 1 , UpperRoman , Period ) [ [ Plain [ Str "f" ] ] ] ]"#,
+        ),
+        case(
+            "bullet-list",
+            r#"[ BulletList [ [ Plain [ Str "a" ] ] , [ Plain [ Str "b" ] ] ] ]"#,
+        ),
+        case(
+            "definition-list",
+            r#"[ DefinitionList [ ( [ Str "Term" ] , [ [ Plain [ Str "def" ] ] ] ) ] ]"#,
+        ),
+        case(
+            "header",
+            r#"[ Header 2 ( "id" , [ "c" ] , [ ( "k" , "v" ) ] ) [ Str "H" ] ]"#,
+        ),
+        case("horizontal-rule", "[ HorizontalRule ]"),
+        case(
+            "div",
+            r#"[ Div ( "d" , [ "note" ] , [] ) [ Para [ Str "body" ] ] ]"#,
+        ),
+        case(
+            "figure",
+            r#"[ Figure ( "f" , [] , [] ) (Caption Nothing [ Plain [ Str "cap" ] ]) [ Plain [ Image ( "" , [] , [] ) [ Str "alt" ] ( "p.png" , "" ) ] ] ]"#,
+        ),
+        case(
+            "figure-short-caption",
+            r#"[ Figure ( "" , [] , [] ) (Caption (Just [ Str "short" ]) [ Plain [ Str "long" ] ]) [ Para [ Str "x" ] ] ]"#,
+        ),
+        // Tables: alignments, column widths, spans, head/body/foot.
+        case(
+            "table",
+            r#"[ Table ( "" , [] , [] ) (Caption Nothing [ Plain [ Str "cap" ] ]) [ ( AlignLeft , ColWidth 0.5 ) , ( AlignRight , ColWidthDefault ) , ( AlignCenter , ColWidthDefault ) , ( AlignDefault , ColWidthDefault ) ] (TableHead ( "" , [] , [] ) [ Row ( "" , [] , [] ) [ Cell ( "" , [] , [] ) AlignDefault (RowSpan 1) (ColSpan 1) [ Plain [ Str "h" ] ] ] ]) [ TableBody ( "" , [] , [] ) (RowHeadColumns 0) [] [ Row ( "" , [] , [] ) [ Cell ( "" , [] , [] ) AlignDefault (RowSpan 2) (ColSpan 1) [ Plain [ Str "a" ] ] ] ] ] (TableFoot ( "" , [] , [] ) []) ]"#,
+        ),
+        // Lexer: string escapes (named control, decimal, hex, octal, gap, separator) and non-ASCII.
+        case("escape-nonascii", r#"[ Para [ Str "caf\233" ] ]"#),
+        case("escape-separator", r#"[ Para [ Str "\233\&1" ] ]"#),
+        case("escape-named-control", r#"[ Para [ Str "a\SOHb\ESCc" ] ]"#),
+        case("escape-radix", r#"[ Para [ Str "\x41\o101" ] ]"#),
+        case("escape-c-style", r#"[ Para [ Str "tab\there\nnl" ] ]"#),
+        case("escape-gap", "[ Para [ Str \"a\\   \\b\" ] ]"),
+    ]
+}
+
+#[test]
+fn reader_matches_oracle_native() {
+    assert!(
+        pandoc_bin().is_file(),
+        "pinned pandoc binary not found at {}.\nRun tools/install-pandoc.sh.",
+        pandoc_bin().display()
+    );
+
+    let mut failures = Vec::new();
+    for case in cases() {
+        match differential::reader_json("native", case.input).expect("run reader surface") {
+            Diff::Match | Diff::OracleRejected { .. } => {}
+            Diff::Mismatch { detail } => failures.push(format!("{}: {detail}", case.label)),
+            Diff::OxidocError { detail } => {
+                failures.push(format!("{}: error: {detail}", case.label));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{}/{} reader cases diverged:\n{}",
+        failures.len(),
+        cases().len(),
+        failures.join("\n")
+    );
+}

--- a/crates/oxidoc-testkit/tests/native_roundtrip.rs
+++ b/crates/oxidoc-testkit/tests/native_roundtrip.rs
@@ -1,0 +1,349 @@
+//! Oracle-free round-trip identity tests for the native reader/writer pair, driven entirely through
+//! the facade (no pinned binary). Two directions establish mutual consistency:
+//!
+//! - `read(write(doc)) == doc` over a corpus of documents covering every block, inline, and table
+//!   node the pair handles (metadata aside — the writer renders the block list alone).
+//! - `write(read(text)) == text` over a corpus of canonical native texts.
+//!
+//! This is the core justification for co-implementing the pair, and it must pass without the oracle.
+
+// This whole file is test code, where panicking on a known case is the idiomatic assertion.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use oxidoc::ast::{
+    Alignment, Attr, Block, Caption, Cell, Citation, CitationMode, ColSpec, ColWidth, Document,
+    Format, Inline, ListAttributes, ListNumberDelim, ListNumberStyle, MathType, QuoteType, Row,
+    Table, TableBody, TableFoot, TableHead, Target,
+};
+use oxidoc::{ReaderOptions, WriterOptions};
+
+fn render(document: &Document) -> String {
+    oxidoc::writer_for("native")
+        .expect("native writer enabled")
+        .write(document, &WriterOptions::default())
+        .expect("native writer succeeds")
+}
+
+fn parse(text: &str) -> Document {
+    oxidoc::reader_for("native")
+        .expect("native reader enabled")
+        .read(text, &ReaderOptions::default())
+        .expect("native reader succeeds")
+}
+
+fn document(blocks: Vec<Block>) -> Document {
+    Document {
+        blocks,
+        ..Document::default()
+    }
+}
+
+fn str_inline(text: &str) -> Inline {
+    Inline::Str(text.to_owned())
+}
+
+fn attr(id: &str, classes: &[&str], attributes: &[(&str, &str)]) -> Attr {
+    Attr {
+        id: id.to_owned(),
+        classes: classes.iter().map(|c| (*c).to_owned()).collect(),
+        attributes: attributes
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect(),
+    }
+}
+
+/// Documents covering every node the native pair handles. Metadata is intentionally empty: the
+/// writer renders the block list alone, so it is not part of the write→read identity.
+#[allow(clippy::too_many_lines)]
+fn document_corpus() -> Vec<Document> {
+    let plain = |text: &str| Block::Plain(vec![str_inline(text)]);
+    let item = |text: &str| vec![plain(text)];
+
+    vec![
+        document(vec![]),
+        document(vec![Block::Para(vec![
+            str_inline("a"),
+            Inline::Space,
+            Inline::SoftBreak,
+            Inline::LineBreak,
+            str_inline("b"),
+        ])]),
+        document(vec![Block::Para(vec![
+            Inline::Emph(vec![str_inline("e")]),
+            Inline::Strong(vec![str_inline("s")]),
+            Inline::Underline(vec![str_inline("u")]),
+            Inline::Strikeout(vec![str_inline("k")]),
+            Inline::Superscript(vec![str_inline("2")]),
+            Inline::Subscript(vec![str_inline("3")]),
+            Inline::SmallCaps(vec![str_inline("c")]),
+        ])]),
+        document(vec![Block::Para(vec![
+            Inline::Quoted(QuoteType::SingleQuote, vec![str_inline("a")]),
+            Inline::Quoted(QuoteType::DoubleQuote, vec![str_inline("b")]),
+        ])]),
+        document(vec![Block::Para(vec![
+            Inline::Code(attr("i", &["lang"], &[("k", "v")]), "x = 1".to_owned()),
+            Inline::Math(MathType::InlineMath, "a^2".to_owned()),
+            Inline::Math(MathType::DisplayMath, "b".to_owned()),
+            Inline::RawInline(Format("html".to_owned()), "<b>".to_owned()),
+        ])]),
+        document(vec![Block::Para(vec![
+            Inline::Link(
+                attr("l", &["c"], &[]),
+                vec![str_inline("t")],
+                Target {
+                    url: "http://x".to_owned(),
+                    title: "ti".to_owned(),
+                },
+            ),
+            Inline::Image(
+                Attr::default(),
+                vec![str_inline("alt")],
+                Target {
+                    url: "p.png".to_owned(),
+                    title: String::new(),
+                },
+            ),
+            Inline::Span(attr("s", &["c"], &[]), vec![str_inline("inner")]),
+            Inline::Note(vec![Block::Para(vec![str_inline("n")])]),
+        ])]),
+        document(vec![Block::Para(vec![Inline::Cite(
+            vec![
+                Citation {
+                    id: "k".to_owned(),
+                    prefix: vec![str_inline("see")],
+                    suffix: vec![str_inline("p5")],
+                    mode: CitationMode::NormalCitation,
+                    note_num: 1,
+                    hash: 0,
+                },
+                Citation {
+                    id: "j".to_owned(),
+                    prefix: vec![],
+                    suffix: vec![],
+                    mode: CitationMode::AuthorInText,
+                    note_num: 0,
+                    hash: 0,
+                },
+                Citation {
+                    id: "h".to_owned(),
+                    prefix: vec![],
+                    suffix: vec![],
+                    mode: CitationMode::SuppressAuthor,
+                    note_num: 0,
+                    hash: 0,
+                },
+            ],
+            vec![str_inline("[@k]")],
+        )])]),
+        document(vec![
+            Block::LineBlock(vec![vec![str_inline("one")], vec![str_inline("two")]]),
+            Block::CodeBlock(attr("", &["rust"], &[]), "let x = 1;".to_owned()),
+            Block::RawBlock(Format("html".to_owned()), "<div>".to_owned()),
+            Block::BlockQuote(vec![Block::Para(vec![str_inline("q")])]),
+            Block::HorizontalRule,
+        ]),
+        document(vec![
+            Block::OrderedList(
+                ListAttributes {
+                    start: 5,
+                    style: ListNumberStyle::Decimal,
+                    delim: ListNumberDelim::Period,
+                },
+                vec![item("a"), item("b")],
+            ),
+            Block::OrderedList(
+                ListAttributes {
+                    start: 1,
+                    style: ListNumberStyle::LowerRoman,
+                    delim: ListNumberDelim::OneParen,
+                },
+                vec![item("c")],
+            ),
+            Block::OrderedList(
+                ListAttributes {
+                    start: 1,
+                    style: ListNumberStyle::UpperAlpha,
+                    delim: ListNumberDelim::TwoParens,
+                },
+                vec![item("d")],
+            ),
+            Block::OrderedList(
+                ListAttributes {
+                    start: 1,
+                    style: ListNumberStyle::Example,
+                    delim: ListNumberDelim::DefaultDelim,
+                },
+                vec![item("e")],
+            ),
+            Block::OrderedList(
+                ListAttributes {
+                    start: 1,
+                    style: ListNumberStyle::DefaultStyle,
+                    delim: ListNumberDelim::Period,
+                },
+                vec![item("f")],
+            ),
+            Block::OrderedList(
+                ListAttributes {
+                    start: 1,
+                    style: ListNumberStyle::LowerAlpha,
+                    delim: ListNumberDelim::Period,
+                },
+                vec![item("g")],
+            ),
+            Block::OrderedList(
+                ListAttributes {
+                    start: 1,
+                    style: ListNumberStyle::UpperRoman,
+                    delim: ListNumberDelim::Period,
+                },
+                vec![item("h")],
+            ),
+            Block::BulletList(vec![item("a"), item("b")]),
+            Block::DefinitionList(vec![(vec![str_inline("Term")], vec![vec![plain("def")]])]),
+        ]),
+        document(vec![
+            Block::Header(2, attr("id", &["c"], &[("k", "v")]), vec![str_inline("H")]),
+            Block::Div(
+                attr("d", &["note"], &[]),
+                vec![Block::Para(vec![str_inline("body")])],
+            ),
+        ]),
+        document(vec![
+            Block::Figure(
+                attr("f", &[], &[]),
+                Caption {
+                    short: None,
+                    long: vec![Block::Plain(vec![str_inline("cap")])],
+                },
+                vec![Block::Plain(vec![Inline::Image(
+                    Attr::default(),
+                    vec![str_inline("alt")],
+                    Target {
+                        url: "p.png".to_owned(),
+                        title: String::new(),
+                    },
+                )])],
+            ),
+            Block::Figure(
+                Attr::default(),
+                Caption {
+                    short: Some(vec![str_inline("short")]),
+                    long: vec![Block::Plain(vec![str_inline("long")])],
+                },
+                vec![Block::Para(vec![str_inline("x")])],
+            ),
+        ]),
+        document(vec![Block::Table(Box::new(Table {
+            attr: Attr::default(),
+            caption: Caption {
+                short: None,
+                long: vec![Block::Plain(vec![str_inline("cap")])],
+            },
+            col_specs: vec![
+                ColSpec {
+                    align: Alignment::AlignLeft,
+                    width: ColWidth::ColWidth(0.5),
+                },
+                ColSpec {
+                    align: Alignment::AlignRight,
+                    width: ColWidth::ColWidthDefault,
+                },
+                ColSpec {
+                    align: Alignment::AlignCenter,
+                    width: ColWidth::ColWidthDefault,
+                },
+                ColSpec {
+                    align: Alignment::AlignDefault,
+                    width: ColWidth::ColWidthDefault,
+                },
+            ],
+            head: TableHead {
+                attr: Attr::default(),
+                rows: vec![Row {
+                    attr: Attr::default(),
+                    cells: vec![Cell {
+                        attr: Attr::default(),
+                        align: Alignment::AlignDefault,
+                        row_span: 1,
+                        col_span: 1,
+                        content: vec![Block::Plain(vec![str_inline("h")])],
+                    }],
+                }],
+            },
+            bodies: vec![TableBody {
+                attr: Attr::default(),
+                row_head_columns: 0,
+                head: vec![],
+                body: vec![Row {
+                    attr: Attr::default(),
+                    cells: vec![Cell {
+                        attr: Attr::default(),
+                        align: Alignment::AlignDefault,
+                        row_span: 2,
+                        col_span: 1,
+                        content: vec![Block::Plain(vec![str_inline("a")])],
+                    }],
+                }],
+            }],
+            foot: TableFoot {
+                attr: Attr::default(),
+                rows: vec![],
+            },
+        }))]),
+        // String payloads exercising the writer's escaping and the reader's un-escaping.
+        document(vec![Block::Para(vec![
+            str_inline("café"),
+            str_inline("a\u{1}b"),
+            str_inline("tab\there"),
+            str_inline("a\"b\\c"),
+            str_inline("\u{e9}1"),
+        ])]),
+    ]
+}
+
+/// Canonical native texts: each is exactly what the writer emits, so writing the parse must
+/// reproduce it byte-for-byte. Kept short enough to stay on one flat line.
+fn text_corpus() -> Vec<&'static str> {
+    vec![
+        "[]",
+        r#"[ Para [ Str "hi" ] ]"#,
+        r#"[ Para [ Str "a" , Space , Str "b" ] ]"#,
+        r#"[ Para [ Emph [ Str "e" ] , Strong [ Str "s" ] ] ]"#,
+        r#"[ Header 1 ( "h" , [] , [] ) [ Str "Hi" ] ]"#,
+        "[ HorizontalRule ]",
+        r#"[ BulletList [ [ Plain [ Str "a" ] ] ] ]"#,
+        r#"[ CodeBlock ( "" , [ "rust" ] , [] ) "x" ]"#,
+        r#"[ RawBlock (Format "html") "<b>" ]"#,
+        r#"[ Para [ Math InlineMath "a^2" ] ]"#,
+    ]
+}
+
+#[test]
+fn read_after_write_is_identity() {
+    let mut failures = Vec::new();
+    for (index, doc) in document_corpus().into_iter().enumerate() {
+        let text = render(&doc);
+        let parsed = parse(&text);
+        if parsed != doc {
+            failures.push(format!(
+                "document {index}: round-trip differs\nrendered:\n{text}"
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n\n"));
+}
+
+#[test]
+fn write_after_read_is_identity() {
+    let mut failures = Vec::new();
+    for text in text_corpus() {
+        let rendered = render(&parse(text));
+        if rendered != text {
+            failures.push(format!("expected {text:?}, got {rendered:?}"));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/crates/oxidoc-testkit/tests/native_writer.rs
+++ b/crates/oxidoc-testkit/tests/native_writer.rs
@@ -1,0 +1,155 @@
+//! Writer-parity tests for the native writer across the full document model — every block and
+//! inline node, including those the `CommonMark` reader never produces (tables, definition lists,
+//! figures, footnotes, citations, math, raw passthrough, …). Each case feeds a small source through
+//! the oracle to mint both the AST (as JSON our writer consumes) and the expected native rendering,
+//! then diffs our writer's output byte-for-byte. Expected values are minted at run time, never
+//! committed; the oracle is hard-required (its absence fails with provisioning instructions rather
+//! than skipping).
+
+// This whole file is test code, where panicking on a known case is the idiomatic assertion.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use oxidoc_testkit::differential::{self, Diff};
+use oxidoc_testkit::pandoc_bin;
+
+/// A writer-parity case: a human label, the oracle source format, and the source text.
+struct Case {
+    label: &'static str,
+    from: &'static str,
+    input: &'static str,
+}
+
+const fn md(label: &'static str, input: &'static str) -> Case {
+    Case {
+        label,
+        from: "markdown",
+        input,
+    }
+}
+
+const fn html(label: &'static str, input: &'static str) -> Case {
+    Case {
+        label,
+        from: "html",
+        input,
+    }
+}
+
+/// Cases chosen to cover every writer node path. Markdown reaches most of the model; raw HTML is
+/// used for the table spans markdown cannot express.
+fn cases() -> Vec<Case> {
+    vec![
+        md(
+            "emphasis-family",
+            "*emph* **strong** ~~struck~~ super^2^ sub~3~",
+        ),
+        md(
+            "underline-smallcaps",
+            "[under]{.underline} [small]{.smallcaps}",
+        ),
+        md("inline-code", "a `let x = 1;` b"),
+        md(
+            "code-block-lang-and-quote",
+            "``` rust\nlet s = \"hi\";\nx < y && y > z\n```",
+        ),
+        md("headers", "# One\n\n## Two\n\n###### Six"),
+        md("header-attr", "# Titled {#anchor .cls key=val}"),
+        md("blockquote", "> quoted\n>\n> lines"),
+        md("bullet-list-tight", "- a\n- b\n- c"),
+        md("bullet-list-loose", "- a\n\n- b\n\n- c"),
+        md("ordered-start", "5. five\n6. six"),
+        md("ordered-lower-alpha", "a. one\nb. two"),
+        md("ordered-upper-alpha", "A. one\nB. two"),
+        md("ordered-lower-roman", "i. one\nii. two"),
+        md("ordered-upper-roman", "I. one\nII. two"),
+        md("ordered-example", "(@) first\n(@) second"),
+        md(
+            "definition-list",
+            "Term\n:   Definition one\n\n:   Definition two",
+        ),
+        md("line-block", "| first line\n| second line"),
+        md("horizontal-rule", "above\n\n---\n\nbelow"),
+        md("raw-html-block", "<div class=\"x\">raw block</div>"),
+        md("raw-html-inline", "text <cite>raw</cite> more"),
+        md("raw-latex-block", "```{=latex}\n\\macro\n```"),
+        md("raw-latex-inline", "a `\\macro`{=latex} b"),
+        md("math-inline", "an equation $a^2 + b^2 = c^2$ inline"),
+        md("math-display", "$$\\int_0^1 x \\, dx$$"),
+        md("citation", "see [@knuth1984] for details"),
+        md("span", "a [styled]{#s .c data-k=\"v\"} word"),
+        md("div", "::: {#d .note}\nbody paragraph\n:::"),
+        md("quoted-smart", "She said \"hello\" and 'hi'."),
+        md(
+            "link-title-attr",
+            "[text](http://example.com \"a title\"){#l .ext}",
+        ),
+        md(
+            "image-implicit-figure",
+            "![alt text](pic.png \"t\"){width=200}",
+        ),
+        md("footnote-simple", "ref[^a]\n\n[^a]: the note body"),
+        md(
+            "footnote-multipara",
+            "ref[^a]\n\n[^a]: first paragraph\n\n    second paragraph",
+        ),
+        md("footnote-two", "x[^a] y[^b]\n\n[^a]: first\n\n[^b]: second"),
+        md("table-simple", "| h1 | h2 |\n|----|----|\n| a  | b  |"),
+        md(
+            "table-aligned",
+            "| l | r | c | d |\n|:--|--:|:-:|---|\n| 1 | 2 | 3 | 4 |",
+        ),
+        md(
+            "table-caption",
+            "| h |\n|---|\n| v |\n\n: A caption for the table",
+        ),
+        md(
+            "table-grid-widths",
+            "+---+---------+\n| a | b       |\n+===+=========+\n| 1 | 2       |\n+---+---------+",
+        ),
+        html(
+            "table-colspan",
+            "<table><tr><td colspan=\"2\">wide</td></tr><tr><td>a</td><td>b</td></tr></table>",
+        ),
+        html(
+            "table-rowspan",
+            "<table><tr><td rowspan=\"2\">tall</td><td>a</td></tr><tr><td>b</td></tr></table>",
+        ),
+        md(
+            "wide-and-combining-wrap",
+            "This is a deliberately long paragraph with wide 中文字符 glyphs and a combining mark e\u{0301} so the writer measures column widths while wrapping at the fill column boundary.",
+        ),
+        md(
+            "literal-control-chars",
+            "a literal NUL a\u{0}b and a U+0001 c\u{1}d are preserved verbatim",
+        ),
+        md("nonascii-escape", "café résumé naïve"),
+    ]
+}
+
+#[test]
+fn writer_matches_oracle_native_across_the_model() {
+    assert!(
+        pandoc_bin().is_file(),
+        "pinned pandoc binary not found at {}.\nRun tools/install-pandoc.sh.",
+        pandoc_bin().display()
+    );
+
+    let mut failures = Vec::new();
+    for case in cases() {
+        match differential::writer("native", case.from, case.input).expect("run writer surface") {
+            Diff::Match | Diff::OracleRejected { .. } => {}
+            Diff::Mismatch { detail } => failures.push(format!("{}: {detail}", case.label)),
+            Diff::OxidocError { detail } => {
+                failures.push(format!("{}: error: {detail}", case.label));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{}/{} writer cases diverged:\n{}",
+        failures.len(),
+        cases().len(),
+        failures.join("\n")
+    );
+}

--- a/crates/oxidoc-writers/Cargo.toml
+++ b/crates/oxidoc-writers/Cargo.toml
@@ -12,10 +12,12 @@ publish.workspace = true
 workspace = true
 
 [features]
-default = ["html", "json", "plain"]
+default = ["html", "json", "plain", "latex", "native"]
 html = ["dep:unicode-general-category"]
 json = []
 plain = []
+latex = []
+native = []
 
 [dependencies]
 oxidoc-ast = { workspace = true }

--- a/crates/oxidoc-writers/src/common.rs
+++ b/crates/oxidoc-writers/src/common.rs
@@ -1,7 +1,8 @@
-//! Shared helpers for the text-oriented writers (plain and HTML): the default fill column, the
-//! East-Asian wide-character measure, and the smart-quote glyphs.
+//! Shared helpers for the text-oriented writers (plain, HTML, and LaTeX): the default fill column,
+//! the greedy line-filling engine, column-width measurement, list-tightness, ordered-list delimiter
+//! wrapping, and the smart-quote glyphs.
 
-use oxidoc_ast::QuoteType;
+use oxidoc_ast::{Block, ListNumberDelim, QuoteType};
 
 /// Column at which inline content is wrapped: the default fill width.
 pub(crate) const FILL_COLUMN: usize = 72;
@@ -12,6 +13,202 @@ pub(crate) fn quote_marks(kind: &QuoteType) -> (char, char) {
         QuoteType::SingleQuote => ('\u{2018}', '\u{2019}'),
         QuoteType::DoubleQuote => ('\u{201c}', '\u{201d}'),
     }
+}
+
+/// A unit of inline content awaiting line filling: an unbreakable text run, a breakable space, or a
+/// forced line break.
+#[derive(Debug, Clone)]
+pub(crate) enum Piece {
+    Text(String),
+    Space,
+    Hard,
+}
+
+/// Greedily fill inline pieces to `width` columns: a breakable space becomes a line break when
+/// keeping the next word on the current line would exceed the fill column. Consecutive text runs (no
+/// intervening space) stay together; runs of spaces collapse; leading and trailing spaces on a line
+/// are dropped.
+pub(crate) fn fill(pieces: &[Piece], width: usize) -> String {
+    fill_offset(pieces, width, 0)
+}
+
+/// Like [`fill`], but the first line is laid out as if `initial` columns were already consumed (the
+/// hanging-marker layout, where a leading marker shifts the first line's wrap point but leaves
+/// continuation lines at the margin).
+pub(crate) fn fill_offset(pieces: &[Piece], width: usize, initial: usize) -> String {
+    let width = width.max(1);
+    let mut out = String::new();
+    let mut column = initial;
+    let mut at_line_start = initial == 0;
+    let mut pending_space = false;
+    // Consecutive text pieces (no intervening space or break) form one unbreakable word, gathered
+    // here as borrowed runs and placed only once its full width is known.
+    let mut word: Vec<&str> = Vec::new();
+    let mut word_width = 0;
+    for piece in pieces {
+        match piece {
+            Piece::Text(text) => {
+                word.push(text);
+                word_width += display_width(text);
+            }
+            Piece::Space => {
+                place_word(
+                    &mut out,
+                    &mut column,
+                    &mut at_line_start,
+                    pending_space,
+                    &word,
+                    word_width,
+                    width,
+                );
+                word.clear();
+                word_width = 0;
+                pending_space = true;
+            }
+            Piece::Hard => {
+                place_word(
+                    &mut out,
+                    &mut column,
+                    &mut at_line_start,
+                    pending_space,
+                    &word,
+                    word_width,
+                    width,
+                );
+                word.clear();
+                word_width = 0;
+                if !at_line_start {
+                    out.push('\n');
+                    column = 0;
+                    at_line_start = true;
+                }
+                pending_space = false;
+            }
+        }
+    }
+    place_word(
+        &mut out,
+        &mut column,
+        &mut at_line_start,
+        pending_space,
+        &word,
+        word_width,
+        width,
+    );
+    out.trim_end_matches('\n').to_owned()
+}
+
+/// Place a gathered word onto the current line, inserting a line break in place of the preceding
+/// space when keeping the word would overflow `width`. A no-op for an empty word.
+fn place_word(
+    out: &mut String,
+    column: &mut usize,
+    at_line_start: &mut bool,
+    pending_space: bool,
+    word: &[&str],
+    word_width: usize,
+    width: usize,
+) {
+    if word.is_empty() {
+        return;
+    }
+    if *at_line_start {
+        *at_line_start = false;
+    } else if pending_space && *column + 1 + word_width > width {
+        out.push('\n');
+        *column = 0;
+        *at_line_start = false;
+    } else if pending_space {
+        out.push(' ');
+        *column += 1;
+    }
+    for part in word {
+        out.push_str(part);
+    }
+    *column += word_width;
+}
+
+/// Apply `first` to the first line and `rest` to each non-empty later line, leaving blank lines
+/// (block separators) unprefixed. This produces a hanging indent: a list marker plus continuation
+/// indent, or a uniform block-quote / code prefix.
+pub(crate) fn indent_block(body: &str, first: &str, rest: &str) -> String {
+    let mut out = String::new();
+    for (index, line) in body.split('\n').enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        if index == 0 {
+            out.push_str(first);
+            out.push_str(line);
+        } else if !line.is_empty() {
+            out.push_str(rest);
+            out.push_str(line);
+        }
+    }
+    out
+}
+
+/// Whether a list is tight: every item is empty or opens with a [`Block::Plain`].
+pub(crate) fn list_is_tight(items: &[Vec<Block>]) -> bool {
+    items
+        .iter()
+        .all(|item| matches!(item.first(), None | Some(Block::Plain(_))))
+}
+
+/// Wrap an ordered-list numeral in its delimiter: `n.`, `n)`, or `(n)`.
+pub(crate) fn wrap_delim(numeral: &str, delim: &ListNumberDelim) -> String {
+    match delim {
+        ListNumberDelim::DefaultDelim | ListNumberDelim::Period => format!("{numeral}."),
+        ListNumberDelim::OneParen => format!("{numeral})"),
+        ListNumberDelim::TwoParens => format!("({numeral})"),
+    }
+}
+
+/// Display width of a string in columns, summed over its characters.
+pub(crate) fn display_width(text: &str) -> usize {
+    text.chars().map(char_width).sum()
+}
+
+/// Display width of a character: zero for common combining marks and controls, two for wide East
+/// Asian characters, one otherwise. A self-contained column-width approximation.
+pub(crate) fn char_width(ch: char) -> usize {
+    let code = ch as u32;
+    if is_control(code) {
+        return 0;
+    }
+    if code < 0x0300 {
+        return 1;
+    }
+    if is_zero_width(code) {
+        return 0;
+    }
+    if is_wide(code) { 2 } else { 1 }
+}
+
+/// C0 controls, DEL, and C1 controls occupy no display columns.
+fn is_control(code: u32) -> bool {
+    code < 0x20 || (0x7F..=0x9F).contains(&code)
+}
+
+fn is_zero_width(code: u32) -> bool {
+    matches!(code,
+        0x0300..=0x036F
+        | 0x0483..=0x0489
+        | 0x0591..=0x05BD
+        | 0x0610..=0x061A
+        | 0x064B..=0x065F
+        | 0x0670
+        | 0x06D6..=0x06DC
+        | 0x06DF..=0x06E4
+        | 0x0E31
+        | 0x0E34..=0x0E3A
+        | 0x1AB0..=0x1AFF
+        | 0x1DC0..=0x1DFF
+        | 0x200B..=0x200F
+        | 0x20D0..=0x20FF
+        | 0xFE00..=0xFE0F
+        | 0xFE20..=0xFE2F
+    )
 }
 
 /// Whether a character occupies two display columns: the wide and fullwidth East Asian ranges.

--- a/crates/oxidoc-writers/src/common.rs
+++ b/crates/oxidoc-writers/src/common.rs
@@ -1,6 +1,11 @@
 //! Shared helpers for the text-oriented writers (plain, HTML, and LaTeX): the default fill column,
 //! the greedy line-filling engine, column-width measurement, list-tightness, ordered-list delimiter
 //! wrapping, and the smart-quote glyphs.
+//!
+//! Each consumer is behind its own writer feature, so which helpers are live depends on the enabled
+//! features: a build with only one writer leaves the others' helpers unreferenced. That is expected
+//! for this toolbox, so unused-item warnings are allowed here rather than gated per item.
+#![allow(dead_code)]
 
 use oxidoc_ast::{Block, ListNumberDelim, QuoteType};
 

--- a/crates/oxidoc-writers/src/html.rs
+++ b/crates/oxidoc-writers/src/html.rs
@@ -701,6 +701,9 @@ fn reflow(input: &str) -> String {
 
 /// Display width of a character in columns: zero for
 /// combining marks, two for wide and fullwidth East Asian characters, one otherwise.
+///
+/// This uses a Unicode-category zero-width test, distinct from the range-table measure in
+/// [`crate::common`] that the plain and LaTeX writers share.
 fn char_width(ch: char) -> usize {
     let code = ch as u32;
     if code < 0x0300 {

--- a/crates/oxidoc-writers/src/latex.rs
+++ b/crates/oxidoc-writers/src/latex.rs
@@ -1,0 +1,531 @@
+//! LaTeX writer: renders the document model to a LaTeX document fragment.
+//!
+//! Output is a body fragment (no preamble or `\begin{document}`) wrapped at a fill column of 72;
+//! the wrap counts the literal LaTeX, markup included. Document metadata is not emitted. Syntax
+//! highlighting is neutralized: a code block renders as a `verbatim` environment and inline code as
+//! `\texttt{…}`, regardless of any language class. The result carries no trailing newline; the
+//! caller appends one. This format has no public specification.
+
+use oxidoc_ast::{
+    Attr, Block, Caption, Document, Inline, ListAttributes, ListNumberDelim, ListNumberStyle,
+    MathType, QuoteType, Target, to_plain_text,
+};
+use oxidoc_core::{Result, Writer, WriterOptions};
+
+use crate::common::{FILL_COLUMN, Piece, fill, indent_block, list_is_tight, wrap_delim};
+
+/// Renders a document to a LaTeX fragment.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LatexWriter;
+
+impl Writer for LatexWriter {
+    fn write(&self, document: &Document, _options: &WriterOptions) -> Result<String> {
+        let body = render_blocks(&document.blocks, FILL_COLUMN, 0);
+        Ok(body.trim_end_matches('\n').to_owned())
+    }
+}
+
+/// Selects the escaping policy for a run of literal text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EscapeMode {
+    /// Running prose.
+    Text,
+    /// Inside a `\texttt{…}` group, where spaces and a few extra glyphs gain escapes.
+    Code,
+}
+
+/// Render a block sequence with a blank line between blocks, dropping those that produce no output.
+fn render_blocks(blocks: &[Block], width: usize, enum_depth: usize) -> String {
+    blocks
+        .iter()
+        .map(|block| block_to_string(block, width, enum_depth))
+        .filter(|rendered| !rendered.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn block_to_string(block: &Block, width: usize, enum_depth: usize) -> String {
+    match block {
+        Block::Plain(inlines) | Block::Para(inlines) => inlines_to_string(inlines, width),
+        Block::Header(level, attr, inlines) => header(*level, attr, inlines, width),
+        Block::CodeBlock(attr, text) => code_block(attr, text),
+        Block::RawBlock(format, text) => {
+            if is_latex_format(&format.0) {
+                text.strip_suffix('\n').unwrap_or(text).to_owned()
+            } else {
+                String::new()
+            }
+        }
+        Block::BlockQuote(blocks) => format!(
+            "\\begin{{quote}}\n{}\n\\end{{quote}}",
+            render_blocks(blocks, width, enum_depth)
+        ),
+        Block::BulletList(items) => bullet_list(items, width, enum_depth),
+        Block::OrderedList(attrs, items) => ordered_list(attrs, items, width, enum_depth),
+        Block::DefinitionList(items) => definition_list(items, width, enum_depth),
+        Block::HorizontalRule => {
+            "\\begin{center}\\rule{0.5\\linewidth}{0.5pt}\\end{center}".to_owned()
+        }
+        Block::LineBlock(lines) => line_block(lines, width),
+        Block::Div(attr, blocks) => {
+            let body = render_blocks(blocks, width, enum_depth);
+            if attr.id.is_empty() {
+                body
+            } else {
+                format!("{}\n{body}", phantom_label(&attr.id))
+            }
+        }
+        Block::Figure(attr, caption, blocks) => figure(attr, caption, blocks, width, enum_depth),
+        Block::Table(_) => todo!("latex writer: render tables"),
+    }
+}
+
+fn header(level: i32, attr: &Attr, inlines: &[Inline], width: usize) -> String {
+    let command = match level {
+        1 => "section",
+        2 => "subsection",
+        3 => "subsubsection",
+        4 => "paragraph",
+        5 => "subparagraph",
+        _ => return inlines_to_string(inlines, width),
+    };
+    let unnumbered = attr.classes.iter().any(|class| class == "unnumbered");
+    let star = if unnumbered { "*" } else { "" };
+    let inner = inline_pieces(inlines);
+
+    let mut content = vec![Piece::Text(format!("\\{command}{star}{{"))];
+    if needs_texorpdfstring(inlines) {
+        content.push(Piece::Text("\\texorpdfstring{".to_owned()));
+        content.extend(inner.iter().cloned());
+        let pdf = escape(&to_plain_text(inlines), EscapeMode::Text);
+        content.push(Piece::Text(format!("}}{{{pdf}}}")));
+    } else {
+        content.extend(inner.iter().cloned());
+    }
+    content.push(Piece::Text("}".to_owned()));
+    if !attr.id.is_empty() {
+        content.push(Piece::Text(format!("\\label{{{}}}", attr.id)));
+    }
+    let heading = fill(&content, width);
+
+    if unnumbered {
+        let mut toc = vec![Piece::Text(format!(
+            "\\addcontentsline{{toc}}{{{command}}}{{"
+        ))];
+        toc.extend(inner);
+        toc.push(Piece::Text("}".to_owned()));
+        format!("{heading}\n{}", fill(&toc, width))
+    } else {
+        heading
+    }
+}
+
+fn code_block(attr: &Attr, text: &str) -> String {
+    let body = text.strip_suffix('\n').unwrap_or(text);
+    let verbatim = format!("\\begin{{verbatim}}\n{body}\n\\end{{verbatim}}");
+    if attr.id.is_empty() {
+        verbatim
+    } else {
+        format!("{}%\n{verbatim}", phantom_label(&attr.id))
+    }
+}
+
+/// The anchor markup emitted for an element carrying an identifier.
+fn phantom_label(id: &str) -> String {
+    format!("\\protect\\phantomsection\\label{{{id}}}")
+}
+
+fn bullet_list(items: &[Vec<Block>], width: usize, enum_depth: usize) -> String {
+    let mut lines = vec!["\\begin{itemize}".to_owned()];
+    if list_is_tight(items) {
+        lines.push("\\tightlist".to_owned());
+    }
+    for item in items {
+        lines.push(list_item(item, width, enum_depth));
+    }
+    lines.push("\\end{itemize}".to_owned());
+    lines.join("\n")
+}
+
+fn ordered_list(
+    attrs: &ListAttributes,
+    items: &[Vec<Block>],
+    width: usize,
+    enum_depth: usize,
+) -> String {
+    let depth = enum_depth + 1;
+    let counter = enum_counter(depth);
+    let mut lines = vec!["\\begin{enumerate}".to_owned()];
+    if let Some(label) = label_definition(attrs, counter) {
+        lines.push(label);
+    }
+    if attrs.start != 1 {
+        lines.push(format!(
+            "\\setcounter{{{counter}}}{{{}}}",
+            attrs.start.saturating_sub(1)
+        ));
+    }
+    if list_is_tight(items) {
+        lines.push("\\tightlist".to_owned());
+    }
+    for item in items {
+        lines.push(list_item(item, width, depth));
+    }
+    lines.push("\\end{enumerate}".to_owned());
+    lines.join("\n")
+}
+
+/// Render one list item: its blocks indented two columns under an `\item` line.
+fn list_item(item: &[Block], width: usize, enum_depth: usize) -> String {
+    let body = render_blocks(item, width.saturating_sub(2), enum_depth);
+    let content = indent_block(&body, "  ", "  ");
+    if content.is_empty() {
+        "\\item".to_owned()
+    } else {
+        format!("\\item\n{content}")
+    }
+}
+
+fn definition_list(
+    items: &[(Vec<Inline>, Vec<Vec<Block>>)],
+    width: usize,
+    enum_depth: usize,
+) -> String {
+    let mut lines = vec!["\\begin{description}".to_owned()];
+    if is_tight_definitions(items) {
+        lines.push("\\tightlist".to_owned());
+    }
+    for (term, definitions) in items {
+        let header = format!("\\item[{}]", inlines_to_string(term, width));
+        let bodies: Vec<String> = definitions
+            .iter()
+            .map(|definition| render_blocks(definition, width, enum_depth))
+            .filter(|rendered| !rendered.is_empty())
+            .collect();
+        if bodies.is_empty() {
+            lines.push(header);
+        } else {
+            lines.push(format!("{header}\n{}", bodies.join("\n\n")));
+        }
+    }
+    lines.push("\\end{description}".to_owned());
+    lines.join("\n")
+}
+
+fn line_block(lines: &[Vec<Inline>], width: usize) -> String {
+    lines
+        .iter()
+        .map(|line| inlines_to_string(line, width))
+        .collect::<Vec<_>>()
+        .join("\\\\\n")
+}
+
+fn figure(
+    attr: &Attr,
+    caption: &Caption,
+    blocks: &[Block],
+    width: usize,
+    enum_depth: usize,
+) -> String {
+    let mut parts = vec![
+        "\\begin{figure}".to_owned(),
+        "\\centering".to_owned(),
+        render_blocks(blocks, width, enum_depth),
+    ];
+    if !attr.id.is_empty() {
+        parts.push(format!("\\label{{{}}}", attr.id));
+    }
+    let caption_inlines = caption_text(caption);
+    if !caption_inlines.is_empty() {
+        parts.push(format!(
+            "\\caption{{{}}}",
+            inlines_to_string(&caption_inlines, width)
+        ));
+    }
+    parts.push("\\end{figure}".to_owned());
+    parts.join("\n")
+}
+
+/// Collect a caption's inline content from its block-level body.
+fn caption_text(caption: &Caption) -> Vec<Inline> {
+    let mut out = Vec::new();
+    for block in &caption.long {
+        if let Block::Plain(inlines) | Block::Para(inlines) = block {
+            out.extend(inlines.iter().cloned());
+        }
+    }
+    out
+}
+
+/// The leading `\def\labelenum…` an ordered list carries, or `None` when both numeral style and
+/// delimiter are the renderer defaults (where the built-in label suffices).
+fn label_definition(attrs: &ListAttributes, counter: &str) -> Option<String> {
+    if matches!(attrs.style, ListNumberStyle::DefaultStyle)
+        && matches!(attrs.delim, ListNumberDelim::DefaultDelim)
+    {
+        return None;
+    }
+    let numeral = numeral_command(&attrs.style, counter);
+    let label = wrap_delim(&numeral, &attrs.delim);
+    Some(format!("\\def\\label{counter}{{{label}}}"))
+}
+
+fn numeral_command(style: &ListNumberStyle, counter: &str) -> String {
+    let command = match style {
+        ListNumberStyle::DefaultStyle | ListNumberStyle::Decimal | ListNumberStyle::Example => {
+            "arabic"
+        }
+        ListNumberStyle::LowerAlpha => "alph",
+        ListNumberStyle::UpperAlpha => "Alph",
+        ListNumberStyle::LowerRoman => "roman",
+        ListNumberStyle::UpperRoman => "Roman",
+    };
+    format!("\\{command}{{{counter}}}")
+}
+
+/// The LaTeX enumerate counter name for a nesting depth (`enumi`, `enumii`, …), capped at the four
+/// levels LaTeX provides.
+fn enum_counter(depth: usize) -> &'static str {
+    match depth {
+        0 | 1 => "enumi",
+        2 => "enumii",
+        3 => "enumiii",
+        _ => "enumiv",
+    }
+}
+
+fn is_tight_definitions(items: &[(Vec<Inline>, Vec<Vec<Block>>)]) -> bool {
+    items
+        .iter()
+        .all(|(_, definitions)| list_is_tight(definitions))
+}
+
+/// Whether a heading needs a `\texorpdfstring` wrapper: it carries an inline that produces no plain
+/// PDF-bookmark text on its own (anything beyond literal text and spaces).
+fn needs_texorpdfstring(inlines: &[Inline]) -> bool {
+    inlines
+        .iter()
+        .any(|inline| !matches!(inline, Inline::Str(_) | Inline::Space | Inline::SoftBreak))
+}
+
+fn inlines_to_string(inlines: &[Inline], width: usize) -> String {
+    fill(&inline_pieces(inlines), width)
+}
+
+fn inline_pieces(inlines: &[Inline]) -> Vec<Piece> {
+    let mut out = Vec::new();
+    for inline in inlines {
+        push_inline(inline, &mut out);
+    }
+    out
+}
+
+fn push_inline(inline: &Inline, out: &mut Vec<Piece>) {
+    match inline {
+        Inline::Str(text) => out.push(Piece::Text(escape(text, EscapeMode::Text))),
+        Inline::Emph(inlines) => wrap_command("\\emph{", inlines, out),
+        Inline::Strong(inlines) => wrap_command("\\textbf{", inlines, out),
+        Inline::Underline(inlines) => wrap_command("\\ul{", inlines, out),
+        Inline::Strikeout(inlines) => wrap_command("\\st{", inlines, out),
+        Inline::Superscript(inlines) => wrap_command("\\textsuperscript{", inlines, out),
+        Inline::Subscript(inlines) => wrap_command("\\textsubscript{", inlines, out),
+        Inline::SmallCaps(inlines) => wrap_command("\\textsc{", inlines, out),
+        Inline::Quoted(kind, inlines) => {
+            let (open, close) = quote_marks(kind);
+            out.push(Piece::Text(open.to_owned()));
+            for inline in inlines {
+                push_inline(inline, out);
+            }
+            out.push(Piece::Text(close.to_owned()));
+        }
+        Inline::Cite(_, inlines) => {
+            for inline in inlines {
+                push_inline(inline, out);
+            }
+        }
+        Inline::Code(_, text) => {
+            out.push(Piece::Text(format!(
+                "\\texttt{{{}}}",
+                escape(text, EscapeMode::Code)
+            )));
+        }
+        Inline::Space | Inline::SoftBreak => out.push(Piece::Space),
+        Inline::LineBreak => {
+            out.push(Piece::Text("\\\\".to_owned()));
+            out.push(Piece::Hard);
+        }
+        Inline::Math(kind, text) => {
+            let rendered = match kind {
+                MathType::InlineMath => format!("\\({text}\\)"),
+                MathType::DisplayMath => format!("\\[{text}\\]"),
+            };
+            out.push(Piece::Text(rendered));
+        }
+        Inline::RawInline(format, text) => {
+            if is_latex_format(&format.0) {
+                out.push(Piece::Text(text.clone()));
+            }
+        }
+        Inline::Link(_, inlines, target) => push_link(inlines, target, out),
+        Inline::Image(_, inlines, target) => out.push(Piece::Text(image(inlines, target))),
+        Inline::Span(attr, inlines) => {
+            let mut open = if attr.id.is_empty() {
+                String::new()
+            } else {
+                phantom_label(&attr.id)
+            };
+            open.push('{');
+            out.push(Piece::Text(open));
+            for inline in inlines {
+                push_inline(inline, out);
+            }
+            out.push(Piece::Text("}".to_owned()));
+        }
+        Inline::Note(blocks) => out.push(Piece::Text(note(blocks))),
+    }
+}
+
+fn wrap_command(open: &str, inlines: &[Inline], out: &mut Vec<Piece>) {
+    out.push(Piece::Text(open.to_owned()));
+    for inline in inlines {
+        push_inline(inline, out);
+    }
+    out.push(Piece::Text("}".to_owned()));
+}
+
+fn push_link(inlines: &[Inline], target: &Target, out: &mut Vec<Piece>) {
+    let url = escape_url(&target.url);
+    if let [Inline::Str(text)] = inlines
+        && *text == target.url
+    {
+        out.push(Piece::Text(format!("\\url{{{url}}}")));
+        return;
+    }
+    out.push(Piece::Text(format!("\\href{{{url}}}{{")));
+    for inline in inlines {
+        push_inline(inline, out);
+    }
+    out.push(Piece::Text("}".to_owned()));
+}
+
+fn image(inlines: &[Inline], target: &Target) -> String {
+    let alt = to_plain_text(inlines);
+    let options = if alt.is_empty() {
+        "keepaspectratio".to_owned()
+    } else {
+        format!("keepaspectratio,alt={{{}}}", escape(&alt, EscapeMode::Text))
+    };
+    format!(
+        "\\pandocbounded{{\\includegraphics[{options}]{{{}}}}}",
+        escape_url(&target.url)
+    )
+}
+
+/// Render a footnote as an inline `\footnote{…}`; its blocks hang two columns under the opening so
+/// continuation paragraphs align with the first.
+fn note(blocks: &[Block]) -> String {
+    let body = render_blocks(blocks, FILL_COLUMN.saturating_sub(2), 0);
+    format!("{}}}", indent_block(&body, "\\footnote{", "  "))
+}
+
+fn quote_marks(kind: &QuoteType) -> (&'static str, &'static str) {
+    match kind {
+        QuoteType::SingleQuote => ("`", "'"),
+        QuoteType::DoubleQuote => ("``", "''"),
+    }
+}
+
+fn is_latex_format(format: &str) -> bool {
+    format.eq_ignore_ascii_case("latex") || format.eq_ignore_ascii_case("tex")
+}
+
+/// Escape a run of literal text for the given context.
+fn escape(text: &str, mode: EscapeMode) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        let next = chars.peek().copied();
+        match ch {
+            '&' | '%' | '#' | '_' | '$' | '{' | '}' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            '^' => out.push_str("\\^{}"),
+            '[' => out.push_str("{[}"),
+            ']' => out.push_str("{]}"),
+            '~' => push_control_word(&mut out, "\\textasciitilde", next, mode),
+            '\\' => push_control_word(&mut out, "\\textbackslash", next, mode),
+            '<' => push_control_word(&mut out, "\\textless", next, mode),
+            '>' => push_control_word(&mut out, "\\textgreater", next, mode),
+            '|' => push_control_word(&mut out, "\\textbar", next, mode),
+            '\'' => push_control_word(&mut out, "\\textquotesingle", next, mode),
+            '-' if next == Some('-') => out.push_str("-\\/"),
+            ' ' if mode == EscapeMode::Code => out.push_str("\\ "),
+            '`' if mode == EscapeMode::Code => out.push_str("\\textasciigrave{}"),
+            '\u{a0}' if mode == EscapeMode::Text => out.push('~'),
+            '\u{2026}' if mode == EscapeMode::Text => {
+                push_control_word(&mut out, "\\ldots", next, mode);
+            }
+            '\u{2013}' if mode == EscapeMode::Text => out.push_str("--"),
+            '\u{2014}' if mode == EscapeMode::Text => out.push_str("---"),
+            '\u{2018}' if mode == EscapeMode::Text => out.push('`'),
+            '\u{2019}' if mode == EscapeMode::Text => out.push('\''),
+            '\u{201C}' if mode == EscapeMode::Text => out.push_str("``"),
+            '\u{201D}' if mode == EscapeMode::Text => out.push_str("''"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Emit a control-word command and the separator that stops it from absorbing the following
+/// character. In code context the command always closes with an empty group; in text context the
+/// separator depends on what follows: a space before a letter, an empty group before whitespace or
+/// the end of the run, and nothing before other glyphs (which already terminate the command).
+fn push_control_word(out: &mut String, command: &str, next: Option<char>, mode: EscapeMode) {
+    out.push_str(command);
+    match mode {
+        EscapeMode::Code => out.push_str("{}"),
+        EscapeMode::Text => match next {
+            Some(following) if following.is_alphabetic() => out.push(' '),
+            Some(following) if following.is_whitespace() => out.push_str("{}"),
+            None => out.push_str("{}"),
+            Some(_) => {}
+        },
+    }
+}
+
+/// Escape a URL for `\href`/`\url`/`\includegraphics`: percent-encode the bytes LaTeX cannot carry
+/// in a URL argument, map a backslash to a forward slash, and escape the surviving `#` and `%`.
+fn escape_url(url: &str) -> String {
+    let mut out = String::with_capacity(url.len());
+    for ch in url.chars() {
+        match ch {
+            '\\' => out.push('/'),
+            '#' => out.push_str("\\#"),
+            '%' => out.push_str("\\%"),
+            ' ' | '"' | '<' | '>' | '[' | ']' | '^' | '`' | '{' | '|' | '}' => {
+                percent_encode(ch, &mut out);
+            }
+            other if !other.is_ascii() || (other as u32) < 0x20 => percent_encode(other, &mut out),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+fn percent_encode(ch: char, out: &mut String) {
+    let mut buffer = [0u8; 4];
+    for byte in ch.encode_utf8(&mut buffer).bytes() {
+        out.push_str("\\%");
+        out.push(hex_digit(byte >> 4));
+        out.push(hex_digit(byte & 0x0f));
+    }
+}
+
+fn hex_digit(value: u8) -> char {
+    match value {
+        0..=9 => (b'0' + value) as char,
+        _ => (b'A' + value - 10) as char,
+    }
+}

--- a/crates/oxidoc-writers/src/lib.rs
+++ b/crates/oxidoc-writers/src/lib.rs
@@ -1,13 +1,17 @@
 //! Output-format writers. Each module renders the document model ([`oxidoc_ast::Document`]) into a
 //! target format's text via the [`oxidoc_core::Writer`] trait.
 
-#[cfg(any(feature = "html", feature = "plain"))]
+#[cfg(any(feature = "html", feature = "plain", feature = "latex"))]
 mod common;
 
 #[cfg(feature = "html")]
 pub mod html;
 #[cfg(feature = "json")]
 pub mod json;
+#[cfg(feature = "latex")]
+pub mod latex;
+#[cfg(feature = "native")]
+pub mod native;
 #[cfg(feature = "plain")]
 pub mod plain;
 
@@ -15,5 +19,9 @@ pub mod plain;
 pub use html::HtmlWriter;
 #[cfg(feature = "json")]
 pub use json::JsonWriter;
+#[cfg(feature = "latex")]
+pub use latex::LatexWriter;
+#[cfg(feature = "native")]
+pub use native::NativeWriter;
 #[cfg(feature = "plain")]
 pub use plain::PlainWriter;

--- a/crates/oxidoc-writers/src/native.rs
+++ b/crates/oxidoc-writers/src/native.rs
@@ -1,0 +1,781 @@
+//! Native writer: renders the document model to the textual form of its data structure.
+//!
+//! The output is the document's block sequence rendered as a parenthesized, comma-led data literal:
+//! constructor names applied to their arguments, with tuples, lists, and records laid out by a
+//! pretty-printer with a line width of 72 and a ribbon width of 60. Strings are escaped with
+//! backslash escapes, using symbolic names for control characters. Document metadata is not
+//! rendered; the output is the
+//! block list alone. The result carries no trailing newline; the caller appends one. This format
+//! has no public specification.
+
+use oxidoc_ast::{
+    Alignment, Attr, Block, Caption, Cell, Citation, CitationMode, ColSpec, ColWidth, Document,
+    Format, Inline, ListAttributes, ListNumberDelim, ListNumberStyle, MathType, QuoteType, Row,
+    Table, TableBody, Target,
+};
+use oxidoc_core::{Result, Writer, WriterOptions};
+
+/// Renders a document to the textual form of its data structure (no trailing newline).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NativeWriter;
+
+impl Writer for NativeWriter {
+    fn write(&self, document: &Document, _options: &WriterOptions) -> Result<String> {
+        let tree = list(document.blocks.iter().map(block).collect());
+        let mut printer = Printer {
+            out: String::new(),
+            col: 0,
+            line_indent: 0,
+        };
+        printer.render(&tree);
+        Ok(printer.out)
+    }
+}
+
+/// Maximum total column a flat layout may reach before a node breaks across lines.
+const LINE_LENGTH: usize = 72;
+/// Maximum number of non-indentation characters a flat layout may add to a line.
+const RIBBON: usize = 60;
+/// Columns each level of nesting adds.
+const INDENT: usize = 2;
+/// Width of the `" , "` separator written between composite items.
+const COMPOSITE_SEPARATOR: usize = 3;
+/// Width a composite's brackets and inner padding contribute: `[ ` plus ` ]`.
+const COMPOSITE_PADDING: usize = 4;
+
+/// A layout tree node: the shape plus its precomputed flat width in characters.
+///
+/// A node renders flat when its flat width fits the line and ribbon budgets at the current column;
+/// otherwise it breaks, and each of its children is then laid out independently. The width is
+/// computed once, bottom-up, by the builders, so layout never re-walks a subtree to measure it.
+struct Doc {
+    width: usize,
+    kind: Kind,
+}
+
+enum Kind {
+    /// An indivisible run of text (already escaped); never broken.
+    Atom(String),
+    /// A constructor argument wrapped in parentheses with no inner padding: `(Con …)`.
+    Wrap(Box<Doc>),
+    /// A bracketed, comma-led sequence: a list `[ … ]`, tuple `( … )`, or record `{ … }`.
+    Composite {
+        open: char,
+        close: char,
+        items: Vec<Doc>,
+    },
+    /// A constructor applied to arguments: flat `Con a b`, or the name with each argument on its
+    /// own indented line.
+    Cons { name: String, args: Vec<Doc> },
+}
+
+/// Tracks the output buffer and the current cursor position while laying out a [`Doc`].
+struct Printer {
+    out: String,
+    col: usize,
+    line_indent: usize,
+}
+
+impl Printer {
+    fn write_str(&mut self, text: &str) {
+        self.out.push_str(text);
+        self.col += text.chars().count();
+    }
+
+    fn write_char(&mut self, ch: char) {
+        self.out.push(ch);
+        self.col += 1;
+    }
+
+    fn newline_to(&mut self, indent: usize) {
+        self.out.push('\n');
+        for _ in 0..indent {
+            self.out.push(' ');
+        }
+        self.col = indent;
+        self.line_indent = indent;
+    }
+
+    fn fits(&self, width: usize) -> bool {
+        self.col + width <= LINE_LENGTH
+            && self.col.saturating_sub(self.line_indent) + width <= RIBBON
+    }
+
+    fn render(&mut self, doc: &Doc) {
+        match &doc.kind {
+            Kind::Atom(text) => self.write_str(text),
+            Kind::Wrap(inner) => {
+                if self.fits(doc.width) {
+                    self.write_flat(doc);
+                } else if let Kind::Cons { name, args } = &inner.kind {
+                    self.write_char('(');
+                    self.render_cons_broken(name, args);
+                    self.write_char(')');
+                } else {
+                    self.write_char('(');
+                    self.render(inner);
+                    self.write_char(')');
+                }
+            }
+            Kind::Composite { open, close, items } => {
+                if items.is_empty() {
+                    self.write_char(*open);
+                    self.write_char(*close);
+                } else if self.fits(doc.width) {
+                    self.write_flat(doc);
+                } else {
+                    self.render_composite_broken(*open, *close, items);
+                }
+            }
+            Kind::Cons { name, args } => {
+                if args.is_empty() {
+                    self.write_str(name);
+                } else if self.fits(doc.width) {
+                    self.write_flat(doc);
+                } else {
+                    self.render_cons_broken(name, args);
+                }
+            }
+        }
+    }
+
+    fn write_flat(&mut self, doc: &Doc) {
+        match &doc.kind {
+            Kind::Atom(text) => self.write_str(text),
+            Kind::Wrap(inner) => {
+                self.write_char('(');
+                self.write_flat(inner);
+                self.write_char(')');
+            }
+            Kind::Composite { open, close, items } => {
+                if items.is_empty() {
+                    self.write_char(*open);
+                    self.write_char(*close);
+                } else {
+                    self.write_char(*open);
+                    self.write_char(' ');
+                    for (index, item) in items.iter().enumerate() {
+                        if index > 0 {
+                            self.write_str(" , ");
+                        }
+                        self.write_flat(item);
+                    }
+                    self.write_char(' ');
+                    self.write_char(*close);
+                }
+            }
+            Kind::Cons { name, args } => {
+                self.write_str(name);
+                for arg in args {
+                    self.write_char(' ');
+                    self.write_flat(arg);
+                }
+            }
+        }
+    }
+
+    fn render_composite_broken(&mut self, open: char, close: char, items: &[Doc]) {
+        let open_col = self.col;
+        self.write_char(open);
+        self.write_char(' ');
+        if let Some(first) = items.first() {
+            self.render(first);
+        }
+        for item in items.iter().skip(1) {
+            self.newline_to(open_col);
+            self.write_str(", ");
+            self.render(item);
+        }
+        self.newline_to(open_col);
+        self.write_char(close);
+    }
+
+    /// Lay out a constructor that does not fit flat: the name, then its arguments on the next line.
+    /// The arguments share that one line when they all fit; otherwise each takes its own line.
+    fn render_cons_broken(&mut self, name: &str, args: &[Doc]) {
+        let name_col = self.col;
+        self.write_str(name);
+        if args.is_empty() {
+            return;
+        }
+        self.newline_to(name_col + INDENT);
+        let joined = args.iter().map(|arg| arg.width).sum::<usize>() + (args.len() - 1);
+        if self.fits(joined) {
+            for (index, arg) in args.iter().enumerate() {
+                if index > 0 {
+                    self.write_char(' ');
+                }
+                self.write_flat(arg);
+            }
+        } else {
+            for (index, arg) in args.iter().enumerate() {
+                if index > 0 {
+                    self.newline_to(name_col + INDENT);
+                }
+                self.render(arg);
+            }
+        }
+    }
+}
+
+fn atom(text: impl Into<String>) -> Doc {
+    let text = text.into();
+    Doc {
+        width: text.chars().count(),
+        kind: Kind::Atom(text),
+    }
+}
+
+fn composite(open: char, close: char, items: Vec<Doc>) -> Doc {
+    let width = if items.is_empty() {
+        2
+    } else {
+        let content: usize = items.iter().map(|item| item.width).sum();
+        content + COMPOSITE_SEPARATOR * (items.len() - 1) + COMPOSITE_PADDING
+    };
+    Doc {
+        width,
+        kind: Kind::Composite { open, close, items },
+    }
+}
+
+fn list(items: Vec<Doc>) -> Doc {
+    composite('[', ']', items)
+}
+
+fn tuple(items: Vec<Doc>) -> Doc {
+    composite('(', ')', items)
+}
+
+fn record(fields: Vec<Doc>) -> Doc {
+    composite('{', '}', fields)
+}
+
+fn cons(name: &str, args: Vec<Doc>) -> Doc {
+    let width = if args.is_empty() {
+        name.chars().count()
+    } else {
+        name.chars().count() + args.iter().map(|arg| 1 + arg.width).sum::<usize>()
+    };
+    Doc {
+        width,
+        kind: Kind::Cons {
+            name: name.to_owned(),
+            args,
+        },
+    }
+}
+
+fn wrap(inner: Doc) -> Doc {
+    Doc {
+        width: inner.width + 2,
+        kind: Kind::Wrap(Box::new(inner)),
+    }
+}
+
+/// A record field `name = value`. Modeled as a constructor whose name is `name =` so that a value
+/// too wide to follow inline hangs on the next line, indented from the field name.
+fn field(name: &str, value: Doc) -> Doc {
+    cons(&format!("{name} ="), vec![value])
+}
+
+fn text_atom(value: &str) -> Doc {
+    atom(show_string(value))
+}
+
+/// Where an integer appears: as a constructor argument, where a negative value is parenthesized as
+/// `show` renders it at that precedence, or standing alone, where it is not.
+#[derive(Clone, Copy)]
+enum NumberPos {
+    Argument,
+    Standalone,
+}
+
+/// An integer literal, parenthesized when a negative value sits in argument position.
+fn integer(value: i64, position: NumberPos) -> Doc {
+    if value < 0 && matches!(position, NumberPos::Argument) {
+        atom(format!("({value})"))
+    } else {
+        atom(value.to_string())
+    }
+}
+
+fn inlines(items: &[Inline]) -> Doc {
+    list(items.iter().map(inline).collect())
+}
+
+fn blocks(items: &[Block]) -> Doc {
+    list(items.iter().map(block).collect())
+}
+
+fn attr(value: &Attr) -> Doc {
+    tuple(vec![
+        text_atom(&value.id),
+        list(value.classes.iter().map(|c| text_atom(c)).collect()),
+        list(
+            value
+                .attributes
+                .iter()
+                .map(|(key, val)| tuple(vec![text_atom(key), text_atom(val)]))
+                .collect(),
+        ),
+    ])
+}
+
+fn target(value: &Target) -> Doc {
+    tuple(vec![text_atom(&value.url), text_atom(&value.title)])
+}
+
+fn format_argument(value: &Format) -> Doc {
+    wrap(cons("Format", vec![text_atom(&value.0)]))
+}
+
+fn caption_argument(value: &Caption) -> Doc {
+    let short = match &value.short {
+        None => atom("Nothing"),
+        Some(items) => wrap(cons("Just", vec![inlines(items)])),
+    };
+    wrap(cons("Caption", vec![short, blocks(&value.long)]))
+}
+
+fn list_attributes(value: &ListAttributes) -> Doc {
+    tuple(vec![
+        integer(i64::from(value.start), NumberPos::Standalone),
+        atom(number_style(&value.style)),
+        atom(number_delim(&value.delim)),
+    ])
+}
+
+fn block(value: &Block) -> Doc {
+    match value {
+        Block::Plain(items) => cons("Plain", vec![inlines(items)]),
+        Block::Para(items) => cons("Para", vec![inlines(items)]),
+        Block::LineBlock(lines) => cons(
+            "LineBlock",
+            vec![list(lines.iter().map(|l| inlines(l)).collect())],
+        ),
+        Block::CodeBlock(a, text) => cons("CodeBlock", vec![attr(a), text_atom(text)]),
+        Block::RawBlock(fmt, text) => cons("RawBlock", vec![format_argument(fmt), text_atom(text)]),
+        Block::BlockQuote(items) => cons("BlockQuote", vec![blocks(items)]),
+        Block::OrderedList(list_attrs, items) => cons(
+            "OrderedList",
+            vec![
+                list_attributes(list_attrs),
+                list(items.iter().map(|item| blocks(item)).collect()),
+            ],
+        ),
+        Block::BulletList(items) => cons(
+            "BulletList",
+            vec![list(items.iter().map(|item| blocks(item)).collect())],
+        ),
+        Block::DefinitionList(definitions) => cons(
+            "DefinitionList",
+            vec![list(
+                definitions
+                    .iter()
+                    .map(|(term, defs)| {
+                        tuple(vec![
+                            inlines(term),
+                            list(defs.iter().map(|d| blocks(d)).collect()),
+                        ])
+                    })
+                    .collect(),
+            )],
+        ),
+        Block::Header(level, a, items) => cons(
+            "Header",
+            vec![
+                integer(i64::from(*level), NumberPos::Argument),
+                attr(a),
+                inlines(items),
+            ],
+        ),
+        Block::HorizontalRule => atom("HorizontalRule"),
+        Block::Table(table_box) => table(table_box),
+        Block::Figure(a, caption, items) => cons(
+            "Figure",
+            vec![attr(a), caption_argument(caption), blocks(items)],
+        ),
+        Block::Div(a, items) => cons("Div", vec![attr(a), blocks(items)]),
+    }
+}
+
+fn inline(value: &Inline) -> Doc {
+    match value {
+        Inline::Str(text) => cons("Str", vec![text_atom(text)]),
+        Inline::Emph(items) => cons("Emph", vec![inlines(items)]),
+        Inline::Underline(items) => cons("Underline", vec![inlines(items)]),
+        Inline::Strong(items) => cons("Strong", vec![inlines(items)]),
+        Inline::Strikeout(items) => cons("Strikeout", vec![inlines(items)]),
+        Inline::Superscript(items) => cons("Superscript", vec![inlines(items)]),
+        Inline::Subscript(items) => cons("Subscript", vec![inlines(items)]),
+        Inline::SmallCaps(items) => cons("SmallCaps", vec![inlines(items)]),
+        Inline::Quoted(quote, items) => {
+            cons("Quoted", vec![atom(quote_type(quote)), inlines(items)])
+        }
+        Inline::Cite(citations, items) => cons(
+            "Cite",
+            vec![
+                list(citations.iter().map(citation).collect()),
+                inlines(items),
+            ],
+        ),
+        Inline::Code(a, text) => cons("Code", vec![attr(a), text_atom(text)]),
+        Inline::Space => atom("Space"),
+        Inline::SoftBreak => atom("SoftBreak"),
+        Inline::LineBreak => atom("LineBreak"),
+        Inline::Math(kind, text) => cons("Math", vec![atom(math_type(kind)), text_atom(text)]),
+        Inline::RawInline(fmt, text) => {
+            cons("RawInline", vec![format_argument(fmt), text_atom(text)])
+        }
+        Inline::Link(a, items, tgt) => cons("Link", vec![attr(a), inlines(items), target(tgt)]),
+        Inline::Image(a, items, tgt) => cons("Image", vec![attr(a), inlines(items), target(tgt)]),
+        Inline::Note(items) => cons("Note", vec![blocks(items)]),
+        Inline::Span(a, items) => cons("Span", vec![attr(a), inlines(items)]),
+    }
+}
+
+fn citation(value: &Citation) -> Doc {
+    cons(
+        "Citation",
+        vec![record(vec![
+            field("citationId", text_atom(&value.id)),
+            field("citationPrefix", inlines(&value.prefix)),
+            field("citationSuffix", inlines(&value.suffix)),
+            field("citationMode", atom(citation_mode(&value.mode))),
+            field(
+                "citationNoteNum",
+                integer(i64::from(value.note_num), NumberPos::Standalone),
+            ),
+            field(
+                "citationHash",
+                integer(i64::from(value.hash), NumberPos::Standalone),
+            ),
+        ])],
+    )
+}
+
+fn table(value: &Table) -> Doc {
+    cons(
+        "Table",
+        vec![
+            attr(&value.attr),
+            caption_argument(&value.caption),
+            list(value.col_specs.iter().map(col_spec).collect()),
+            wrap(cons(
+                "TableHead",
+                vec![
+                    attr(&value.head.attr),
+                    list(value.head.rows.iter().map(row).collect()),
+                ],
+            )),
+            list(value.bodies.iter().map(table_body).collect()),
+            wrap(cons(
+                "TableFoot",
+                vec![
+                    attr(&value.foot.attr),
+                    list(value.foot.rows.iter().map(row).collect()),
+                ],
+            )),
+        ],
+    )
+}
+
+fn col_spec(value: &ColSpec) -> Doc {
+    tuple(vec![atom(alignment(&value.align)), col_width(&value.width)])
+}
+
+fn col_width(value: &ColWidth) -> Doc {
+    match value {
+        ColWidth::ColWidthDefault => atom("ColWidthDefault"),
+        ColWidth::ColWidth(fraction) => cons("ColWidth", vec![atom(show_double(*fraction))]),
+    }
+}
+
+fn row(value: &Row) -> Doc {
+    cons(
+        "Row",
+        vec![
+            attr(&value.attr),
+            list(value.cells.iter().map(cell).collect()),
+        ],
+    )
+}
+
+fn cell(value: &Cell) -> Doc {
+    cons(
+        "Cell",
+        vec![
+            attr(&value.attr),
+            atom(alignment(&value.align)),
+            wrap(cons(
+                "RowSpan",
+                vec![integer(i64::from(value.row_span), NumberPos::Argument)],
+            )),
+            wrap(cons(
+                "ColSpan",
+                vec![integer(i64::from(value.col_span), NumberPos::Argument)],
+            )),
+            blocks(&value.content),
+        ],
+    )
+}
+
+fn table_body(value: &TableBody) -> Doc {
+    cons(
+        "TableBody",
+        vec![
+            attr(&value.attr),
+            wrap(cons(
+                "RowHeadColumns",
+                vec![integer(
+                    i64::from(value.row_head_columns),
+                    NumberPos::Argument,
+                )],
+            )),
+            list(value.head.iter().map(row).collect()),
+            list(value.body.iter().map(row).collect()),
+        ],
+    )
+}
+
+fn alignment(value: &Alignment) -> &'static str {
+    match value {
+        Alignment::AlignLeft => "AlignLeft",
+        Alignment::AlignRight => "AlignRight",
+        Alignment::AlignCenter => "AlignCenter",
+        Alignment::AlignDefault => "AlignDefault",
+    }
+}
+
+fn quote_type(value: &QuoteType) -> &'static str {
+    match value {
+        QuoteType::SingleQuote => "SingleQuote",
+        QuoteType::DoubleQuote => "DoubleQuote",
+    }
+}
+
+fn math_type(value: &MathType) -> &'static str {
+    match value {
+        MathType::InlineMath => "InlineMath",
+        MathType::DisplayMath => "DisplayMath",
+    }
+}
+
+fn citation_mode(value: &CitationMode) -> &'static str {
+    match value {
+        CitationMode::AuthorInText => "AuthorInText",
+        CitationMode::SuppressAuthor => "SuppressAuthor",
+        CitationMode::NormalCitation => "NormalCitation",
+    }
+}
+
+fn number_style(value: &ListNumberStyle) -> &'static str {
+    match value {
+        ListNumberStyle::DefaultStyle => "DefaultStyle",
+        ListNumberStyle::Example => "Example",
+        ListNumberStyle::Decimal => "Decimal",
+        ListNumberStyle::LowerRoman => "LowerRoman",
+        ListNumberStyle::UpperRoman => "UpperRoman",
+        ListNumberStyle::LowerAlpha => "LowerAlpha",
+        ListNumberStyle::UpperAlpha => "UpperAlpha",
+    }
+}
+
+fn number_delim(value: &ListNumberDelim) -> &'static str {
+    match value {
+        ListNumberDelim::DefaultDelim => "DefaultDelim",
+        ListNumberDelim::Period => "Period",
+        ListNumberDelim::OneParen => "OneParen",
+        ListNumberDelim::TwoParens => "TwoParens",
+    }
+}
+
+/// Escape names for control characters 0–31, indexed by code point. The entries `a`, `b`, `t`,
+/// `n`, `v`, `f`, `r` (codes 7–13) and `SO` (14) yield the short forms `\a`…`\r` and `\SO`.
+const CONTROL_NAMES: [&str; 32] = [
+    "NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "a", "b", "t", "n", "v", "f", "r", "SO", "SI",
+    "DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB", "CAN", "EM", "SUB", "ESC", "FS", "GS",
+    "RS", "US",
+];
+
+/// Render a string as `show` would: surrounded by double quotes, with backslash and quote escaped,
+/// control characters named, and every non-ASCII character emitted as a decimal escape. A `\&`
+/// separator is inserted where a numeric or `\SO` escape would otherwise merge with the following
+/// character.
+fn show_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    let mut after_numeric = false;
+    let mut after_so = false;
+    for ch in value.chars() {
+        if (after_numeric && ch.is_ascii_digit()) || (after_so && ch == 'H') {
+            out.push_str("\\&");
+        }
+        after_numeric = false;
+        after_so = false;
+
+        let code = ch as u32;
+        if ch == '"' {
+            out.push_str("\\\"");
+        } else if code > 127 {
+            out.push('\\');
+            out.push_str(&code.to_string());
+            after_numeric = true;
+        } else if code == 127 {
+            out.push_str("\\DEL");
+        } else if ch == '\\' {
+            out.push_str("\\\\");
+        } else if code >= 32 {
+            out.push(ch);
+        } else {
+            out.push('\\');
+            out.push_str(CONTROL_NAMES.get(code as usize).copied().unwrap_or(""));
+            if code == 14 {
+                after_so = true;
+            }
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Render a float in the native value syntax: fixed-point when its magnitude falls in the range
+/// `[10^-1, 10^6]`, scientific notation otherwise, always carrying a fractional part.
+fn show_double(value: f64) -> String {
+    if value.is_nan() {
+        return "NaN".to_owned();
+    }
+    if value.is_infinite() {
+        return if value < 0.0 { "-Infinity" } else { "Infinity" }.to_owned();
+    }
+
+    let negative = value.is_sign_negative();
+    let scientific = format!("{:e}", value.abs());
+    let (mantissa, exponent_text) = scientific
+        .split_once('e')
+        .unwrap_or((scientific.as_str(), "0"));
+    let exponent: i64 = exponent_text.parse().unwrap_or(0);
+    let digits: String = mantissa.chars().filter(|c| *c != '.').collect();
+
+    let body = if (-1..=6).contains(&exponent) {
+        fixed_point(&digits, exponent)
+    } else {
+        scientific_form(&digits, exponent)
+    };
+
+    if negative { format!("-{body}") } else { body }
+}
+
+fn fixed_point(digits: &str, exponent: i64) -> String {
+    let point = exponent + 1;
+    if point <= 0 {
+        let zeros = usize::try_from(-point).unwrap_or(0);
+        format!("0.{}{}", "0".repeat(zeros), digits)
+    } else {
+        let point = usize::try_from(point).unwrap_or(usize::MAX);
+        let len = digits.len();
+        if point >= len {
+            format!("{}{}.0", digits, "0".repeat(point - len))
+        } else {
+            let (whole, fraction) = digits.split_at(point);
+            format!("{whole}.{fraction}")
+        }
+    }
+}
+
+fn scientific_form(digits: &str, exponent: i64) -> String {
+    let (first, rest) = digits.split_at(1.min(digits.len()));
+    let fraction = if rest.is_empty() { "0" } else { rest };
+    format!("{first}.{fraction}e{exponent}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxidoc_ast::{Attr, Document, Format};
+
+    fn render(blocks: Vec<Block>) -> String {
+        let document = Document {
+            blocks,
+            ..Document::default()
+        };
+        NativeWriter
+            .write(&document, &WriterOptions::default())
+            .unwrap()
+    }
+
+    #[test]
+    fn empty_document() {
+        assert_eq!(render(vec![]), "[]");
+    }
+
+    #[test]
+    fn short_paragraph_stays_flat() {
+        let para = Block::Para(vec![
+            Inline::Str("hi".into()),
+            Inline::Space,
+            Inline::Str("there".into()),
+        ]);
+        assert_eq!(
+            render(vec![para]),
+            r#"[ Para [ Str "hi" , Space , Str "there" ] ]"#
+        );
+    }
+
+    #[test]
+    fn header_with_attr() {
+        let header = Block::Header(
+            1,
+            Attr {
+                id: "hi".into(),
+                ..Attr::default()
+            },
+            vec![Inline::Str("Hi".into())],
+        );
+        assert_eq!(
+            render(vec![header]),
+            r#"[ Header 1 ( "hi" , [] , [] ) [ Str "Hi" ] ]"#
+        );
+    }
+
+    #[test]
+    fn raw_block_wraps_format() {
+        let raw = Block::RawBlock(Format("html".into()), "<b>".into());
+        assert_eq!(render(vec![raw]), r#"[ RawBlock (Format "html") "<b>" ]"#);
+    }
+
+    #[test]
+    fn paragraph_breaks_when_wide() {
+        let para = Block::Para(
+            (0..8)
+                .flat_map(|_| [Inline::Str("aaaa".into()), Inline::Space])
+                .take(15)
+                .collect(),
+        );
+        let rendered = render(vec![para]);
+        assert!(rendered.starts_with("[ Para\n    [ Str \"aaaa\"\n    , Space\n"));
+        assert!(rendered.ends_with("\n    ]\n]"));
+    }
+
+    #[test]
+    fn string_escaping_matches_show() {
+        assert_eq!(show_string("café"), r#""caf\233""#);
+        assert_eq!(show_string("a\u{1}b"), r#""a\SOHb""#);
+        assert_eq!(show_string("a\"b\\c"), r#""a\"b\\c""#);
+        assert_eq!(show_string("\u{e9}1"), r#""\233\&1""#);
+        assert_eq!(show_string("\u{e}H"), r#""\SO\&H""#);
+    }
+
+    #[test]
+    fn double_formatting_matches_show() {
+        assert_eq!(show_double(0.5), "0.5");
+        assert_eq!(show_double(0.05), "5.0e-2");
+        assert_eq!(show_double(0.1), "0.1");
+        assert_eq!(show_double(1.0), "1.0");
+        assert_eq!(show_double(1_234_567.0), "1234567.0");
+        assert_eq!(show_double(12_345_678.0), "1.2345678e7");
+        assert_eq!(show_double(100.25), "100.25");
+        assert_eq!(show_double(0.333_333_333_333_333_3), "0.3333333333333333");
+    }
+}

--- a/crates/oxidoc-writers/src/plain.rs
+++ b/crates/oxidoc-writers/src/plain.rs
@@ -9,7 +9,9 @@ use oxidoc_ast::{
 };
 use oxidoc_core::{Result, Writer, WriterOptions};
 
-use crate::common::{FILL_COLUMN, is_wide, quote_marks};
+use crate::common::{
+    FILL_COLUMN, Piece, fill, fill_offset, indent_block, list_is_tight, quote_marks, wrap_delim,
+};
 
 /// Renders a document to plain text.
 #[derive(Debug, Default, Clone, Copy)]
@@ -30,15 +32,6 @@ impl Writer for PlainWriter {
         }
         Ok(out.trim_end_matches('\n').to_owned())
     }
-}
-
-/// A unit of inline content awaiting line filling: an unbreakable text run, a breakable space, or a
-/// forced line break.
-#[derive(Debug, Clone)]
-enum Piece {
-    Text(String),
-    Space,
-    Hard,
 }
 
 /// Carries the footnote bodies accumulated while rendering, so notes can be collected inline and
@@ -345,9 +338,7 @@ fn join_loose(rendered: Vec<(bool, String)>) -> String {
 /// are separated with a blank line and each item's blocks are laid out with blank lines; a tight list
 /// uses single newlines throughout.
 fn is_loose(items: &[Vec<Block>]) -> bool {
-    !items
-        .iter()
-        .all(|item| matches!(item.first(), None | Some(Block::Plain(_))))
+    !list_is_tight(items)
 }
 
 fn item_separator(loose: bool) -> &'static str {
@@ -403,130 +394,6 @@ fn pieces_to_string(pieces: &[Piece]) -> String {
 /// header on one line.
 fn header_text(pieces: &[Piece]) -> String {
     join_pieces(pieces, ' ')
-}
-
-/// Greedily fill inline pieces to `width` columns: a breakable
-/// space becomes a line break when keeping the next word on the current line would exceed the fill
-/// column. Consecutive text runs (no intervening space) stay together; runs of spaces collapse;
-/// leading and trailing spaces on a line are dropped.
-fn fill(pieces: &[Piece], width: usize) -> String {
-    fill_offset(pieces, width, 0)
-}
-
-/// Like [`fill`], but the first line is laid out as if `initial` columns were already consumed (the
-/// hanging-marker layout, where a footnote marker shifts the first line's wrap point but leaves
-/// continuation lines at the margin).
-fn fill_offset(pieces: &[Piece], width: usize, initial: usize) -> String {
-    let width = width.max(1);
-    let mut out = String::new();
-    let mut column = initial;
-    let mut at_line_start = initial == 0;
-    let mut pending_space = false;
-    // Consecutive text pieces (no intervening space or break) form one unbreakable word, gathered
-    // here as borrowed runs and placed only once its full width is known.
-    let mut word: Vec<&str> = Vec::new();
-    let mut word_width = 0;
-    for piece in pieces {
-        match piece {
-            Piece::Text(text) => {
-                word.push(text);
-                word_width += display_width(text);
-            }
-            Piece::Space => {
-                place_word(
-                    &mut out,
-                    &mut column,
-                    &mut at_line_start,
-                    pending_space,
-                    &word,
-                    word_width,
-                    width,
-                );
-                word.clear();
-                word_width = 0;
-                pending_space = true;
-            }
-            Piece::Hard => {
-                place_word(
-                    &mut out,
-                    &mut column,
-                    &mut at_line_start,
-                    pending_space,
-                    &word,
-                    word_width,
-                    width,
-                );
-                word.clear();
-                word_width = 0;
-                if !at_line_start {
-                    out.push('\n');
-                    column = 0;
-                    at_line_start = true;
-                }
-                pending_space = false;
-            }
-        }
-    }
-    place_word(
-        &mut out,
-        &mut column,
-        &mut at_line_start,
-        pending_space,
-        &word,
-        word_width,
-        width,
-    );
-    out.trim_end_matches('\n').to_owned()
-}
-
-/// Place a gathered word onto the current line, inserting a line break in place of the preceding
-/// space when keeping the word would overflow `width`. A no-op for an empty word.
-fn place_word(
-    out: &mut String,
-    column: &mut usize,
-    at_line_start: &mut bool,
-    pending_space: bool,
-    word: &[&str],
-    word_width: usize,
-    width: usize,
-) {
-    if word.is_empty() {
-        return;
-    }
-    if *at_line_start {
-        *at_line_start = false;
-    } else if pending_space && *column + 1 + word_width > width {
-        out.push('\n');
-        *column = 0;
-        *at_line_start = false;
-    } else if pending_space {
-        out.push(' ');
-        *column += 1;
-    }
-    for part in word {
-        out.push_str(part);
-    }
-    *column += word_width;
-}
-
-/// Apply `first` to the first line and `rest` to each non-empty later line, leaving blank lines
-/// (block separators) unprefixed. This produces a hanging indent: a list marker plus continuation
-/// indent, or a uniform block-quote / code prefix.
-fn indent_block(body: &str, first: &str, rest: &str) -> String {
-    let mut out = String::new();
-    for (index, line) in body.split('\n').enumerate() {
-        if index > 0 {
-            out.push('\n');
-        }
-        if index == 0 {
-            out.push_str(first);
-            out.push_str(line);
-        } else if !line.is_empty() {
-            out.push_str(rest);
-            out.push_str(line);
-        }
-    }
-    out
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -616,12 +483,7 @@ fn script_char(ch: char, kind: Script) -> Option<char> {
 /// The leading marker an ordered-list item carries: its number rendered in the list's numeral style,
 /// wrapped by the list's delimiter.
 fn ordered_marker(number: i32, style: &ListNumberStyle, delim: &ListNumberDelim) -> String {
-    let numeral = numeral(number, style);
-    match delim {
-        ListNumberDelim::DefaultDelim | ListNumberDelim::Period => format!("{numeral}."),
-        ListNumberDelim::OneParen => format!("{numeral})"),
-        ListNumberDelim::TwoParens => format!("({numeral})"),
-    }
+    wrap_delim(&numeral(number, style), delim)
 }
 
 fn numeral(number: i32, style: &ListNumberStyle) -> String {
@@ -683,51 +545,4 @@ fn roman(number: i32, upper: bool) -> String {
         }
     }
     if upper { out.to_uppercase() } else { out }
-}
-
-/// Display width of a string in columns, summed over its characters.
-fn display_width(text: &str) -> usize {
-    text.chars().map(char_width).sum()
-}
-
-/// Display width of a character: zero for common combining marks, two for wide East Asian
-/// characters, one otherwise. A self-contained column-width approximation.
-fn char_width(ch: char) -> usize {
-    let code = ch as u32;
-    if is_control(code) {
-        return 0;
-    }
-    if code < 0x0300 {
-        return 1;
-    }
-    if is_zero_width(code) {
-        return 0;
-    }
-    if is_wide(code) { 2 } else { 1 }
-}
-
-/// C0 controls, DEL, and C1 controls occupy no display columns.
-fn is_control(code: u32) -> bool {
-    code < 0x20 || (0x7F..=0x9F).contains(&code)
-}
-
-fn is_zero_width(code: u32) -> bool {
-    matches!(code,
-        0x0300..=0x036F
-        | 0x0483..=0x0489
-        | 0x0591..=0x05BD
-        | 0x0610..=0x061A
-        | 0x064B..=0x065F
-        | 0x0670
-        | 0x06D6..=0x06DC
-        | 0x06DF..=0x06E4
-        | 0x0E31
-        | 0x0E34..=0x0E3A
-        | 0x1AB0..=0x1AFF
-        | 0x1DC0..=0x1DFF
-        | 0x200B..=0x200F
-        | 0x20D0..=0x20FF
-        | 0xFE00..=0xFE0F
-        | 0xFE20..=0xFE2F
-    )
 }

--- a/crates/oxidoc/Cargo.toml
+++ b/crates/oxidoc/Cargo.toml
@@ -13,12 +13,16 @@ workspace = true
 
 [features]
 default = ["full"]
-full = ["read-commonmark", "read-json", "write-html", "write-json", "write-plain"]
+full = ["read-commonmark", "read-json", "write-html", "write-json", "write-plain", "read-native", "read-html", "write-native", "write-latex"]
 read-commonmark = ["dep:oxidoc-readers", "oxidoc-readers/commonmark"]
 read-json = ["dep:oxidoc-readers", "oxidoc-readers/json"]
 write-html = ["dep:oxidoc-writers", "oxidoc-writers/html"]
 write-json = ["dep:oxidoc-writers", "oxidoc-writers/json"]
 write-plain = ["dep:oxidoc-writers", "oxidoc-writers/plain"]
+read-native = ["dep:oxidoc-readers", "oxidoc-readers/native"]
+read-html = ["dep:oxidoc-readers", "oxidoc-readers/html"]
+write-native = ["dep:oxidoc-writers", "oxidoc-writers/native"]
+write-latex = ["dep:oxidoc-writers", "oxidoc-writers/latex"]
 
 [dependencies]
 oxidoc-ast = { workspace = true }

--- a/crates/oxidoc/src/registry.rs
+++ b/crates/oxidoc/src/registry.rs
@@ -59,6 +59,8 @@ format_dispatch! {
     supported: supported_input_formats;
     "read-commonmark" => "commonmark" | "markdown" => oxidoc_readers::CommonmarkReader;
     "read-json" => "json" => oxidoc_readers::JsonReader;
+    "read-native" => "native" => oxidoc_readers::NativeReader;
+    "read-html" => "html" => oxidoc_readers::HtmlReader;
 }
 
 format_dispatch! {
@@ -68,4 +70,6 @@ format_dispatch! {
     "write-html" => "html" | "html5" => oxidoc_writers::HtmlWriter;
     "write-json" => "json" => oxidoc_writers::JsonWriter;
     "write-plain" => "plain" => oxidoc_writers::PlainWriter;
+    "write-native" => "native" => oxidoc_writers::NativeWriter;
+    "write-latex" => "latex" => oxidoc_writers::LatexWriter;
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,6 +29,20 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "native"
+path = "fuzz_targets/native.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "html"
+path = "fuzz_targets/html.rs"
+test = false
+doc = false
+bench = false
+
 [profile.release]
 debug = 1
 

--- a/fuzz/fuzz_targets/html.rs
+++ b/fuzz/fuzz_targets/html.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use oxidoc_core::{Reader, ReaderOptions};
+use oxidoc_readers::HtmlReader;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let _ = HtmlReader.read(text, &ReaderOptions::default());
+    }
+});

--- a/fuzz/fuzz_targets/native.rs
+++ b/fuzz/fuzz_targets/native.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use oxidoc_core::{Reader, ReaderOptions};
+use oxidoc_readers::NativeReader;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let _ = NativeReader.read(text, &ReaderOptions::default());
+    }
+});


### PR DESCRIPTION
Adds three formats — a native reader and writer (with a round-trip identity test), an HTML reader, and a LaTeX writer — plus a shared line-fill engine extracted across the writers. All reach byte-parity with the oracle across the model; full suite (65 tests) green.