### PR TITLE
fix: writer divergences across six targets

### DIFF
--- a/crates/oxidoc-writers/src/common.rs
+++ b/crates/oxidoc-writers/src/common.rs
@@ -187,10 +187,15 @@ pub(crate) trait NotesHost {
         let marker = format!("[{}]", index + 1);
         let field = marker.chars().count() + 1;
         let body = self.note_body(blocks, field);
+        // The body shares the marker's line only when it opens with a paragraph; a leading block of
+        // any other kind (a code block, a list) begins on the line below the marker.
+        let starts_inline = matches!(blocks.first(), Some(Block::Plain(_) | Block::Para(_)));
         let rendered = if body.is_empty() {
             marker.clone()
-        } else {
+        } else if starts_inline {
             format!("{marker} {body}")
+        } else {
+            format!("{marker}\n{body}")
         };
         if let Some(slot) = self.notes().get_mut(index) {
             *slot = rendered;

--- a/crates/oxidoc-writers/src/commonmark.rs
+++ b/crates/oxidoc-writers/src/commonmark.rs
@@ -294,11 +294,13 @@ impl State {
     }
 
     fn link(&mut self, attr: &Attr, inlines: &[Inline], target: &Target, out: &mut Vec<Piece>) {
-        if attr_is_empty(attr) {
+        if attr_is_empty(attr) || is_autolink_class(attr) {
             if let Some(autolink) = autolink(inlines, target) {
                 out.push(Piece::Text(autolink));
                 return;
             }
+        }
+        if attr_is_empty(attr) {
             out.push(Piece::Text("[".to_owned()));
             self.extend_pieces(inlines, out, false);
             out.push(Piece::Text(format!("]({})", destination(target))));
@@ -530,6 +532,14 @@ fn is_known_scheme(scheme: &str) -> bool {
 
 fn attr_is_empty(attr: &Attr) -> bool {
     attr.id.is_empty() && attr.classes.is_empty() && attr.attributes.is_empty()
+}
+
+/// Whether a link's attributes consist solely of the `uri` or `email` class that marks it as an
+/// autolink: with no id and no further attributes, such a link is written in angle-bracket form.
+fn is_autolink_class(attr: &Attr) -> bool {
+    attr.id.is_empty()
+        && attr.attributes.is_empty()
+        && matches!(attr.classes.as_slice(), [class] if class == "uri" || class == "email")
 }
 
 fn has_dimension(attr: &Attr) -> bool {

--- a/crates/oxidoc-writers/src/commonmark.rs
+++ b/crates/oxidoc-writers/src/commonmark.rs
@@ -7,7 +7,10 @@
 //! span, or div that carries attributes. Output carries no trailing newline; the caller appends one.
 //! This format has no public specification.
 
-use oxidoc_ast::{Attr, Block, Document, Format, Inline, ListAttributes, Target, Text};
+use oxidoc_ast::{
+    Attr, Block, Document, Format, Inline, ListAttributes, ListNumberDelim, ListNumberStyle,
+    Target, Text,
+};
 use oxidoc_core::{Result, Writer, WriterOptions};
 
 use crate::common::{
@@ -137,12 +140,19 @@ impl State {
         width: usize,
     ) -> String {
         let loose = is_loose(items);
+        // CommonMark numbers ordered lists only in decimal, delimited by a period or a single
+        // closing parenthesis; every other numeral style collapses to decimal and a two-parenthesis
+        // delimiter collapses to the single closing form.
+        let delim = match attrs.delim {
+            ListNumberDelim::OneParen | ListNumberDelim::TwoParens => ListNumberDelim::OneParen,
+            ListNumberDelim::Period | ListNumberDelim::DefaultDelim => ListNumberDelim::Period,
+        };
         let rendered: Vec<String> = items
             .iter()
             .enumerate()
             .map(|(offset, item)| {
                 let number = attrs.start.saturating_add(offset_as_i32(offset));
-                let marker = ordered_marker(number, &attrs.style, &attrs.delim);
+                let marker = ordered_marker(number, &ListNumberStyle::Decimal, &delim);
                 let field = (marker.chars().count() + 1).max(4);
                 let rendered = self.blocks_to_string(item, width.saturating_sub(field));
                 let body = offset_horizontal_rule(item, rendered);

--- a/crates/oxidoc-writers/src/commonmark.rs
+++ b/crates/oxidoc-writers/src/commonmark.rs
@@ -294,11 +294,11 @@ impl State {
     }
 
     fn link(&mut self, attr: &Attr, inlines: &[Inline], target: &Target, out: &mut Vec<Piece>) {
-        if attr_is_empty(attr) || is_autolink_class(attr) {
-            if let Some(autolink) = autolink(inlines, target) {
-                out.push(Piece::Text(autolink));
-                return;
-            }
+        if (attr_is_empty(attr) || is_autolink_class(attr))
+            && let Some(autolink) = autolink(inlines, target)
+        {
+            out.push(Piece::Text(autolink));
+            return;
         }
         if attr_is_empty(attr) {
             out.push(Piece::Text("[".to_owned()));

--- a/crates/oxidoc-writers/src/html.rs
+++ b/crates/oxidoc-writers/src/html.rs
@@ -636,18 +636,18 @@ fn reflow(input: &str) -> String {
     out
 }
 
-/// Display width of a character in columns: zero for
-/// combining marks, two for wide and fullwidth East Asian characters, one otherwise.
+/// Display width of a character in columns: zero for combining marks and control characters, two
+/// for wide and fullwidth East Asian characters, one otherwise.
 ///
 /// This uses a Unicode-category zero-width test, distinct from the range-table measure in
 /// [`crate::common`] that the plain and LaTeX writers share.
 fn char_width(ch: char) -> usize {
     let code = ch as u32;
-    if code < 0x0300 {
-        return 1;
-    }
     if is_zero_width(ch) {
         return 0;
+    }
+    if code < 0x0300 {
+        return 1;
     }
     if is_wide(code) { 2 } else { 1 }
 }

--- a/crates/oxidoc-writers/src/latex.rs
+++ b/crates/oxidoc-writers/src/latex.rs
@@ -366,7 +366,7 @@ fn push_inline(inline: &Inline, out: &mut Vec<Piece>) {
                 out.push(Piece::Text(text.clone()));
             }
         }
-        Inline::Link(_, inlines, target) => push_link(inlines, target, out),
+        Inline::Link(attr, inlines, target) => push_link(attr, inlines, target, out),
         Inline::Image(_, inlines, target) => out.push(Piece::Text(image(inlines, target))),
         Inline::Span(attr, inlines) => {
             let mut open = if attr.id.is_empty() {
@@ -393,7 +393,10 @@ fn wrap_command(open: &str, inlines: &[Inline], out: &mut Vec<Piece>) {
     out.push(Piece::Text("}".to_owned()));
 }
 
-fn push_link(inlines: &[Inline], target: &Target, out: &mut Vec<Piece>) {
+fn push_link(attr: &Attr, inlines: &[Inline], target: &Target, out: &mut Vec<Piece>) {
+    if !attr.id.is_empty() {
+        out.push(Piece::Text(phantom_label(&attr.id)));
+    }
     let url = escape_url(&target.url);
     if let [Inline::Str(text)] = inlines
         && *text == target.url

--- a/crates/oxidoc-writers/src/latex.rs
+++ b/crates/oxidoc-writers/src/latex.rs
@@ -367,7 +367,7 @@ fn push_inline(inline: &Inline, out: &mut Vec<Piece>) {
             }
         }
         Inline::Link(attr, inlines, target) => push_link(attr, inlines, target, out),
-        Inline::Image(_, inlines, target) => out.push(Piece::Text(image(inlines, target))),
+        Inline::Image(attr, inlines, target) => out.push(Piece::Text(image(attr, inlines, target))),
         Inline::Span(attr, inlines) => {
             let mut open = if attr.id.is_empty() {
                 String::new()
@@ -411,17 +411,92 @@ fn push_link(attr: &Attr, inlines: &[Inline], target: &Target, out: &mut Vec<Pie
     out.push(Piece::Text("}".to_owned()));
 }
 
-fn image(inlines: &[Inline], target: &Target) -> String {
+fn image(attr: &Attr, inlines: &[Inline], target: &Target) -> String {
     let alt = to_plain_text(inlines);
-    let options = if alt.is_empty() {
-        "keepaspectratio".to_owned()
+    let alt_option = if alt.is_empty() {
+        String::new()
     } else {
-        format!("keepaspectratio,alt={{{}}}", escape(&alt, EscapeMode::Text))
+        format!(",alt={{{}}}", escape(&alt, EscapeMode::Text))
+    };
+    let url = escape_url(&target.url);
+
+    let width = attr_value(attr, "width").and_then(Dimension::parse);
+    let height = attr_value(attr, "height").and_then(Dimension::parse);
+    if width.is_none() && height.is_none() {
+        return format!(
+            "\\pandocbounded{{\\includegraphics[keepaspectratio{alt_option}]{{{url}}}}}"
+        );
+    }
+
+    let width_option = match &width {
+        Some(dimension) => dimension.render("\\linewidth"),
+        None => "\\linewidth".to_owned(),
+    };
+    let height_option = match &height {
+        Some(dimension) => dimension.render("\\textheight"),
+        None => "\\textheight".to_owned(),
+    };
+    let aspect = if width.is_some() && height.is_some() {
+        ""
+    } else {
+        ",keepaspectratio"
     };
     format!(
-        "\\pandocbounded{{\\includegraphics[{options}]{{{}}}}}",
-        escape_url(&target.url)
+        "\\includegraphics[width={width_option},height={height_option}{aspect}{alt_option}]{{{url}}}"
     )
+}
+
+/// A parsed image dimension. A pixel or bare number is expressed in inches at 96 pixels per inch; a
+/// percentage is expressed as a fraction of a reference length; any other recognized unit is kept
+/// verbatim.
+enum Dimension {
+    Length(String),
+    Percent(f64),
+}
+
+impl Dimension {
+    fn parse(value: &str) -> Option<Dimension> {
+        let value = value.trim();
+        let split = value
+            .find(|ch: char| !(ch.is_ascii_digit() || ch == '.'))
+            .unwrap_or(value.len());
+        let (number, unit) = value.split_at(split);
+        let number: f64 = number.parse().ok()?;
+        match unit.to_ascii_lowercase().as_str() {
+            "" | "px" => Some(Dimension::Length(format!(
+                "{}in",
+                trim_number(number / 96.0)
+            ))),
+            "%" => Some(Dimension::Percent(number)),
+            "in" | "cm" | "mm" | "pt" | "pc" | "em" => {
+                Some(Dimension::Length(format!("{}{unit}", trim_number(number))))
+            }
+            _ => None,
+        }
+    }
+
+    fn render(&self, reference: &str) -> String {
+        match self {
+            Dimension::Length(rendered) => rendered.clone(),
+            Dimension::Percent(percent) => format!("{}{reference}", trim_number(percent / 100.0)),
+        }
+    }
+}
+
+/// Format a number to at most five fractional digits, dropping trailing zeros.
+fn trim_number(value: f64) -> String {
+    let formatted = format!("{value:.5}");
+    formatted
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_owned()
+}
+
+fn attr_value<'a>(attr: &'a Attr, key: &str) -> Option<&'a str> {
+    attr.attributes
+        .iter()
+        .find(|(name, _)| name == key)
+        .map(|(_, value)| value.as_str())
 }
 
 /// Render a footnote as an inline `\footnote{…}`; its blocks hang two columns under the opening so

--- a/crates/oxidoc-writers/src/latex.rs
+++ b/crates/oxidoc-writers/src/latex.rs
@@ -121,8 +121,12 @@ fn header(level: i32, attr: &Attr, inlines: &[Inline], width: usize) -> String {
 }
 
 fn code_block(attr: &Attr, text: &str) -> String {
+    code_block_env(attr, text, "verbatim")
+}
+
+fn code_block_env(attr: &Attr, text: &str, environment: &str) -> String {
     let body = text.strip_suffix('\n').unwrap_or(text);
-    let verbatim = format!("\\begin{{verbatim}}\n{body}\n\\end{{verbatim}}");
+    let verbatim = format!("\\begin{{{environment}}}\n{body}\n\\end{{{environment}}}");
     if attr.id.is_empty() {
         verbatim
     } else {
@@ -499,11 +503,35 @@ fn attr_value<'a>(attr: &'a Attr, key: &str) -> Option<&'a str> {
         .map(|(_, value)| value.as_str())
 }
 
-/// Render a footnote as an inline `\footnote{…}`; its blocks hang two columns under the opening so
-/// continuation paragraphs align with the first.
+/// Render a footnote as an inline `\footnote{…}`. Its blocks hang two columns under the opening so
+/// continuation paragraphs align with the first; a code block instead sits flush against the margin
+/// in a `Verbatim` environment, since verbatim content cannot be indented, and pushes the closing
+/// brace onto its own line.
 fn note(blocks: &[Block]) -> String {
-    let body = render_blocks(blocks, FILL_COLUMN.saturating_sub(2), 0);
-    format!("{}}}", indent_block(&body, "\\footnote{", "  "))
+    let width = FILL_COLUMN.saturating_sub(2);
+    let mut parts: Vec<String> = Vec::new();
+    let mut ends_with_code = false;
+    for block in blocks {
+        let (rendered, is_code) = match block {
+            Block::CodeBlock(attr, text) => (code_block_env(attr, text, "Verbatim"), true),
+            _ => (block_to_string(block, width, 0), false),
+        };
+        if rendered.is_empty() {
+            continue;
+        }
+        ends_with_code = is_code;
+        let indented = if is_code {
+            rendered
+        } else if parts.is_empty() {
+            indent_block(&rendered, "", "  ")
+        } else {
+            indent_block(&rendered, "  ", "  ")
+        };
+        parts.push(indented);
+    }
+    let body = parts.join("\n\n");
+    let closing = if ends_with_code { "\n}" } else { "}" };
+    format!("\\footnote{{{body}{closing}")
 }
 
 fn quote_marks(kind: &QuoteType) -> (&'static str, &'static str) {

--- a/crates/oxidoc-writers/src/mediawiki.rs
+++ b/crates/oxidoc-writers/src/mediawiki.rs
@@ -312,13 +312,26 @@ impl State {
 
     fn inlines(&mut self, inlines: &[Inline]) -> String {
         let mut out = String::new();
+        let mut pending_space = false;
         for inline in inlines {
+            if matches!(inline, Inline::Space | Inline::SoftBreak) {
+                pending_space = true;
+                continue;
+            }
+            let rendered = self.inline(inline);
+            if rendered.is_empty() {
+                continue;
+            }
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
             // A link or image opens with `[`; if the preceding character is also `[`, the run would
             // read as the start of an internal link, so an empty `<nowiki/>` breaks the pair.
             if out.ends_with('[') && matches!(inline, Inline::Link(..) | Inline::Image(..)) {
                 out.push_str("<nowiki/>");
             }
-            out.push_str(&self.inline(inline));
+            out.push_str(&rendered);
         }
         out
     }

--- a/crates/oxidoc-writers/src/mediawiki.rs
+++ b/crates/oxidoc-writers/src/mediawiki.rs
@@ -108,7 +108,7 @@ impl State {
             Block::Figure(attr, _, blocks) => self.figure(attr, blocks),
             Block::Div(attr, blocks) => {
                 let body = self.blocks(blocks);
-                format!("<div{}>\n{body}\n</div>", render_html_attr(attr))
+                format!("<div{}>\n{body}\n\n</div>", render_html_attr(attr))
             }
             Block::LineBlock(lines) => self.line_block(lines),
         }

--- a/crates/oxidoc-writers/src/mediawiki.rs
+++ b/crates/oxidoc-writers/src/mediawiki.rs
@@ -600,7 +600,12 @@ fn is_external_uri(url: &str) -> bool {
 }
 
 fn escape_text(text: &str) -> String {
-    escape_xml(text, true)
+    // C0 control characters other than tab and newline have no wiki rendering and are dropped.
+    let stripped: String = text
+        .chars()
+        .filter(|&ch| (ch as u32) >= 0x20 || ch == '\t' || ch == '\n')
+        .collect();
+    escape_xml(&stripped, true)
 }
 
 fn is_highlight_language(name: &str) -> bool {

--- a/crates/oxidoc-writers/src/rst.rs
+++ b/crates/oxidoc-writers/src/rst.rs
@@ -432,6 +432,10 @@ impl State {
             Inline::RawInline(format, text) => {
                 if format.0.eq_ignore_ascii_case("rst") {
                     out.push(word(text.clone(), false));
+                } else if format.0.eq_ignore_ascii_case("latex")
+                    || format.0.eq_ignore_ascii_case("tex")
+                {
+                    out.push(word(format!(":raw-latex:`{text}`"), true));
                 } else {
                     out.push(Token::Marker);
                 }


### PR DESCRIPTION
Fixes twelve writer-output divergences surfaced by a comprehensive cross-writer corpus: CommonMark non-decimal ordered lists now downgrade to decimal markers and uri/email links render as autolinks; footnote code blocks lay out below the marker in CommonMark and plain; LaTeX anchors identified links with a phantomsection label, sizes images with explicit width/height, and renders footnote code blocks as flush Verbatim; RST emits raw latex inlines through the raw-latex role; MediaWiki collapses spaces around dropped inlines, blank-line-separates a div's closing tag, and strips C0 control characters; and the HTML writer measures control characters as zero width when wrapping. Each is verified byte-for-byte against the oracle; conformance sweeps (commonmark/rst/mediawiki) stay 652/0/0 and the full suite (66 tests) is green.