### PR TITLE
refactor(writers,readers): dedup shared logic and push-buffer HTML assembly

### DIFF
--- a/crates/oxidoc-ast/src/ast.rs
+++ b/crates/oxidoc-ast/src/ast.rs
@@ -303,6 +303,26 @@ pub fn to_plain_text(inlines: &[Inline]) -> String {
     out
 }
 
+/// Derive a heading identifier from plain text: a non-breaking space is treated as an ordinary
+/// space, only alphanumerics, whitespace, and `_`, `-`, `.` are kept, the result is lowercased,
+/// whitespace runs collapse to single hyphens, and any leading non-letter characters are dropped.
+/// The result is empty when no alphabetic character survives.
+#[must_use]
+pub fn slug(text: &str) -> String {
+    let mut filtered = String::new();
+    for ch in text.chars() {
+        let ch = if ch == '\u{a0}' { ' ' } else { ch };
+        if ch.is_alphanumeric() || ch.is_whitespace() || matches!(ch, '_' | '-' | '.') {
+            filtered.extend(ch.to_lowercase());
+        }
+    }
+    let joined = filtered.split_whitespace().collect::<Vec<_>>().join("-");
+    joined
+        .chars()
+        .skip_while(|ch| !ch.is_alphabetic())
+        .collect()
+}
+
 fn push_plain_text(inlines: &[Inline], out: &mut String) {
     for inline in inlines {
         match inline {

--- a/crates/oxidoc-readers/src/commonmark/cursor.rs
+++ b/crates/oxidoc-readers/src/commonmark/cursor.rs
@@ -370,7 +370,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    fn ordered_marker_at(&mut self) -> Option<ListMarkerParse> {
+    fn ordered_marker_at(&self) -> Option<ListMarkerParse> {
         let mut digits = 0;
         let mut value: i64 = 0;
         while let Some(byte) = self.bytes.get(self.offset + digits) {

--- a/crates/oxidoc-readers/src/commonmark/inline.rs
+++ b/crates/oxidoc-readers/src/commonmark/inline.rs
@@ -343,7 +343,7 @@ impl InlineParser<'_> {
 
     /// Attempt to parse what follows `]` as an inline `(...)`, reference, collapsed, or shortcut
     /// link, returning the target and the position after it.
-    fn try_link_target(&mut self, opener_index: usize) -> Option<(Target, usize)> {
+    fn try_link_target(&self, opener_index: usize) -> Option<(Target, usize)> {
         if self.at(0) == Some('(')
             && let Some(result) = scan_inline_target(self.chars, self.pos)
         {

--- a/crates/oxidoc-readers/src/commonmark/scan.rs
+++ b/crates/oxidoc-readers/src/commonmark/scan.rs
@@ -317,7 +317,7 @@ fn decode_entity(body: &str) -> Option<String> {
             return None;
         }
         let code = u32::from_str_radix(num, 16).ok()?;
-        return Some(code_point_char(code));
+        return Some(crate::entities::code_point(code).to_string());
     }
     if let Some(num) = body.strip_prefix('#') {
         // A decimal reference is one to seven digits.
@@ -325,28 +325,9 @@ fn decode_entity(body: &str) -> Option<String> {
             return None;
         }
         let code: u32 = num.parse().ok()?;
-        return Some(code_point_char(code));
+        return Some(crate::entities::code_point(code).to_string());
     }
-    named_entity(body)
-}
-
-fn code_point_char(code: u32) -> String {
-    if code == 0 {
-        return '\u{fffd}'.to_string();
-    }
-    char::from_u32(code).unwrap_or('\u{fffd}').to_string()
-}
-
-fn named_entity(name: &str) -> Option<String> {
-    entities::ENTITIES
-        .binary_search_by(|(candidate, _)| (*candidate).cmp(name))
-        .ok()
-        .and_then(|index| entities::ENTITIES.get(index))
-        .map(|(_, characters)| (*characters).to_owned())
-}
-
-mod entities {
-    include!(concat!(env!("OUT_DIR"), "/entities_table.rs"));
+    crate::entities::lookup_named(body).map(str::to_owned)
 }
 
 /// Scan an inline link tail `(url "title")` beginning at `pos` (which points at `(`).

--- a/crates/oxidoc-readers/src/entities.rs
+++ b/crates/oxidoc-readers/src/entities.rs
@@ -1,0 +1,23 @@
+//! Named and numeric character-reference decoding shared by the text readers. The named-entity
+//! table is generated at build time from the vendored character-reference data.
+
+include!(concat!(env!("OUT_DIR"), "/entities_table.rs"));
+
+/// Convert a numeric character reference's code point to a character: the null code point and any
+/// value outside the Unicode scalar range both map to the replacement character.
+pub(crate) fn code_point(code: u32) -> char {
+    if code == 0 {
+        return '\u{fffd}';
+    }
+    char::from_u32(code).unwrap_or('\u{fffd}')
+}
+
+/// Look up a named character reference (keyed without the leading `&` or trailing `;`), returning its
+/// replacement text.
+pub(crate) fn lookup_named(name: &str) -> Option<&'static str> {
+    ENTITIES
+        .binary_search_by(|(candidate, _)| (*candidate).cmp(name))
+        .ok()
+        .and_then(|index| ENTITIES.get(index))
+        .map(|(_, characters)| *characters)
+}

--- a/crates/oxidoc-readers/src/html.rs
+++ b/crates/oxidoc-readers/src/html.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use oxidoc_ast::{
     Alignment, Attr, Block, Caption, Cell, ColSpec, ColWidth, Document, Inline, ListAttributes,
     ListNumberDelim, ListNumberStyle, MetaValue, QuoteType, Row, Table, TableBody, TableFoot,
-    TableHead, Target, to_plain_text,
+    TableHead, Target, slug, to_plain_text,
 };
 use oxidoc_core::{Reader, ReaderOptions, Result};
 
@@ -1413,18 +1413,6 @@ fn gather_text(nodes: &[Node], out: &mut String) {
 
 /// Derive an ASCII-ish anchor identifier: keep letters, digits, spaces and `_-.`, lowercase, join
 /// words with hyphens, then drop any leading characters before the first letter.
-fn slug(text: &str) -> String {
-    let mut filtered = String::new();
-    for ch in text.chars() {
-        let ch = if ch == '\u{a0}' { ' ' } else { ch };
-        if ch.is_alphanumeric() || ch.is_whitespace() || ch == '_' || ch == '-' || ch == '.' {
-            filtered.extend(ch.to_lowercase());
-        }
-    }
-    let joined = filtered.split_whitespace().collect::<Vec<_>>().join("-");
-    joined.chars().skip_while(|c| !c.is_alphabetic()).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::HtmlReader;

--- a/crates/oxidoc-readers/src/html.rs
+++ b/crates/oxidoc-readers/src/html.rs
@@ -15,7 +15,7 @@ use oxidoc_ast::{
 };
 use oxidoc_core::{Reader, ReaderOptions, Result};
 
-include!(concat!(env!("OUT_DIR"), "/entities_table.rs"));
+use crate::entities::{code_point, lookup_named};
 
 /// Parses HTML text into the document model.
 #[derive(Debug, Default, Clone, Copy)]
@@ -414,22 +414,7 @@ fn scan_numeric_ref(chars: &[char], start: usize) -> Option<(String, usize)> {
     let digits: String = slice(chars, digits_start, i);
     let code = u32::from_str_radix(&digits, radix).ok()?;
     let end = if chars.get(i) == Some(&';') { i + 1 } else { i };
-    Some((code_point(code), end))
-}
-
-fn code_point(code: u32) -> String {
-    if code == 0 {
-        return '\u{fffd}'.to_string();
-    }
-    char::from_u32(code).unwrap_or('\u{fffd}').to_string()
-}
-
-fn lookup_named(name: &str) -> Option<&'static str> {
-    ENTITIES
-        .binary_search_by(|(candidate, _)| (*candidate).cmp(name))
-        .ok()
-        .and_then(|index| ENTITIES.get(index))
-        .map(|(_, characters)| *characters)
+    Some((code_point(code).to_string(), end))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/oxidoc-readers/src/lib.rs
+++ b/crates/oxidoc-readers/src/lib.rs
@@ -1,6 +1,9 @@
 //! Input-format readers. Each module parses a source format's text into the document model
 //! ([`oxidoc_ast::Document`]) via the [`oxidoc_core::Reader`] trait.
 
+#[cfg(any(feature = "commonmark", feature = "html"))]
+mod entities;
+
 #[cfg(feature = "commonmark")]
 pub mod commonmark;
 #[cfg(feature = "html")]

--- a/crates/oxidoc-readers/src/native.rs
+++ b/crates/oxidoc-readers/src/native.rs
@@ -347,6 +347,26 @@ struct Parser {
     pos: usize,
 }
 
+/// Defines a parser method that reads a constructor name and maps it to a value of `$ty`. Each arm
+/// pairs a constructor name with the expression it produces (which may itself consume further tokens,
+/// as a constructor carrying a payload does); an unrecognized name is a syntax error naming `$label`.
+macro_rules! parse_constructor {
+    (
+        $method:ident -> $ty:ty, $label:literal {
+            $( $tag:literal => $value:expr ),* $(,)?
+        }
+    ) => {
+        fn $method(&mut self) -> Result<$ty> {
+            match self.constructor()?.as_str() {
+                $( $tag => Ok($value), )*
+                other => {
+                    Err(syntax_error(format!(concat!("unknown ", $label, " '{}'"), other)))
+                }
+            }
+        }
+    };
+}
+
 impl Parser {
     fn peek(&self) -> Option<&Token> {
         self.tokens.get(self.pos)
@@ -770,63 +790,55 @@ impl Parser {
         Ok((term, definitions))
     }
 
-    fn parse_quote_type(&mut self) -> Result<QuoteType> {
-        match self.constructor()?.as_str() {
-            "SingleQuote" => Ok(QuoteType::SingleQuote),
-            "DoubleQuote" => Ok(QuoteType::DoubleQuote),
-            other => Err(syntax_error(format!("unknown quote type '{other}'"))),
+    parse_constructor! {
+        parse_quote_type -> QuoteType, "quote type" {
+            "SingleQuote" => QuoteType::SingleQuote,
+            "DoubleQuote" => QuoteType::DoubleQuote,
         }
     }
 
-    fn parse_math_type(&mut self) -> Result<MathType> {
-        match self.constructor()?.as_str() {
-            "InlineMath" => Ok(MathType::InlineMath),
-            "DisplayMath" => Ok(MathType::DisplayMath),
-            other => Err(syntax_error(format!("unknown math type '{other}'"))),
+    parse_constructor! {
+        parse_math_type -> MathType, "math type" {
+            "InlineMath" => MathType::InlineMath,
+            "DisplayMath" => MathType::DisplayMath,
         }
     }
 
-    fn parse_list_number_style(&mut self) -> Result<ListNumberStyle> {
-        match self.constructor()?.as_str() {
-            "DefaultStyle" => Ok(ListNumberStyle::DefaultStyle),
-            "Example" => Ok(ListNumberStyle::Example),
-            "Decimal" => Ok(ListNumberStyle::Decimal),
-            "LowerRoman" => Ok(ListNumberStyle::LowerRoman),
-            "UpperRoman" => Ok(ListNumberStyle::UpperRoman),
-            "LowerAlpha" => Ok(ListNumberStyle::LowerAlpha),
-            "UpperAlpha" => Ok(ListNumberStyle::UpperAlpha),
-            other => Err(syntax_error(format!("unknown list number style '{other}'"))),
+    parse_constructor! {
+        parse_list_number_style -> ListNumberStyle, "list number style" {
+            "DefaultStyle" => ListNumberStyle::DefaultStyle,
+            "Example" => ListNumberStyle::Example,
+            "Decimal" => ListNumberStyle::Decimal,
+            "LowerRoman" => ListNumberStyle::LowerRoman,
+            "UpperRoman" => ListNumberStyle::UpperRoman,
+            "LowerAlpha" => ListNumberStyle::LowerAlpha,
+            "UpperAlpha" => ListNumberStyle::UpperAlpha,
         }
     }
 
-    fn parse_list_number_delim(&mut self) -> Result<ListNumberDelim> {
-        match self.constructor()?.as_str() {
-            "DefaultDelim" => Ok(ListNumberDelim::DefaultDelim),
-            "Period" => Ok(ListNumberDelim::Period),
-            "OneParen" => Ok(ListNumberDelim::OneParen),
-            "TwoParens" => Ok(ListNumberDelim::TwoParens),
-            other => Err(syntax_error(format!(
-                "unknown list number delimiter '{other}'"
-            ))),
+    parse_constructor! {
+        parse_list_number_delim -> ListNumberDelim, "list number delimiter" {
+            "DefaultDelim" => ListNumberDelim::DefaultDelim,
+            "Period" => ListNumberDelim::Period,
+            "OneParen" => ListNumberDelim::OneParen,
+            "TwoParens" => ListNumberDelim::TwoParens,
         }
     }
 
-    fn parse_citation_mode(&mut self) -> Result<CitationMode> {
-        match self.constructor()?.as_str() {
-            "AuthorInText" => Ok(CitationMode::AuthorInText),
-            "SuppressAuthor" => Ok(CitationMode::SuppressAuthor),
-            "NormalCitation" => Ok(CitationMode::NormalCitation),
-            other => Err(syntax_error(format!("unknown citation mode '{other}'"))),
+    parse_constructor! {
+        parse_citation_mode -> CitationMode, "citation mode" {
+            "AuthorInText" => CitationMode::AuthorInText,
+            "SuppressAuthor" => CitationMode::SuppressAuthor,
+            "NormalCitation" => CitationMode::NormalCitation,
         }
     }
 
-    fn parse_alignment(&mut self) -> Result<Alignment> {
-        match self.constructor()?.as_str() {
-            "AlignLeft" => Ok(Alignment::AlignLeft),
-            "AlignRight" => Ok(Alignment::AlignRight),
-            "AlignCenter" => Ok(Alignment::AlignCenter),
-            "AlignDefault" => Ok(Alignment::AlignDefault),
-            other => Err(syntax_error(format!("unknown alignment '{other}'"))),
+    parse_constructor! {
+        parse_alignment -> Alignment, "alignment" {
+            "AlignLeft" => Alignment::AlignLeft,
+            "AlignRight" => Alignment::AlignRight,
+            "AlignCenter" => Alignment::AlignCenter,
+            "AlignDefault" => Alignment::AlignDefault,
         }
     }
 

--- a/crates/oxidoc-writers/src/common.rs
+++ b/crates/oxidoc-writers/src/common.rs
@@ -160,6 +160,47 @@ pub(crate) fn list_is_tight(items: &[Vec<Block>]) -> bool {
         .all(|item| matches!(item.first(), None | Some(Block::Plain(_))))
 }
 
+/// Whether a list is loose — at least one item carries a top-level paragraph. A loose list's items
+/// are separated with a blank line and each item's blocks are laid out with blank lines; a tight
+/// list uses single newlines throughout.
+pub(crate) fn is_loose(items: &[Vec<Block>]) -> bool {
+    !list_is_tight(items)
+}
+
+/// The separator between two list items at the given layout density: a blank line when loose, a
+/// single newline when tight.
+pub(crate) fn item_separator(loose: bool) -> &'static str {
+    if loose { "\n\n" } else { "\n" }
+}
+
+/// Join already-rendered blocks with the document's default blank-line spacing, dropping blocks that
+/// produced no output. A [`Block::Plain`] contributes only a single newline (not a blank line)
+/// before the next visible block when an empty block falls between them.
+pub(crate) fn join_loose(rendered: Vec<(bool, String)>) -> String {
+    let mut out = String::new();
+    let mut previous_was_plain: Option<bool> = None;
+    let mut empty_since_previous = false;
+    for (is_plain, text) in rendered {
+        if text.is_empty() {
+            if previous_was_plain.is_some() {
+                empty_since_previous = true;
+            }
+            continue;
+        }
+        if let Some(was_plain) = previous_was_plain {
+            if was_plain && empty_since_previous {
+                out.push('\n');
+            } else {
+                out.push_str("\n\n");
+            }
+        }
+        out.push_str(&text);
+        previous_was_plain = Some(is_plain);
+        empty_since_previous = false;
+    }
+    out
+}
+
 /// Wrap an ordered-list numeral in its delimiter: `n.`, `n)`, or `(n)`.
 pub(crate) fn wrap_delim(numeral: &str, delim: &ListNumberDelim) -> String {
     match delim {

--- a/crates/oxidoc-writers/src/common.rs
+++ b/crates/oxidoc-writers/src/common.rs
@@ -7,7 +7,7 @@
 //! for this toolbox, so unused-item warnings are allowed here rather than gated per item.
 #![allow(dead_code)]
 
-use oxidoc_ast::{Attr, Block, ListNumberDelim, ListNumberStyle, QuoteType};
+use oxidoc_ast::{Attr, Block, Inline, ListNumberDelim, ListNumberStyle, QuoteType};
 
 /// Column at which inline content is wrapped: the default fill width.
 pub(crate) const FILL_COLUMN: usize = 72;
@@ -158,6 +158,90 @@ pub(crate) fn list_is_tight(items: &[Vec<Block>]) -> bool {
     items
         .iter()
         .all(|item| matches!(item.first(), None | Some(Block::Plain(_))))
+}
+
+/// A text writer that gathers footnotes inline and emits them as a trailing section. Each note is
+/// referenced by a numbered `[n]` marker; its body is rendered offset so the marker shifts only the
+/// first line's wrap point. The format supplies how a block and a marker-offset leading paragraph
+/// render; the marker numbering and slot bookkeeping are shared here.
+pub(crate) trait NotesHost {
+    /// The accumulated note bodies, indexed by note number minus one.
+    fn notes(&mut self) -> &mut Vec<String>;
+
+    /// Render a block at the given fill width.
+    fn render_block(&mut self, block: &Block, width: usize) -> String;
+
+    /// Render a leading paragraph's text with its first line beginning `initial` columns in.
+    fn render_offset_paragraph(
+        &mut self,
+        inlines: &[Inline],
+        width: usize,
+        initial: usize,
+    ) -> String;
+
+    /// Record a footnote: reserve its slot before rendering (so nested notes number after it), fill
+    /// the slot with the assembled body, and return the inline `[n]` marker.
+    fn record_note(&mut self, blocks: &[Block]) -> String {
+        let index = self.notes().len();
+        self.notes().push(String::new());
+        let marker = format!("[{}]", index + 1);
+        let field = marker.chars().count() + 1;
+        let body = self.note_body(blocks, field);
+        let rendered = if body.is_empty() {
+            marker.clone()
+        } else {
+            format!("{marker} {body}")
+        };
+        if let Some(slot) = self.notes().get_mut(index) {
+            *slot = rendered;
+        }
+        marker
+    }
+
+    /// Render a footnote's body: the first block's opening line is offset by the marker width, every
+    /// later block and continuation line sits at the margin.
+    fn note_body(&mut self, blocks: &[Block], initial: usize) -> String {
+        let rendered = blocks
+            .iter()
+            .enumerate()
+            .map(|(position, block)| {
+                let is_plain = matches!(block, Block::Plain(_));
+                let text = if position == 0 {
+                    self.note_block_offset(block, FILL_COLUMN, initial)
+                } else {
+                    self.render_block(block, FILL_COLUMN)
+                };
+                (is_plain, text)
+            })
+            .collect();
+        join_loose(rendered)
+    }
+
+    /// Render a block whose first line begins `initial` columns in. Only a leading paragraph wraps,
+    /// so the offset is meaningful for it alone; other block kinds render at the margin.
+    fn note_block_offset(&mut self, block: &Block, width: usize, initial: usize) -> String {
+        match block {
+            Block::Plain(inlines) | Block::Para(inlines) => {
+                self.render_offset_paragraph(inlines, width, initial)
+            }
+            other => self.render_block(other, width),
+        }
+    }
+}
+
+/// Append a gathered footnote section to a rendered body, separated by a blank line, and trim the
+/// trailing newlines. With no notes this just trims the body.
+pub(crate) fn append_notes(body: String, notes: &[String]) -> String {
+    let mut out = body;
+    if !notes.is_empty() {
+        let section = notes.join("\n\n");
+        out = if out.is_empty() {
+            section
+        } else {
+            format!("{out}\n\n{section}")
+        };
+    }
+    out.trim_end_matches('\n').to_owned()
 }
 
 /// Whether a list is loose — at least one item carries a top-level paragraph. A loose list's items

--- a/crates/oxidoc-writers/src/common.rs
+++ b/crates/oxidoc-writers/src/common.rs
@@ -463,6 +463,59 @@ pub(crate) fn is_uri_scheme(scheme: &str) -> bool {
         && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
 }
 
+/// Whether `text` is made up solely of URI-permitted characters with every `%` introducing a
+/// two-digit hex escape. ASCII alphanumerics and the unreserved, sub-delimiter, and generic-delimiter
+/// punctuation are permitted; non-ASCII characters are permitted only when `allow_non_ascii` is set.
+pub(crate) fn is_percent_escaped_uri(text: &str, allow_non_ascii: bool) -> bool {
+    let chars: Vec<char> = text.chars().collect();
+    let mut index = 0;
+    while let Some(&ch) = chars.get(index) {
+        if ch == '%' {
+            let two_hex = chars.get(index + 1).is_some_and(char::is_ascii_hexdigit)
+                && chars.get(index + 2).is_some_and(char::is_ascii_hexdigit);
+            if !two_hex {
+                return false;
+            }
+            index += 3;
+            continue;
+        }
+        if !is_uri_char(ch, allow_non_ascii) {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}
+
+fn is_uri_char(ch: char, allow_non_ascii: bool) -> bool {
+    if !ch.is_ascii() {
+        return allow_non_ascii;
+    }
+    ch.is_ascii_alphanumeric()
+        || matches!(
+            ch,
+            '-' | '.'
+                | '_'
+                | '~'
+                | ':'
+                | '/'
+                | '?'
+                | '#'
+                | '@'
+                | '!'
+                | '$'
+                | '&'
+                | '\''
+                | '('
+                | ')'
+                | '*'
+                | '+'
+                | ','
+                | ';'
+                | '='
+        )
+}
+
 /// Escape the XML/HTML metacharacters `&`, `<`, and `>` to their entities, and additionally `"` when
 /// `escape_quotes` is set (as in an attribute value).
 pub(crate) fn escape_xml(text: &str, escape_quotes: bool) -> String {

--- a/crates/oxidoc-writers/src/common.rs
+++ b/crates/oxidoc-writers/src/common.rs
@@ -479,6 +479,33 @@ pub(crate) fn escape_xml(text: &str, escape_quotes: bool) -> String {
     out
 }
 
+/// Escape an HTML attribute value: `&`, `<`, `>`, and `"` to their entities.
+pub(crate) fn escape_attr(text: &str) -> String {
+    escape_xml(text, true)
+}
+
+/// Render an [`Attr`] to an HTML attribute string (a leading space per attribute, empty when blank):
+/// `id`, then `class`, then key/value pairs, with unrecognized keys `data-` prefixed.
+pub(crate) fn render_html_attr(attr: &Attr) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    if !attr.id.is_empty() {
+        let _ = write!(out, " id=\"{}\"", escape_attr(&attr.id));
+    }
+    if !attr.classes.is_empty() {
+        let _ = write!(out, " class=\"{}\"", escape_attr(&attr.classes.join(" ")));
+    }
+    for (key, value) in &attr.attributes {
+        let name = if is_known_attribute(key) {
+            key.clone()
+        } else {
+            format!("data-{key}")
+        };
+        let _ = write!(out, " {name}=\"{}\"", escape_attr(value));
+    }
+    out
+}
+
 /// Whether an attribute name is emitted verbatim in HTML output. Recognized names, the `data-`/`aria-`
 /// prefixes, and a few namespaced names pass through; any other key/value attribute is `data-`
 /// prefixed by the caller.

--- a/crates/oxidoc-writers/src/commonmark.rs
+++ b/crates/oxidoc-writers/src/commonmark.rs
@@ -11,8 +11,8 @@ use oxidoc_ast::{Attr, Block, Document, Format, Inline, ListAttributes, Target, 
 use oxidoc_core::{Result, Writer, WriterOptions};
 
 use crate::common::{
-    FILL_COLUMN, Piece, escape_xml, fill, fill_offset, indent_block, is_known_attribute, is_loose,
-    item_separator, join_loose, offset_as_i32, ordered_marker, quote_marks,
+    FILL_COLUMN, NotesHost, Piece, append_notes, escape_xml, fill, fill_offset, indent_block,
+    is_known_attribute, is_loose, item_separator, offset_as_i32, ordered_marker, quote_marks,
 };
 
 /// Renders a document to `CommonMark` text.
@@ -23,16 +23,7 @@ impl Writer for CommonmarkWriter {
     fn write(&self, document: &Document, _options: &WriterOptions) -> Result<String> {
         let mut state = State::default();
         let body = state.blocks_to_string(&document.blocks, FILL_COLUMN);
-        let mut out = body;
-        if !state.footnotes.is_empty() {
-            let notes = state.footnotes.join("\n\n");
-            out = if out.is_empty() {
-                notes
-            } else {
-                format!("{out}\n\n{notes}")
-            };
-        }
-        Ok(out.trim_end_matches('\n').to_owned())
+        Ok(append_notes(body, &state.footnotes))
     }
 }
 
@@ -272,7 +263,10 @@ impl State {
                     out.push(Piece::Text("</span>".to_owned()));
                 }
             }
-            Inline::Note(blocks) => self.note(blocks, out),
+            Inline::Note(blocks) => {
+                let marker = self.record_note(blocks);
+                out.push(Piece::Text(marker));
+            }
         }
     }
 
@@ -332,53 +326,25 @@ impl State {
             render_attr(attr),
         )));
     }
+}
 
-    fn note(&mut self, blocks: &[Block], out: &mut Vec<Piece>) {
-        let index = self.footnotes.len();
-        self.footnotes.push(String::new());
-        let marker = format!("[{}]", index + 1);
-        let field = marker.chars().count() + 1;
-        let body = self.note_body(blocks, field);
-        let rendered = if body.is_empty() {
-            marker.clone()
-        } else {
-            format!("{marker} {body}")
-        };
-        if let Some(slot) = self.footnotes.get_mut(index) {
-            *slot = rendered;
-        }
-        out.push(Piece::Text(marker));
+impl NotesHost for State {
+    fn notes(&mut self) -> &mut Vec<String> {
+        &mut self.footnotes
     }
 
-    /// Render a footnote's body. The marker the caller prepends shifts only the first line's wrap
-    /// point (modeled with `initial`); continuation lines and later blocks sit at the margin.
-    fn note_body(&mut self, blocks: &[Block], initial: usize) -> String {
-        let rendered = blocks
-            .iter()
-            .enumerate()
-            .map(|(position, block)| {
-                let is_plain = matches!(block, Block::Plain(_));
-                let text = if position == 0 {
-                    self.block_offset(block, FILL_COLUMN, initial)
-                } else {
-                    self.block(block, FILL_COLUMN)
-                };
-                (is_plain, text)
-            })
-            .collect();
-        join_loose(rendered)
+    fn render_block(&mut self, block: &Block, width: usize) -> String {
+        self.block(block, width)
     }
 
-    /// Render a block whose first line begins `initial` columns in. Only text blocks wrap, so the
-    /// offset is meaningful for them alone; other block kinds render at the margin.
-    fn block_offset(&mut self, block: &Block, width: usize, initial: usize) -> String {
-        match block {
-            Block::Plain(inlines) | Block::Para(inlines) => {
-                let pieces = self.pieces(inlines, true);
-                fill_offset(&pieces, width, initial)
-            }
-            other => self.block(other, width),
-        }
+    fn render_offset_paragraph(
+        &mut self,
+        inlines: &[Inline],
+        width: usize,
+        initial: usize,
+    ) -> String {
+        let pieces = self.pieces(inlines, true);
+        fill_offset(&pieces, width, initial)
     }
 }
 

--- a/crates/oxidoc-writers/src/commonmark.rs
+++ b/crates/oxidoc-writers/src/commonmark.rs
@@ -11,8 +11,8 @@ use oxidoc_ast::{Attr, Block, Document, Format, Inline, ListAttributes, Target, 
 use oxidoc_core::{Result, Writer, WriterOptions};
 
 use crate::common::{
-    FILL_COLUMN, NotesHost, Piece, append_notes, escape_xml, fill, fill_offset, indent_block,
-    is_known_attribute, is_loose, item_separator, offset_as_i32, ordered_marker, quote_marks,
+    FILL_COLUMN, NotesHost, Piece, append_notes, escape_attr, fill, fill_offset, indent_block,
+    is_loose, item_separator, offset_as_i32, ordered_marker, quote_marks, render_html_attr,
 };
 
 /// Renders a document to `CommonMark` text.
@@ -99,7 +99,7 @@ impl State {
             Block::HorizontalRule => "-".repeat(FILL_COLUMN),
             Block::Div(attr, blocks) => {
                 let body = self.blocks_to_string(blocks, width);
-                format!("<div{}>\n\n{body}\n\n</div>", render_attr(attr))
+                format!("<div{}>\n\n{body}\n\n</div>", render_html_attr(attr))
             }
             Block::LineBlock(lines) => self.line_block(lines),
             Block::Figure(_, _, _) => todo!("commonmark writer: render figures as HTML fallback"),
@@ -258,7 +258,7 @@ impl State {
                 if attr_is_empty(attr) {
                     self.extend_pieces(inlines, out, false);
                 } else {
-                    out.push(Piece::Text(format!("<span{}>", render_attr(attr))));
+                    out.push(Piece::Text(format!("<span{}>", render_html_attr(attr))));
                     self.extend_pieces(inlines, out, false);
                     out.push(Piece::Text("</span>".to_owned()));
                 }
@@ -295,7 +295,7 @@ impl State {
             out.push(Piece::Text(format!(
                 "<a href=\"{}\"{}{}>",
                 escape_attr(&target.url),
-                render_attr(attr),
+                render_html_attr(attr),
                 title_attr(&target.title)
             )));
             self.extend_pieces(inlines, out, false);
@@ -323,7 +323,7 @@ impl State {
             "<img src=\"{}\"{}{}{alt_attr} />",
             escape_attr(&target.url),
             title_attr(&target.title),
-            render_attr(attr),
+            render_html_attr(attr),
         )));
     }
 }
@@ -592,33 +592,6 @@ fn title_attr(title: &Text) -> String {
     } else {
         format!(" title=\"{}\"", escape_attr(title))
     }
-}
-
-/// Render an [`Attr`] to its HTML attribute string (leading space per attribute, empty when blank):
-/// `id`, then `class`, then key/value pairs, with unrecognized keys `data-` prefixed.
-fn render_attr(attr: &Attr) -> String {
-    use std::fmt::Write as _;
-    let mut out = String::new();
-    if !attr.id.is_empty() {
-        let _ = write!(out, " id=\"{}\"", escape_attr(&attr.id));
-    }
-    if !attr.classes.is_empty() {
-        let _ = write!(out, " class=\"{}\"", escape_attr(&attr.classes.join(" ")));
-    }
-    for (key, value) in &attr.attributes {
-        let name = if is_known_attribute(key) {
-            key.clone()
-        } else {
-            format!("data-{key}")
-        };
-        let _ = write!(out, " {name}=\"{}\"", escape_attr(value));
-    }
-    out
-}
-
-/// Escape an HTML attribute value: `&`, `<`, `>`, and `"` to their entities.
-fn escape_attr(text: &str) -> String {
-    escape_xml(text, true)
 }
 
 /// Escape the `CommonMark`-significant characters of running text. The characters that can open inline

--- a/crates/oxidoc-writers/src/commonmark.rs
+++ b/crates/oxidoc-writers/src/commonmark.rs
@@ -551,113 +551,120 @@ fn title_attr(title: &Text) -> String {
 /// additionally escaped if it would begin a block construct (a list item or the delimiter of an
 /// ordered-list marker).
 fn escape_str(text: &str, line_start: bool) -> String {
-    let chars: Vec<char> = text.chars().collect();
     let leading = if line_start {
-        leading_escape(&chars)
+        leading_escape(text)
     } else {
         None
     };
     let mut out = String::with_capacity(text.len());
-    let mut index = 0;
-    while let Some(&ch) = chars.get(index) {
-        if Some(index) == leading {
+    let mut prev: Option<char> = None;
+    let mut iter = text.char_indices().peekable();
+    while let Some((offset, ch)) = iter.next() {
+        if Some(offset) == leading {
             out.push('\\');
             out.push(ch);
-            index += 1;
+            prev = Some(ch);
             continue;
         }
+        let next = iter.peek().map(|&(_, following)| following);
+        let tail = || text.get(offset..).unwrap_or_default();
         match ch {
-            '#' if index == 0 => out.push_str("\\#"),
-            '!' if matches!(chars.get(index + 1), Some('[')) => out.push_str("\\!"),
-            '[' if index > 0 && chars.get(index - 1) == Some(&'!') => out.push('['),
+            '#' if offset == 0 => out.push_str("\\#"),
+            '!' if next == Some('[') => out.push_str("\\!"),
+            '[' if prev == Some('!') => out.push('['),
             '`' | '*' | '[' | ']' | '<' | '>' => {
                 out.push('\\');
                 out.push(ch);
             }
-            '&' if begins_character_reference(&chars, index) => out.push_str("\\&"),
-            '&' if begins_named_entity(&chars, index) => out.push_str("\\&"),
-            '_' if is_word_boundary(&chars, index) => out.push_str("\\_"),
-            '\\' => match chars.get(index + 1) {
-                Some(next) if next.is_alphanumeric() => out.push('\\'),
-                Some(_) => {
+            '&' if begins_character_reference(tail()) => out.push_str("\\&"),
+            '&' if begins_named_entity(tail()) => out.push_str("\\&"),
+            '_' if is_word_boundary(prev, next) => out.push_str("\\_"),
+            '\\' => match next {
+                Some(following) if following.is_alphanumeric() => out.push('\\'),
+                Some(following) => {
                     out.push_str("\\\\");
-                    index += 1;
+                    iter.next();
+                    prev = Some(following);
+                    continue;
                 }
                 None => out.push_str("\\\\"),
             },
             other => out.push(other),
         }
-        index += 1;
+        prev = Some(ch);
     }
     out
 }
 
-/// Whether an `&` at `index` opens a syntactically valid numeric character reference: `&#` followed by
-/// at least one decimal digit, or `&#x`/`&#X` followed by at least one hex digit, terminated by `;`.
-fn begins_character_reference(chars: &[char], index: usize) -> bool {
-    if chars.get(index) != Some(&'&') || chars.get(index + 1) != Some(&'#') {
+/// Whether `text` opens with a syntactically valid numeric character reference: `&#` followed by at
+/// least one decimal digit, or `&#x`/`&#X` followed by at least one hex digit, terminated by `;`. The
+/// reference syntax is wholly ASCII, so this scans bytes.
+fn begins_character_reference(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    if bytes.first() != Some(&b'&') || bytes.get(1) != Some(&b'#') {
         return false;
     }
-    let hex = matches!(chars.get(index + 2), Some('x' | 'X'));
-    let start = if hex { index + 3 } else { index + 2 };
+    let hex = matches!(bytes.get(2), Some(b'x' | b'X'));
+    let start = if hex { 3 } else { 2 };
     let mut pos = start;
-    while chars.get(pos).is_some_and(|ch| {
+    while bytes.get(pos).is_some_and(|byte| {
         if hex {
-            ch.is_ascii_hexdigit()
+            byte.is_ascii_hexdigit()
         } else {
-            ch.is_ascii_digit()
+            byte.is_ascii_digit()
         }
     }) {
         pos += 1;
     }
-    pos > start && chars.get(pos) == Some(&';')
+    pos > start && bytes.get(pos) == Some(&b';')
 }
 
-/// Whether an `&` at `index` opens a valid named character reference: an ASCII letter followed by
-/// further ASCII alphanumerics and a `;`, whose name is one the format recognizes.
-fn begins_named_entity(chars: &[char], index: usize) -> bool {
-    if chars.get(index) != Some(&'&') {
+/// Whether `text` opens with a valid named character reference: an ASCII letter followed by further
+/// ASCII alphanumerics and a `;`, whose name is one the format recognizes. The reference syntax is
+/// wholly ASCII, so this scans bytes.
+fn begins_named_entity(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    if bytes.first() != Some(&b'&') {
         return false;
     }
-    let start = index + 1;
-    if !chars.get(start).is_some_and(char::is_ascii_alphabetic) {
+    if !bytes.get(1).is_some_and(u8::is_ascii_alphabetic) {
         return false;
     }
-    let mut pos = start + 1;
-    while chars.get(pos).is_some_and(char::is_ascii_alphanumeric) {
+    let mut pos = 2;
+    while bytes.get(pos).is_some_and(u8::is_ascii_alphanumeric) {
         pos += 1;
     }
-    if chars.get(pos) != Some(&';') {
+    if bytes.get(pos) != Some(&b';') {
         return false;
     }
-    let name: String = chars.get(start..pos).unwrap_or_default().iter().collect();
-    entity_names::ENTITY_NAMES
-        .binary_search(&name.as_str())
-        .is_ok()
+    let name = text.get(1..pos).unwrap_or_default();
+    entity_names::ENTITY_NAMES.binary_search(&name).is_ok()
 }
 
 mod entity_names {
     include!(concat!(env!("OUT_DIR"), "/entity_names.rs"));
 }
 
-/// The index of a leading character that must be escaped because it would otherwise start a block
-/// construct: a `#` header marker, a `-`/`+` bullet marker followed by a space, or the `.`/`)`
-/// delimiter terminating a leading run of digits that forms an ordered-list marker.
-fn leading_escape(chars: &[char]) -> Option<usize> {
-    match chars.first()? {
+/// The byte offset of a leading character that must be escaped because it would otherwise start a
+/// block construct: a `#` header marker, a `-`/`+` bullet marker followed by a space, or the `.`/`)`
+/// delimiter terminating a leading run of digits that forms an ordered-list marker. The offset always
+/// falls inside an ASCII prefix, so it doubles as a character index for comparison.
+fn leading_escape(text: &str) -> Option<usize> {
+    let mut chars = text.char_indices();
+    let (_, first) = chars.next()?;
+    match first {
         '#' => Some(0),
-        '-' | '+' if chars.len() == 1 || chars.get(1).is_some_and(|ch| ch.is_whitespace()) => {
-            Some(0)
+        '-' | '+' => {
+            let followed_by_space = chars.next().is_none_or(|(_, ch)| ch.is_whitespace());
+            followed_by_space.then_some(0)
         }
         first if first.is_ascii_digit() => {
-            let delim = chars.iter().position(|ch| !ch.is_ascii_digit())?;
-            if delim > 9 {
+            let (delim_offset, delim) = chars.by_ref().find(|(_, ch)| !ch.is_ascii_digit())?;
+            if delim_offset > 9 {
                 return None;
             }
-            if matches!(chars.get(delim), Some('.' | ')'))
-                && chars.get(delim + 1).is_none_or(|ch| ch.is_whitespace())
-            {
-                Some(delim)
+            if matches!(delim, '.' | ')') && chars.next().is_none_or(|(_, ch)| ch.is_whitespace()) {
+                Some(delim_offset)
             } else {
                 None
             }
@@ -666,14 +673,10 @@ fn leading_escape(chars: &[char]) -> Option<usize> {
     }
 }
 
-/// Whether an `_` at `index` sits at a word boundary: at least one neighbor (treating the ends of
-/// the run as boundaries) is not alphanumeric, so the `_` could flank emphasis.
-fn is_word_boundary(chars: &[char], index: usize) -> bool {
-    let before = index
-        .checked_sub(1)
-        .and_then(|previous| chars.get(previous));
-    let after = chars.get(index + 1);
-    let alnum = |ch: Option<&char>| ch.is_some_and(|c| c.is_alphanumeric());
+/// Whether an `_` with the given neighbors sits at a word boundary: at least one neighbor (treating
+/// the ends of the run as boundaries) is not alphanumeric, so the `_` could flank emphasis.
+fn is_word_boundary(before: Option<char>, after: Option<char>) -> bool {
+    let alnum = |ch: Option<char>| ch.is_some_and(char::is_alphanumeric);
     !(alnum(before) && alnum(after))
 }
 /// Recognized URI schemes, sorted for binary search. A bare URI opens with one of these.

--- a/crates/oxidoc-writers/src/commonmark.rs
+++ b/crates/oxidoc-writers/src/commonmark.rs
@@ -12,7 +12,8 @@ use oxidoc_core::{Result, Writer, WriterOptions};
 
 use crate::common::{
     FILL_COLUMN, NotesHost, Piece, append_notes, escape_attr, fill, fill_offset, indent_block,
-    is_loose, item_separator, offset_as_i32, ordered_marker, quote_marks, render_html_attr,
+    is_loose, is_percent_escaped_uri, item_separator, offset_as_i32, ordered_marker, quote_marks,
+    render_html_attr,
 };
 
 /// Renders a document to `CommonMark` text.
@@ -508,67 +509,13 @@ fn is_uri(text: &str) -> bool {
     let Some(colon) = text.find(':') else {
         return false;
     };
-    text.get(..colon).is_some_and(is_known_scheme) && has_valid_uri_chars(text)
+    text.get(..colon).is_some_and(is_known_scheme) && is_percent_escaped_uri(text, true)
 }
 
 /// Whether `scheme` is one of the recognized URI schemes (compared case-insensitively).
 fn is_known_scheme(scheme: &str) -> bool {
     let lowered = scheme.to_ascii_lowercase();
     URI_SCHEMES.binary_search(&lowered.as_str()).is_ok()
-}
-
-/// Whether every character of `text` is permitted in a URI: any non-ASCII character, the unreserved
-/// and reserved ASCII punctuation, an ASCII alphanumeric, or a percent escape (`%` and two hex
-/// digits).
-fn has_valid_uri_chars(text: &str) -> bool {
-    let chars: Vec<char> = text.chars().collect();
-    let mut index = 0;
-    while let Some(&ch) = chars.get(index) {
-        if ch == '%' {
-            let valid = chars.get(index + 1).is_some_and(char::is_ascii_hexdigit)
-                && chars.get(index + 2).is_some_and(char::is_ascii_hexdigit);
-            if !valid {
-                return false;
-            }
-            index += 3;
-            continue;
-        }
-        if !is_uri_char(ch) {
-            return false;
-        }
-        index += 1;
-    }
-    true
-}
-
-/// Whether a single character may appear literally in a URI (percent escapes aside).
-fn is_uri_char(ch: char) -> bool {
-    if !ch.is_ascii() {
-        return true;
-    }
-    ch.is_ascii_alphanumeric()
-        || matches!(
-            ch,
-            '-' | '.'
-                | '_'
-                | '~'
-                | ':'
-                | '/'
-                | '?'
-                | '#'
-                | '@'
-                | '!'
-                | '$'
-                | '&'
-                | '\''
-                | '('
-                | ')'
-                | '*'
-                | '+'
-                | ','
-                | ';'
-                | '='
-        )
 }
 
 fn attr_is_empty(attr: &Attr) -> bool {

--- a/crates/oxidoc-writers/src/commonmark.rs
+++ b/crates/oxidoc-writers/src/commonmark.rs
@@ -11,8 +11,8 @@ use oxidoc_ast::{Attr, Block, Document, Format, Inline, ListAttributes, Target, 
 use oxidoc_core::{Result, Writer, WriterOptions};
 
 use crate::common::{
-    FILL_COLUMN, Piece, escape_xml, fill, fill_offset, indent_block, is_known_attribute,
-    list_is_tight, offset_as_i32, ordered_marker, quote_marks,
+    FILL_COLUMN, Piece, escape_xml, fill, fill_offset, indent_block, is_known_attribute, is_loose,
+    item_separator, join_loose, offset_as_i32, ordered_marker, quote_marks,
 };
 
 /// Renders a document to `CommonMark` text.
@@ -382,38 +382,6 @@ impl State {
     }
 }
 
-/// Join already-rendered blocks with the document's default blank-line spacing, dropping blocks that
-/// produced no output. A [`Block::Plain`] contributes only a single newline (not a blank line)
-/// before the next visible block when an empty block falls between them.
-fn join_loose(rendered: Vec<(bool, String)>) -> String {
-    let mut out = String::new();
-    let mut previous_was_plain: Option<bool> = None;
-    let mut empty_since_previous = false;
-    for (is_plain, text) in rendered {
-        if text.is_empty() {
-            if previous_was_plain.is_some() {
-                empty_since_previous = true;
-            }
-            continue;
-        }
-        if let Some(was_plain) = previous_was_plain {
-            if was_plain && empty_since_previous {
-                out.push('\n');
-            } else {
-                out.push_str("\n\n");
-            }
-        }
-        out.push_str(&text);
-        previous_was_plain = Some(is_plain);
-        empty_since_previous = false;
-    }
-    out
-}
-
-fn is_loose(items: &[Vec<Block>]) -> bool {
-    !list_is_tight(items)
-}
-
 /// Whether an HTML comment must separate two consecutive blocks so the second is not absorbed into
 /// the first: two lists of the same kind would merge into one, and an indented code block following
 /// a list would read as a continuation of the final item.
@@ -445,10 +413,6 @@ fn offset_horizontal_rule(item: &[Block], body: String) -> String {
 /// keep it on the line with the preceding word.
 fn next_is_para_interrupting_marker(inline: Option<&Inline>) -> bool {
     matches!(inline, Some(Inline::Str(text)) if text == "1." || text == "1)")
-}
-
-fn item_separator(loose: bool) -> &'static str {
-    if loose { "\n\n" } else { "\n" }
 }
 
 /// Prefix every line of a blockquote body with `> ` (a bare `>` on an otherwise empty line).

--- a/crates/oxidoc-writers/src/html.rs
+++ b/crates/oxidoc-writers/src/html.rs
@@ -9,7 +9,7 @@ use std::fmt::Write as _;
 
 use oxidoc_ast::{
     Alignment, Attr, Block, Caption, Cell, ColSpec, ColWidth, Document, Inline, ListAttributes,
-    ListNumberStyle, MathType, Row, Table, TableBody, Target, Text,
+    ListNumberStyle, MathType, Row, Table, TableBody, Target, Text, to_plain_text,
 };
 use oxidoc_core::{Result, Writer, WriterOptions};
 
@@ -361,7 +361,7 @@ impl State {
 }
 
 fn image(attr: &Attr, inlines: &[Inline], target: &Target) -> String {
-    let alt = inlines_to_plain(inlines);
+    let alt = to_plain_text(inlines);
     let alt_attr = if alt.is_empty() {
         String::new()
     } else {
@@ -673,32 +673,4 @@ fn escape_text(text: &str) -> String {
 /// to a `<pre><code>` block's body.
 fn escape_attr(text: &str) -> String {
     escape(text, true)
-}
-
-/// The plain-text projection of an inline sequence, used for an image's `alt` attribute: textual
-/// content is kept, formatting wrappers are flattened, and breaks become spaces.
-fn inlines_to_plain(inlines: &[Inline]) -> String {
-    let mut out = String::new();
-    for inline in inlines {
-        match inline {
-            Inline::Str(text) | Inline::Code(_, text) | Inline::Math(_, text) => {
-                out.push_str(text);
-            }
-            Inline::Space | Inline::SoftBreak | Inline::LineBreak => out.push(' '),
-            Inline::Emph(xs)
-            | Inline::Strong(xs)
-            | Inline::Strikeout(xs)
-            | Inline::Superscript(xs)
-            | Inline::Subscript(xs)
-            | Inline::Underline(xs)
-            | Inline::SmallCaps(xs)
-            | Inline::Quoted(_, xs)
-            | Inline::Span(_, xs)
-            | Inline::Link(_, xs, _)
-            | Inline::Image(_, xs, _)
-            | Inline::Cite(_, xs) => out.push_str(&inlines_to_plain(xs)),
-            Inline::RawInline(..) | Inline::Note(_) => {}
-        }
-    }
-    out
 }

--- a/crates/oxidoc-writers/src/html.rs
+++ b/crates/oxidoc-writers/src/html.rs
@@ -22,8 +22,9 @@ pub struct HtmlWriter;
 impl Writer for HtmlWriter {
     fn write(&self, document: &Document, _options: &WriterOptions) -> Result<String> {
         let mut state = State::default();
-        let mut out = state.blocks(&document.blocks);
-        out.push_str(&state.footnote_section());
+        let mut out = String::new();
+        state.blocks(&mut out, &document.blocks);
+        state.push_footnote_section(&mut out);
         let filled = restore(&reflow(&out));
         Ok(filled.trim_end_matches('\n').to_owned())
     }
@@ -62,129 +63,146 @@ struct State {
 }
 
 impl State {
-    /// Render a block sequence, one block per line.
-    fn blocks(&mut self, blocks: &[Block]) -> String {
-        let rendered: Vec<String> = blocks.iter().map(|block| self.block(block)).collect();
-        rendered.join("\n")
+    /// Render a block sequence into `out`, one block per line.
+    fn blocks(&mut self, out: &mut String, blocks: &[Block]) {
+        for (index, block) in blocks.iter().enumerate() {
+            if index > 0 {
+                out.push('\n');
+            }
+            self.block(out, block);
+        }
     }
 
-    fn block(&mut self, block: &Block) -> String {
+    fn block(&mut self, out: &mut String, block: &Block) {
         match block {
-            Block::Plain(inlines) => self.inlines(inlines),
-            Block::Para(inlines) => format!("<p>{}</p>", self.inlines(inlines)),
+            Block::Plain(inlines) => self.inlines(out, inlines),
+            Block::Para(inlines) => {
+                out.push_str("<p>");
+                self.inlines(out, inlines);
+                out.push_str("</p>");
+            }
             Block::Header(level, attr, inlines) => {
                 let tag = header_tag(*level);
-                format!(
-                    "<{tag}{}>{}</{tag}>",
-                    render_attr(attr, AttrOrder::Header),
-                    self.inlines(inlines)
-                )
+                let _ = write!(out, "<{tag}{}>", render_attr(attr, AttrOrder::Header));
+                self.inlines(out, inlines);
+                let _ = write!(out, "</{tag}>");
             }
-            Block::CodeBlock(attr, text) => format!(
-                "<pre{}><code>{}</code></pre>",
-                render_attr(attr, AttrOrder::Standard),
-                escape_attr(text)
-            ),
-            Block::RawBlock(format, text) => raw_passthrough(&format.0, text),
+            Block::CodeBlock(attr, text) => {
+                let _ = write!(
+                    out,
+                    "<pre{}><code>{}</code></pre>",
+                    render_attr(attr, AttrOrder::Standard),
+                    escape_attr(text)
+                );
+            }
+            Block::RawBlock(format, text) => out.push_str(&raw_passthrough(&format.0, text)),
             Block::BlockQuote(blocks) => {
-                format!("<blockquote>\n{}\n</blockquote>", self.blocks(blocks))
+                out.push_str("<blockquote>\n");
+                self.blocks(out, blocks);
+                out.push_str("\n</blockquote>");
             }
-            Block::BulletList(items) => self.bullet_list(items),
-            Block::OrderedList(attrs, items) => self.ordered_list(attrs, items),
-            Block::DefinitionList(items) => self.definition_list(items),
-            Block::Div(attr, blocks) => format!(
-                "<div{}>\n{}\n</div>",
-                render_attr(attr, AttrOrder::Standard),
-                self.blocks(blocks)
-            ),
-            Block::Figure(attr, caption, blocks) => self.figure(attr, caption, blocks),
-            Block::HorizontalRule => "<hr />".to_owned(),
-            Block::LineBlock(lines) => self.line_block(lines),
-            Block::Table(table) => self.table(table),
+            Block::BulletList(items) => self.bullet_list(out, items),
+            Block::OrderedList(attrs, items) => self.ordered_list(out, attrs, items),
+            Block::DefinitionList(items) => self.definition_list(out, items),
+            Block::Div(attr, blocks) => {
+                let _ = writeln!(out, "<div{}>", render_attr(attr, AttrOrder::Standard));
+                self.blocks(out, blocks);
+                out.push_str("\n</div>");
+            }
+            Block::Figure(attr, caption, blocks) => self.figure(out, attr, caption, blocks),
+            Block::HorizontalRule => out.push_str("<hr />"),
+            Block::LineBlock(lines) => self.line_block(out, lines),
+            Block::Table(table) => self.table(out, table),
         }
     }
 
-    fn bullet_list(&mut self, items: &[Vec<Block>]) -> String {
-        let lis = self.list_items(items);
-        format!("<ul>\n{}\n</ul>", lis.join("\n"))
+    fn bullet_list(&mut self, out: &mut String, items: &[Vec<Block>]) {
+        out.push_str("<ul>\n");
+        self.list_items(out, items);
+        out.push_str("\n</ul>");
     }
 
-    fn ordered_list(&mut self, attrs: &ListAttributes, items: &[Vec<Block>]) -> String {
-        let mut open = String::from("<ol");
+    fn ordered_list(&mut self, out: &mut String, attrs: &ListAttributes, items: &[Vec<Block>]) {
+        out.push_str("<ol");
         if attrs.start != 1 {
-            let _ = write!(open, " start=\"{}\"", attrs.start);
+            let _ = write!(out, " start=\"{}\"", attrs.start);
         }
         if matches!(attrs.style, ListNumberStyle::Example) {
-            open.push_str(" class=\"example\"");
+            out.push_str(" class=\"example\"");
         }
         if let Some(kind) = ordered_list_type(&attrs.style) {
-            let _ = write!(open, " type=\"{kind}\"");
+            let _ = write!(out, " type=\"{kind}\"");
         }
-        open.push('>');
-        let lis = self.list_items(items);
-        format!("{open}\n{}\n</ol>", lis.join("\n"))
+        out.push_str(">\n");
+        self.list_items(out, items);
+        out.push_str("\n</ol>");
     }
 
     /// Render each list item's blocks (newline-joined, no surrounding padding) wrapped in `<li>`.
-    fn list_items(&mut self, items: &[Vec<Block>]) -> Vec<String> {
-        items
-            .iter()
-            .map(|item| format!("<li>{}</li>", self.blocks(item)))
-            .collect()
+    fn list_items(&mut self, out: &mut String, items: &[Vec<Block>]) {
+        for (index, item) in items.iter().enumerate() {
+            if index > 0 {
+                out.push('\n');
+            }
+            out.push_str("<li>");
+            self.blocks(out, item);
+            out.push_str("</li>");
+        }
     }
 
-    fn definition_list(&mut self, items: &[(Vec<Inline>, Vec<Vec<Block>>)]) -> String {
-        let mut parts = Vec::new();
+    fn definition_list(&mut self, out: &mut String, items: &[(Vec<Inline>, Vec<Vec<Block>>)]) {
+        out.push_str("<dl>");
         for (term, definitions) in items {
-            parts.push(format!("<dt>{}</dt>", self.inlines(term)));
+            out.push_str("\n<dt>");
+            self.inlines(out, term);
+            out.push_str("</dt>");
             for definition in definitions {
-                parts.push(format!("<dd>\n{}\n</dd>", self.blocks(definition)));
+                out.push_str("\n<dd>\n");
+                self.blocks(out, definition);
+                out.push_str("\n</dd>");
             }
         }
-        format!("<dl>\n{}\n</dl>", parts.join("\n"))
+        out.push_str("\n</dl>");
     }
 
-    fn figure(&mut self, attr: &Attr, caption: &Caption, blocks: &[Block]) -> String {
-        let body = self.blocks(blocks);
-        let caption_html = if caption.long.is_empty() {
-            String::new()
-        } else {
+    fn figure(&mut self, out: &mut String, attr: &Attr, caption: &Caption, blocks: &[Block]) {
+        let _ = writeln!(out, "<figure{}>", render_attr(attr, AttrOrder::Standard));
+        self.blocks(out, blocks);
+        if !caption.long.is_empty() {
             let hidden = if is_implicit_figure(caption, blocks) {
                 " aria-hidden=\"true\""
             } else {
                 ""
             };
-            format!(
-                "\n<figcaption{hidden}>{}</figcaption>",
-                self.blocks(&caption.long)
-            )
-        };
-        format!(
-            "<figure{}>\n{body}{caption_html}\n</figure>",
-            render_attr(attr, AttrOrder::Standard)
-        )
+            let _ = write!(out, "\n<figcaption{hidden}>");
+            self.blocks(out, &caption.long);
+            out.push_str("</figcaption>");
+        }
+        out.push_str("\n</figure>");
     }
 
-    fn line_block(&mut self, lines: &[Vec<Inline>]) -> String {
-        let rendered: Vec<String> = lines.iter().map(|line| self.inlines(line)).collect();
-        format!(
-            "<div class=\"line-block\">{}</div>",
-            rendered.join("<br />\n")
-        )
+    fn line_block(&mut self, out: &mut String, lines: &[Vec<Inline>]) {
+        out.push_str("<div class=\"line-block\">");
+        for (index, line) in lines.iter().enumerate() {
+            if index > 0 {
+                out.push_str("<br />\n");
+            }
+            self.inlines(out, line);
+        }
+        out.push_str("</div>");
     }
 
-    fn table(&mut self, table: &Table) -> String {
-        let mut out = format!(
+    fn table(&mut self, out: &mut String, table: &Table) {
+        let _ = write!(
+            out,
             "<table{}{}>",
             render_attr(&table.attr, AttrOrder::Standard),
             table_width_style(&table.col_specs)
         );
         if !table.caption.long.is_empty() {
-            let _ = write!(
-                out,
-                "\n<caption>{}</caption>",
-                self.blocks(&table.caption.long)
-            );
+            out.push_str("\n<caption>");
+            self.blocks(out, &table.caption.long);
+            out.push_str("</caption>");
         }
         let aligns: Vec<Alignment> = table
             .col_specs
@@ -193,138 +211,173 @@ impl State {
             .collect();
         out.push_str(&colgroup(&table.col_specs));
         if !table.head.rows.is_empty() {
-            let rows = self.rows(&table.head.rows, &aligns, true);
-            let _ = write!(out, "\n<thead>\n{rows}\n</thead>");
+            out.push_str("\n<thead>\n");
+            self.rows(out, &table.head.rows, &aligns, true);
+            out.push_str("\n</thead>");
         }
         for body in &table.bodies {
-            out.push_str(&self.table_body(body, &aligns));
+            self.table_body(out, body, &aligns);
         }
         if !table.foot.rows.is_empty() {
-            let rows = self.rows(&table.foot.rows, &aligns, false);
-            let _ = write!(out, "\n<tfoot>\n{rows}\n</tfoot>");
+            out.push_str("\n<tfoot>\n");
+            self.rows(out, &table.foot.rows, &aligns, false);
+            out.push_str("\n</tfoot>");
         }
         out.push_str("\n</table>");
-        out
     }
 
-    fn table_body(&mut self, body: &TableBody, aligns: &[Alignment]) -> String {
-        let mut rows = self.rows_vec(&body.head, aligns, true);
-        rows.extend(self.rows_vec(&body.body, aligns, false));
-        format!("\n<tbody>\n{}\n</tbody>", rows.join("\n"))
+    fn table_body(&mut self, out: &mut String, body: &TableBody, aligns: &[Alignment]) {
+        out.push_str("\n<tbody>\n");
+        let mut first = true;
+        for row in &body.head {
+            if !first {
+                out.push('\n');
+            }
+            first = false;
+            self.row(out, row, aligns, true);
+        }
+        for row in &body.body {
+            if !first {
+                out.push('\n');
+            }
+            first = false;
+            self.row(out, row, aligns, false);
+        }
+        out.push_str("\n</tbody>");
     }
 
-    fn rows(&mut self, rows: &[Row], aligns: &[Alignment], header: bool) -> String {
-        self.rows_vec(rows, aligns, header).join("\n")
+    fn rows(&mut self, out: &mut String, rows: &[Row], aligns: &[Alignment], header: bool) {
+        for (index, row) in rows.iter().enumerate() {
+            if index > 0 {
+                out.push('\n');
+            }
+            self.row(out, row, aligns, header);
+        }
     }
 
-    fn rows_vec(&mut self, rows: &[Row], aligns: &[Alignment], header: bool) -> Vec<String> {
-        rows.iter()
-            .map(|row| {
-                let cells: Vec<String> = row
-                    .cells
-                    .iter()
-                    .enumerate()
-                    .map(|(index, cell)| self.cell(cell, aligns.get(index), header))
-                    .collect();
-                format!("<tr>\n{}\n</tr>", cells.join("\n"))
-            })
-            .collect()
+    fn row(&mut self, out: &mut String, row: &Row, aligns: &[Alignment], header: bool) {
+        out.push_str("<tr>\n");
+        for (index, cell) in row.cells.iter().enumerate() {
+            if index > 0 {
+                out.push('\n');
+            }
+            self.cell(out, cell, aligns.get(index), header);
+        }
+        out.push_str("\n</tr>");
     }
 
-    fn cell(&mut self, cell: &Cell, col_align: Option<&Alignment>, header: bool) -> String {
+    fn cell(&mut self, out: &mut String, cell: &Cell, col_align: Option<&Alignment>, header: bool) {
         let tag = if header { "th" } else { "td" };
         let effective = match &cell.align {
             Alignment::AlignDefault => col_align.unwrap_or(&Alignment::AlignDefault),
             explicit => explicit,
         };
-        let mut attrs = String::new();
+        let _ = write!(out, "<{tag}");
         if let Some(style) = alignment_style(effective) {
-            let _ = write!(attrs, "{BREAK}style=\"{style}\"");
+            let _ = write!(out, "{BREAK}style=\"{style}\"");
         }
         if cell.col_span != 1 {
-            let _ = write!(attrs, "{BREAK}colspan=\"{}\"", cell.col_span);
+            let _ = write!(out, "{BREAK}colspan=\"{}\"", cell.col_span);
         }
         if cell.row_span != 1 {
-            let _ = write!(attrs, "{BREAK}rowspan=\"{}\"", cell.row_span);
+            let _ = write!(out, "{BREAK}rowspan=\"{}\"", cell.row_span);
         }
-        format!("<{tag}{attrs}>{}</{tag}>", self.blocks(&cell.content))
+        out.push('>');
+        self.blocks(out, &cell.content);
+        let _ = write!(out, "</{tag}>");
     }
 
-    fn inlines(&mut self, inlines: &[Inline]) -> String {
-        inlines.iter().map(|inline| self.inline(inline)).collect()
+    fn inlines(&mut self, out: &mut String, inlines: &[Inline]) {
+        for inline in inlines {
+            self.inline(out, inline);
+        }
     }
 
-    fn inline(&mut self, inline: &Inline) -> String {
+    fn inline(&mut self, out: &mut String, inline: &Inline) {
         match inline {
-            Inline::Str(text) => escape_text(text),
-            Inline::Emph(inlines) => self.wrap("em", inlines),
-            Inline::Strong(inlines) => self.wrap("strong", inlines),
-            Inline::Strikeout(inlines) => self.wrap("del", inlines),
-            Inline::Superscript(inlines) => self.wrap("sup", inlines),
-            Inline::Subscript(inlines) => self.wrap("sub", inlines),
-            Inline::Underline(inlines) => self.wrap("u", inlines),
+            Inline::Str(text) => out.push_str(&escape_text(text)),
+            Inline::Emph(inlines) => self.wrap(out, "em", inlines),
+            Inline::Strong(inlines) => self.wrap(out, "strong", inlines),
+            Inline::Strikeout(inlines) => self.wrap(out, "del", inlines),
+            Inline::Superscript(inlines) => self.wrap(out, "sup", inlines),
+            Inline::Subscript(inlines) => self.wrap(out, "sub", inlines),
+            Inline::Underline(inlines) => self.wrap(out, "u", inlines),
             Inline::SmallCaps(inlines) => {
-                format!("<span class=\"smallcaps\">{}</span>", self.inlines(inlines))
+                out.push_str("<span class=\"smallcaps\">");
+                self.inlines(out, inlines);
+                out.push_str("</span>");
             }
             Inline::Quoted(kind, inlines) => {
                 let (open, close) = quote_marks(kind);
-                format!("{open}{}{close}", self.inlines(inlines))
+                out.push(open);
+                self.inlines(out, inlines);
+                out.push(close);
             }
-            Inline::Code(attr, text) => format!(
-                "<code{}>{}</code>",
-                render_attr(attr, AttrOrder::Standard),
-                escape_text(text)
-            ),
-            Inline::Space | Inline::SoftBreak => BREAK.to_string(),
-            Inline::LineBreak => "<br />\n".to_owned(),
+            Inline::Code(attr, text) => {
+                let _ = write!(
+                    out,
+                    "<code{}>{}</code>",
+                    render_attr(attr, AttrOrder::Standard),
+                    escape_text(text)
+                );
+            }
+            Inline::Space | Inline::SoftBreak => out.push(BREAK),
+            Inline::LineBreak => out.push_str("<br />\n"),
             Inline::Math(kind, text) => {
                 let (class, open, close) = match kind {
                     MathType::InlineMath => ("inline", "\\(", "\\)"),
                     MathType::DisplayMath => ("display", "\\[", "\\]"),
                 };
-                format!(
+                let _ = write!(
+                    out,
                     "<span class=\"math {class}\">{open}{}{close}</span>",
                     escape_text(text)
-                )
+                );
             }
-            Inline::RawInline(format, text) => raw_passthrough(&format.0, text),
-            Inline::Link(attr, inlines, target) => self.link(attr, inlines, target),
-            Inline::Image(attr, inlines, target) => image(attr, inlines, target),
-            Inline::Span(attr, inlines) => format!(
-                "<span{}>{}</span>",
-                render_attr(attr, AttrOrder::Standard),
-                self.inlines(inlines)
-            ),
+            Inline::RawInline(format, text) => out.push_str(&raw_passthrough(&format.0, text)),
+            Inline::Link(attr, inlines, target) => self.link(out, attr, inlines, target),
+            Inline::Image(attr, inlines, target) => out.push_str(&image(attr, inlines, target)),
+            Inline::Span(attr, inlines) => {
+                let _ = write!(out, "<span{}>", render_attr(attr, AttrOrder::Standard));
+                self.inlines(out, inlines);
+                out.push_str("</span>");
+            }
             Inline::Cite(citations, inlines) => {
                 let ids: Vec<&str> = citations
                     .iter()
                     .map(|citation| citation.id.as_str())
                     .collect();
-                format!(
-                    "<span class=\"citation\" data-cites=\"{}\">{}</span>",
-                    escape_attr(&ids.join(" ")),
-                    self.inlines(inlines)
-                )
+                let _ = write!(
+                    out,
+                    "<span class=\"citation\" data-cites=\"{}\">",
+                    escape_attr(&ids.join(" "))
+                );
+                self.inlines(out, inlines);
+                out.push_str("</span>");
             }
-            Inline::Note(blocks) => self.note(blocks),
+            Inline::Note(blocks) => self.note(out, blocks),
         }
     }
 
-    fn wrap(&mut self, tag: &str, inlines: &[Inline]) -> String {
-        format!("<{tag}>{}</{tag}>", self.inlines(inlines))
+    fn wrap(&mut self, out: &mut String, tag: &str, inlines: &[Inline]) {
+        let _ = write!(out, "<{tag}>");
+        self.inlines(out, inlines);
+        let _ = write!(out, "</{tag}>");
     }
 
-    fn link(&mut self, attr: &Attr, inlines: &[Inline], target: &Target) -> String {
-        format!(
-            "<a{BREAK}href=\"{}\"{}{}>{}</a>",
+    fn link(&mut self, out: &mut String, attr: &Attr, inlines: &[Inline], target: &Target) {
+        let _ = write!(
+            out,
+            "<a{BREAK}href=\"{}\"{}{}>",
             escape_attr(&target.url),
             render_attr(attr, AttrOrder::Standard),
-            title_attr(&target.title),
-            self.inlines(inlines)
-        )
+            title_attr(&target.title)
+        );
+        self.inlines(out, inlines);
+        out.push_str("</a>");
     }
 
-    fn note(&mut self, blocks: &[Block]) -> String {
+    fn note(&mut self, out: &mut String, blocks: &[Block]) {
         let number = self.footnotes.len() + 1;
         let backlink = format!(
             "<a{BREAK}href=\"#fnref{number}\"{BREAK}class=\"footnote-back\"{BREAK}role=\"doc-backlink\">\u{21a9}\u{fe0e}</a>"
@@ -332,31 +385,47 @@ impl State {
         let body = self.note_body(blocks, &backlink);
         self.footnotes
             .push(format!("<li{BREAK}id=\"fn{number}\">{body}</li>"));
-        format!(
+        let _ = write!(
+            out,
             "<a{BREAK}href=\"#fn{number}\"{BREAK}class=\"footnote-ref\"{BREAK}id=\"fnref{number}\"{BREAK}role=\"doc-noteref\"><sup>{number}</sup></a>"
-        )
+        );
     }
 
     /// Render a footnote's blocks, appending the backlink inside the final paragraph when the last
-    /// block is one, else as a bare trailing element (an unwrapped `Plain`) of its own.
+    /// block is one, else as a bare trailing element (an unwrapped `Plain`) of its own. The body is
+    /// returned as its own value because notes are gathered for a trailing section.
     fn note_body(&mut self, blocks: &[Block], backlink: &str) -> String {
+        let mut body = String::new();
         if let Some((Block::Para(inlines), rest)) = blocks.split_last() {
-            let head = with_trailing_newline(self.blocks(rest));
-            format!("{head}<p>{}{backlink}</p>", self.inlines(inlines))
+            self.blocks(&mut body, rest);
+            append_trailing_newline(&mut body);
+            body.push_str("<p>");
+            self.inlines(&mut body, inlines);
+            body.push_str(backlink);
+            body.push_str("</p>");
         } else {
-            let head = with_trailing_newline(self.blocks(blocks));
-            format!("{head}{backlink}")
+            self.blocks(&mut body, blocks);
+            append_trailing_newline(&mut body);
+            body.push_str(backlink);
         }
+        body
     }
 
-    fn footnote_section(&self) -> String {
+    fn push_footnote_section(&self, out: &mut String) {
         if self.footnotes.is_empty() {
-            return String::new();
+            return;
         }
-        format!(
-            "\n<section{BREAK}id=\"footnotes\"{BREAK}class=\"footnotes footnotes-end-of-document\"{BREAK}role=\"doc-endnotes\">\n<hr />\n<ol>\n{}\n</ol>\n</section>",
-            self.footnotes.join("\n")
-        )
+        let _ = write!(
+            out,
+            "\n<section{BREAK}id=\"footnotes\"{BREAK}class=\"footnotes footnotes-end-of-document\"{BREAK}role=\"doc-endnotes\">\n<hr />\n<ol>\n"
+        );
+        for (index, note) in self.footnotes.iter().enumerate() {
+            if index > 0 {
+                out.push('\n');
+            }
+            out.push_str(note);
+        }
+        out.push_str("\n</ol>\n</section>");
     }
 }
 
@@ -428,11 +497,10 @@ fn table_width_style(specs: &[ColSpec]) -> String {
 
 /// Append a newline to `text` unless it is empty (used to separate a footnote's leading blocks
 /// from the paragraph that carries the backlink).
-fn with_trailing_newline(mut text: String) -> String {
+fn append_trailing_newline(text: &mut String) {
     if !text.is_empty() {
         text.push('\n');
     }
-    text
 }
 
 fn title_attr(title: &Text) -> String {

--- a/crates/oxidoc-writers/src/html.rs
+++ b/crates/oxidoc-writers/src/html.rs
@@ -531,29 +531,25 @@ fn render_keyvals(attributes: &[(Text, Text)]) -> String {
 /// the run of literal text up to the next break point or hard newline. Hard newlines (block
 /// structure) reset the column. Consecutive break points collapse to one.
 fn reflow(input: &str) -> String {
-    let chars: Vec<char> = input.chars().collect();
     let mut out = String::with_capacity(input.len());
     let mut column = 0usize;
-    let mut index = 0usize;
-    while let Some(&current) = chars.get(index) {
+    let mut chars = input.chars();
+    while let Some(current) = chars.next() {
         match current {
             '\n' => {
                 out.push('\n');
                 column = 0;
-                index += 1;
             }
             BREAK => {
-                while matches!(chars.get(index), Some(&BREAK)) {
-                    index += 1;
+                while chars.clone().next() == Some(BREAK) {
+                    chars.next();
                 }
                 let mut chunk = 0usize;
-                let mut lookahead = index;
-                while let Some(&following) = chars.get(lookahead) {
+                for following in chars.clone() {
                     if following == BREAK || following == '\n' {
                         break;
                     }
                     chunk += char_width(following);
-                    lookahead += 1;
                 }
                 if column + 1 + chunk > FILL_COLUMN {
                     out.push('\n');
@@ -566,7 +562,6 @@ fn reflow(input: &str) -> String {
             other => {
                 out.push(other);
                 column += char_width(other);
-                index += 1;
             }
         }
     }

--- a/crates/oxidoc-writers/src/mediawiki.rs
+++ b/crates/oxidoc-writers/src/mediawiki.rs
@@ -13,7 +13,8 @@ use oxidoc_ast::{
 use oxidoc_core::{Result, Writer, WriterOptions};
 
 use crate::common::{
-    attribute_value, escape_attr, escape_xml, is_uri_scheme, quote_marks, render_html_attr,
+    attribute_value, escape_attr, escape_xml, is_percent_escaped_uri, is_uri_scheme, quote_marks,
+    render_html_attr,
 };
 
 /// Renders a document to `MediaWiki` markup.
@@ -366,7 +367,7 @@ impl State {
         if is_external_uri(&target.url) {
             if plain != target.url {
                 format!("[{} {label}]", target.url)
-            } else if is_clean_autolink(&target.url) {
+            } else if is_percent_escaped_uri(&target.url, false) {
                 target.url.clone()
             } else if label == target.url {
                 format!("[[{}]]", target.url)
@@ -445,58 +446,6 @@ fn guarded_paragraph(rendered: String) -> String {
     } else {
         rendered
     }
-}
-
-/// Whether a URL renders as a bare auto-linking address: every character is URL-permitted and each
-/// `%` introduces a two-digit hex escape. A URL with any other character is wrapped in link brackets
-/// so the markup stays well-formed.
-fn is_clean_autolink(url: &str) -> bool {
-    let bytes = url.as_bytes();
-    let mut index = 0;
-    while let Some(&byte) = bytes.get(index) {
-        if byte == b'%' {
-            let two_hex = bytes.get(index + 1).is_some_and(u8::is_ascii_hexdigit)
-                && bytes.get(index + 2).is_some_and(u8::is_ascii_hexdigit);
-            if !two_hex {
-                return false;
-            }
-            index += 3;
-            continue;
-        }
-        if !is_autolink_byte(byte) {
-            return false;
-        }
-        index += 1;
-    }
-    true
-}
-
-/// Whether a byte may appear literally in a bare auto-linking URL: the unreserved, sub-delimiter,
-/// and generic-delimiter URI characters.
-fn is_autolink_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric()
-        || matches!(
-            byte,
-            b'-' | b'.'
-                | b'_'
-                | b'~'
-                | b'!'
-                | b'$'
-                | b'&'
-                | b'\''
-                | b'('
-                | b')'
-                | b'*'
-                | b'+'
-                | b','
-                | b';'
-                | b'='
-                | b':'
-                | b'/'
-                | b'?'
-                | b'#'
-                | b'@'
-        )
 }
 
 /// The anchor `MediaWiki` derives for a section heading: its plain-text content with spaces turned

--- a/crates/oxidoc-writers/src/mediawiki.rs
+++ b/crates/oxidoc-writers/src/mediawiki.rs
@@ -12,7 +12,9 @@ use oxidoc_ast::{
 };
 use oxidoc_core::{Result, Writer, WriterOptions};
 
-use crate::common::{attribute_value, escape_xml, is_known_attribute, is_uri_scheme, quote_marks};
+use crate::common::{
+    attribute_value, escape_attr, escape_xml, is_uri_scheme, quote_marks, render_html_attr,
+};
 
 /// Renders a document to `MediaWiki` markup.
 #[derive(Debug, Default, Clone, Copy)]
@@ -105,7 +107,7 @@ impl State {
             Block::Figure(attr, _, blocks) => self.figure(attr, blocks),
             Block::Div(attr, blocks) => {
                 let body = self.blocks(blocks);
-                format!("<div{}>\n{body}\n</div>", render_attr(attr))
+                format!("<div{}>\n{body}\n</div>", render_html_attr(attr))
             }
             Block::LineBlock(lines) => self.line_block(lines),
         }
@@ -136,7 +138,7 @@ impl State {
             attributes: attr.attributes.clone(),
         };
         let body = self.blocks(blocks);
-        format!("<div{}>\n{body}\n</div>", render_attr(&merged))
+        format!("<div{}>\n{body}\n</div>", render_html_attr(&merged))
     }
 
     fn line_block(&mut self, lines: &[Vec<Inline>]) -> String {
@@ -350,7 +352,7 @@ impl State {
             Inline::Span(attr, inlines) => {
                 format!(
                     "<span{}>{}</span>",
-                    render_attr(attr),
+                    render_html_attr(attr),
                     self.inlines(inlines)
                 )
             }
@@ -615,34 +617,6 @@ fn raw_passthrough(format: &Format, text: &str) -> String {
     }
 }
 
-/// Render an [`Attr`] as an HTML attribute string with a leading space when non-empty: the id, the
-/// classes, then key/value pairs (`data-`-prefixed unless the key is a recognized HTML attribute).
-fn render_attr(attr: &Attr) -> String {
-    let mut parts = Vec::new();
-    if !attr.id.is_empty() {
-        parts.push(format!("id=\"{}\"", escape_attr(&attr.id)));
-    }
-    if !attr.classes.is_empty() {
-        parts.push(format!(
-            "class=\"{}\"",
-            escape_attr(&attr.classes.join(" "))
-        ));
-    }
-    for (key, value) in &attr.attributes {
-        let name = if is_known_attribute(key) {
-            key.clone()
-        } else {
-            format!("data-{key}")
-        };
-        parts.push(format!("{name}=\"{}\"", escape_attr(value)));
-    }
-    if parts.is_empty() {
-        String::new()
-    } else {
-        format!(" {}", parts.join(" "))
-    }
-}
-
 /// Whether a URL is an absolute reference to an external resource: it carries a scheme drawn from the
 /// known set. Internal references (page names, anchors, relative paths) use wiki-link syntax instead.
 fn is_external_uri(url: &str) -> bool {
@@ -664,10 +638,6 @@ fn is_external_uri(url: &str) -> bool {
 }
 
 fn escape_text(text: &str) -> String {
-    escape_xml(text, true)
-}
-
-fn escape_attr(text: &str) -> String {
     escape_xml(text, true)
 }
 

--- a/crates/oxidoc-writers/src/plain.rs
+++ b/crates/oxidoc-writers/src/plain.rs
@@ -8,8 +8,8 @@ use oxidoc_ast::{Block, Document, Format, Inline, ListAttributes};
 use oxidoc_core::{Result, Writer, WriterOptions};
 
 use crate::common::{
-    FILL_COLUMN, Piece, fill, fill_offset, indent_block, list_is_tight, offset_as_i32,
-    ordered_marker, quote_marks,
+    FILL_COLUMN, Piece, fill, fill_offset, indent_block, is_loose, item_separator, join_loose,
+    offset_as_i32, ordered_marker, quote_marks,
 };
 
 /// Renders a document to plain text.
@@ -303,45 +303,6 @@ impl State {
             other => self.block(other, width),
         }
     }
-}
-
-/// Join already-rendered blocks with the document's default blank-line spacing, dropping blocks that
-/// produced no output. A [`Block::Plain`] contributes only a single newline (not a blank line)
-/// before the next visible block when an empty block falls between them.
-fn join_loose(rendered: Vec<(bool, String)>) -> String {
-    let mut out = String::new();
-    let mut previous_was_plain: Option<bool> = None;
-    let mut empty_since_previous = false;
-    for (is_plain, text) in rendered {
-        if text.is_empty() {
-            if previous_was_plain.is_some() {
-                empty_since_previous = true;
-            }
-            continue;
-        }
-        if let Some(was_plain) = previous_was_plain {
-            if was_plain && empty_since_previous {
-                out.push('\n');
-            } else {
-                out.push_str("\n\n");
-            }
-        }
-        out.push_str(&text);
-        previous_was_plain = Some(is_plain);
-        empty_since_previous = false;
-    }
-    out
-}
-
-/// Whether a list is "loose" — at least one item carries a top-level paragraph. A loose list's items
-/// are separated with a blank line and each item's blocks are laid out with blank lines; a tight list
-/// uses single newlines throughout.
-fn is_loose(items: &[Vec<Block>]) -> bool {
-    !list_is_tight(items)
-}
-
-fn item_separator(loose: bool) -> &'static str {
-    if loose { "\n\n" } else { "\n" }
 }
 
 /// Whether a raw node targets this writer and should pass its content through verbatim. Raw content

--- a/crates/oxidoc-writers/src/plain.rs
+++ b/crates/oxidoc-writers/src/plain.rs
@@ -8,8 +8,8 @@ use oxidoc_ast::{Block, Document, Format, Inline, ListAttributes};
 use oxidoc_core::{Result, Writer, WriterOptions};
 
 use crate::common::{
-    FILL_COLUMN, Piece, fill, fill_offset, indent_block, is_loose, item_separator, join_loose,
-    offset_as_i32, ordered_marker, quote_marks,
+    FILL_COLUMN, NotesHost, Piece, append_notes, fill, fill_offset, indent_block, is_loose,
+    item_separator, join_loose, offset_as_i32, ordered_marker, quote_marks,
 };
 
 /// Renders a document to plain text.
@@ -20,16 +20,7 @@ impl Writer for PlainWriter {
     fn write(&self, document: &Document, _options: &WriterOptions) -> Result<String> {
         let mut state = State::default();
         let body = state.blocks_to_string(&document.blocks, FILL_COLUMN);
-        let mut out = body;
-        if !state.footnotes.is_empty() {
-            let notes = state.footnotes.join("\n\n");
-            out = if out.is_empty() {
-                notes
-            } else {
-                format!("{out}\n\n{notes}")
-            };
-        }
-        Ok(out.trim_end_matches('\n').to_owned())
+        Ok(append_notes(body, &state.footnotes))
     }
 }
 
@@ -251,57 +242,31 @@ impl State {
                 self.extend_pieces(inlines, out);
                 out.push(Piece::Text("]".to_owned()));
             }
-            Inline::Note(blocks) => self.note(blocks, out),
-        }
-    }
-
-    fn note(&mut self, blocks: &[Block], out: &mut Vec<Piece>) {
-        let index = self.footnotes.len();
-        self.footnotes.push(String::new());
-        let marker = format!("[{}]", index + 1);
-        let field = marker.chars().count() + 1;
-        let body = self.note_body(blocks, field);
-        let rendered = if body.is_empty() {
-            marker.clone()
-        } else {
-            format!("{marker} {body}")
-        };
-        if let Some(slot) = self.footnotes.get_mut(index) {
-            *slot = rendered;
-        }
-        out.push(Piece::Text(marker));
-    }
-
-    /// Render a footnote's body at the full fill column. The marker that the caller prepends shifts
-    /// only the first line's wrap point (modeled with `initial`); continuation lines and every later
-    /// block sit at the margin.
-    fn note_body(&mut self, blocks: &[Block], initial: usize) -> String {
-        let rendered = blocks
-            .iter()
-            .enumerate()
-            .map(|(position, block)| {
-                let is_plain = matches!(block, Block::Plain(_));
-                let text = if position == 0 {
-                    self.block_offset(block, FILL_COLUMN, initial)
-                } else {
-                    self.block(block, FILL_COLUMN)
-                };
-                (is_plain, text)
-            })
-            .collect();
-        join_loose(rendered)
-    }
-
-    /// Render a block whose first line begins `initial` columns in. Only the text blocks wrap, so
-    /// the offset is meaningful for them alone; other block kinds render at the margin.
-    fn block_offset(&mut self, block: &Block, width: usize, initial: usize) -> String {
-        match block {
-            Block::Plain(inlines) | Block::Para(inlines) => {
-                let pieces = self.pieces(inlines);
-                fill_offset(&pieces, width, initial)
+            Inline::Note(blocks) => {
+                let marker = self.record_note(blocks);
+                out.push(Piece::Text(marker));
             }
-            other => self.block(other, width),
         }
+    }
+}
+
+impl NotesHost for State {
+    fn notes(&mut self) -> &mut Vec<String> {
+        &mut self.footnotes
+    }
+
+    fn render_block(&mut self, block: &Block, width: usize) -> String {
+        self.block(block, width)
+    }
+
+    fn render_offset_paragraph(
+        &mut self,
+        inlines: &[Inline],
+        width: usize,
+        initial: usize,
+    ) -> String {
+        let pieces = self.pieces(inlines);
+        fill_offset(&pieces, width, initial)
     }
 }
 

--- a/crates/oxidoc-writers/src/rst.rs
+++ b/crates/oxidoc-writers/src/rst.rs
@@ -513,13 +513,7 @@ impl State {
         lead_break: bool,
         trail_break: bool,
     ) {
-        let is_space = |inline: &Inline| {
-            matches!(
-                inline,
-                Inline::Space | Inline::SoftBreak | Inline::LineBreak
-            )
-        };
-        let Some(first) = segment.iter().position(|inline| !is_space(inline)) else {
+        let Some(split) = split_run(segment, lead_break, trail_break) else {
             if segment.is_empty() && lead_break && trail_break {
                 out.push(word(format!("{open}\\ {close}"), true));
             } else {
@@ -529,62 +523,35 @@ impl State {
             }
             return;
         };
-        let last = segment
-            .iter()
-            .rposition(|inline| !is_space(inline))
-            .unwrap_or(first);
-        if let Some(lead) = segment.get(..first) {
-            for inline in lead {
-                if lead_break && matches!(inline, Inline::SoftBreak | Inline::LineBreak) {
-                    continue;
-                }
-                self.token(inline, true, out);
+        for inline in split.lead {
+            if lead_break && matches!(inline, Inline::SoftBreak | Inline::LineBreak) {
+                continue;
+            }
+            self.token(inline, true, out);
+        }
+        let lines = split_at(split.middle, |inline| matches!(inline, Inline::LineBreak));
+        let final_line = lines.len().saturating_sub(1);
+        for (index, line) in lines.iter().enumerate() {
+            let mut text = String::new();
+            if index == 0 {
+                text.push_str(open);
+                text.push_str(split.lead_sep);
+            }
+            text.push_str(&self.flat_nested(line, true));
+            if index == final_line {
+                text.push_str(split.trail_sep);
+                text.push_str(close);
+            }
+            out.push(word(text, true));
+            if index != final_line {
+                out.push(Token::Hard);
             }
         }
-        if let Some(middle) = segment.get(first..=last) {
-            let plain = to_plain_text(middle);
-            let lead_sep = if lead_break
-                && first == 0
-                && plain.chars().next().is_some_and(|c| !is_safe_follower(c))
-            {
-                "\\ "
-            } else {
-                ""
-            };
-            let trail_sep = if trail_break
-                && last + 1 == segment.len()
-                && plain.chars().last().is_some_and(|c| !is_safe_preceder(c))
-            {
-                "\\ "
-            } else {
-                ""
-            };
-            let lines = split_at(middle, |inline| matches!(inline, Inline::LineBreak));
-            let final_line = lines.len().saturating_sub(1);
-            for (index, line) in lines.iter().enumerate() {
-                let mut text = String::new();
-                if index == 0 {
-                    text.push_str(open);
-                    text.push_str(lead_sep);
-                }
-                text.push_str(&self.flat_nested(line, true));
-                if index == final_line {
-                    text.push_str(trail_sep);
-                    text.push_str(close);
-                }
-                out.push(word(text, true));
-                if index != final_line {
-                    out.push(Token::Hard);
-                }
+        for inline in split.trail {
+            if trail_break && matches!(inline, Inline::SoftBreak | Inline::LineBreak) {
+                continue;
             }
-        }
-        if let Some(trail) = segment.get(last + 1..) {
-            for inline in trail {
-                if trail_break && matches!(inline, Inline::SoftBreak | Inline::LineBreak) {
-                    continue;
-                }
-                self.token(inline, true, out);
-            }
+            self.token(inline, true, out);
         }
     }
 
@@ -656,52 +623,19 @@ impl State {
         lead_break: bool,
         trail_break: bool,
     ) {
-        let is_space = |inline: &Inline| {
-            matches!(
-                inline,
-                Inline::Space | Inline::SoftBreak | Inline::LineBreak
-            )
-        };
-        let Some(first) = segment.iter().position(|inline| !is_space(inline)) else {
+        let Some(split) = split_run(segment, lead_break, trail_break) else {
             for inline in segment {
                 self.token(inline, false, out);
             }
             return;
         };
-        let last = segment
-            .iter()
-            .rposition(|inline| !is_space(inline))
-            .unwrap_or(first);
-        if let Some(lead) = segment.get(..first) {
-            for inline in lead {
-                self.token(inline, false, out);
-            }
+        for inline in split.lead {
+            self.token(inline, false, out);
         }
-        if let Some(middle) = segment.get(first..=last) {
-            let plain = to_plain_text(middle);
-            let lead_sep = if lead_break
-                && first == 0
-                && plain.chars().next().is_some_and(|c| !is_safe_follower(c))
-            {
-                "\\ "
-            } else {
-                ""
-            };
-            let trail_sep = if trail_break
-                && last + 1 == segment.len()
-                && plain.chars().last().is_some_and(|c| !is_safe_preceder(c))
-            {
-                "\\ "
-            } else {
-                ""
-            };
-            let name = format!("{lead_sep}{plain}{trail_sep}");
-            self.register_image(attr, &name, target, None, out);
-        }
-        if let Some(trail) = segment.get(last + 1..) {
-            for inline in trail {
-                self.token(inline, false, out);
-            }
+        let name = format!("{}{}{}", split.lead_sep, split.plain, split.trail_sep);
+        self.register_image(attr, &name, target, None, out);
+        for inline in split.trail {
+            self.token(inline, false, out);
         }
     }
 
@@ -929,6 +863,59 @@ fn separator_needed(
 ) -> bool {
     (previous_complex && !is_safe_follower(current_first))
         || (current_complex && !is_safe_preceder(previous_last))
+}
+
+/// A phrase run partitioned around its non-space core, with the null-separator decision for each
+/// edge that abuts a broken-out child.
+struct RunSplit<'a> {
+    lead: &'a [Inline],
+    middle: &'a [Inline],
+    trail: &'a [Inline],
+    plain: String,
+    lead_sep: &'static str,
+    trail_sep: &'static str,
+}
+
+/// Partition a run into leading whitespace, its non-space core, and trailing whitespace, returning
+/// `None` when the run holds no non-space content. `lead_sep`/`trail_sep` carry the `\ ` null
+/// separator for an edge that abuts a broken-out child where the core character would otherwise read
+/// as continuing markup.
+fn split_run(segment: &[Inline], lead_break: bool, trail_break: bool) -> Option<RunSplit<'_>> {
+    let is_space = |inline: &Inline| {
+        matches!(
+            inline,
+            Inline::Space | Inline::SoftBreak | Inline::LineBreak
+        )
+    };
+    let first = segment.iter().position(|inline| !is_space(inline))?;
+    let last = segment
+        .iter()
+        .rposition(|inline| !is_space(inline))
+        .unwrap_or(first);
+    let middle = segment.get(first..=last).unwrap_or(&[]);
+    let plain = to_plain_text(middle);
+    let lead_sep =
+        if lead_break && first == 0 && plain.chars().next().is_some_and(|c| !is_safe_follower(c)) {
+            "\\ "
+        } else {
+            ""
+        };
+    let trail_sep = if trail_break
+        && last + 1 == segment.len()
+        && plain.chars().last().is_some_and(|c| !is_safe_preceder(c))
+    {
+        "\\ "
+    } else {
+        ""
+    };
+    Some(RunSplit {
+        lead: segment.get(..first).unwrap_or(&[]),
+        middle,
+        trail: segment.get(last + 1..).unwrap_or(&[]),
+        plain,
+        lead_sep,
+        trail_sep,
+    })
 }
 
 /// Characters that may directly follow an inline-markup end without a separator.

--- a/crates/oxidoc-writers/src/rst.rs
+++ b/crates/oxidoc-writers/src/rst.rs
@@ -918,36 +918,6 @@ fn split_run(segment: &[Inline], lead_break: bool, trail_break: bool) -> Option<
     })
 }
 
-/// Characters that may directly follow an inline-markup end without a separator.
-fn is_safe_follower(ch: char) -> bool {
-    matches!(
-        ch,
-        ' ' | '\''
-            | '"'
-            | ')'
-            | ']'
-            | '}'
-            | '>'
-            | '-'
-            | '.'
-            | ','
-            | ':'
-            | ';'
-            | '!'
-            | '?'
-            | '\\'
-            | '/'
-    )
-}
-
-/// Characters that may directly precede an inline-markup start without a separator.
-fn is_safe_preceder(ch: char) -> bool {
-    matches!(
-        ch,
-        ' ' | ':' | '/' | '-' | '"' | '\'' | '<' | '(' | '[' | '{'
-    )
-}
-
 /// Characters that may directly precede an inline-markup start-string.
 const OPENERS: &[char] = &['-', ':', '/', '\'', '"', '<', '(', '[', '{'];
 
@@ -955,6 +925,18 @@ const OPENERS: &[char] = &['-', ':', '/', '\'', '"', '<', '(', '[', '{'];
 const CLOSERS: &[char] = &[
     '-', '.', ',', ':', ';', '!', '?', '\'', '"', ')', ']', '}', '>',
 ];
+
+/// Characters that may directly follow an inline-markup end without a separator: a space, a backslash
+/// or slash, or any end-string closer.
+fn is_safe_follower(ch: char) -> bool {
+    ch == ' ' || ch == '\\' || ch == '/' || CLOSERS.contains(&ch)
+}
+
+/// Characters that may directly precede an inline-markup start without a separator: a space or any
+/// start-string opener.
+fn is_safe_preceder(ch: char) -> bool {
+    ch == ' ' || OPENERS.contains(&ch)
+}
 
 /// Escape the characters of a text run that RST would otherwise read as markup. A backslash is always
 /// doubled. A `*`, backtick, or `|` is escaped where it could open or close inline markup given its

--- a/crates/oxidoc-writers/src/rst.rs
+++ b/crates/oxidoc-writers/src/rst.rs
@@ -7,7 +7,8 @@
 //! column of 72.
 
 use oxidoc_ast::{
-    Attr, Block, Caption, Document, Format, Inline, ListAttributes, MathType, Target, to_plain_text,
+    Attr, Block, Caption, Document, Format, Inline, ListAttributes, MathType, Target, slug,
+    to_plain_text,
 };
 use oxidoc_core::{Result, Writer, WriterOptions};
 
@@ -1373,20 +1374,11 @@ fn breaks_out(inline: &Inline, kind: PhraseKind) -> bool {
 /// first letter; fall back to `section` when nothing remains. An explicit identifier equal to this is
 /// redundant and need not be emitted as a reference target.
 fn auto_identifier(inlines: &[Inline]) -> String {
-    let filtered: String = to_plain_text(inlines)
-        .chars()
-        .filter(|ch| ch.is_alphanumeric() || ch.is_whitespace() || matches!(ch, '_' | '-' | '.'))
-        .flat_map(char::to_lowercase)
-        .collect();
-    let joined = filtered.split_whitespace().collect::<Vec<_>>().join("-");
-    let slug: String = joined
-        .chars()
-        .skip_while(|ch| !ch.is_alphabetic())
-        .collect();
-    if slug.is_empty() {
+    let identifier = slug(&to_plain_text(inlines));
+    if identifier.is_empty() {
         "section".to_owned()
     } else {
-        slug
+        identifier
     }
 }
 


### PR DESCRIPTION
Consolidates duplicated logic across the readers and writers and removes the largest source of redundant allocation, with no change to output: every commit holds byte-for-byte parity (CommonMark/RST/MediaWiki writer sweeps 652/0/0, 66/66 tests, clippy `-D warnings` and typos clean). The dedup pass (13 commits) lifts shared helpers into common homes—loose-list and footnote machinery, HTML attribute emission, percent-escaped URI validation, entity decoding, and heading-slug derivation now live once each; the native enum parsers are macro-generated, the RST phrase-run splitter and boundary predicates are unified, two char-buffering hot paths (HTML reflow, CommonMark escaping) stream instead of materializing `Vec<char>`, and two non-mutating CommonMark scans take `&self`. The final commit rewrites the HTML writer to assemble output by pushing into one shared buffer rather than returning and re-concatenating a tree of owned `String`s, eliminating the O(N·depth) per-node copy; the other writers were deliberately left unchanged because their block sequencing genuinely needs materialized children for width reflow and per-line indenting.