### PR TITLE
feat: benchmark suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,9 @@ gitignored oracle, never committed.
   e.g. `tools/conformance-suite/run.sh writer html`. Each surface prints
   `RESULT <surface> <group> pass=N fail=N err=N skip=N` and exits non-zero on any fail/err.
   **Hard-requires** `.oracle/` and `jq`.
+- Benchmark vs pandoc (perf, not correctness; manual, never CI): `tools/bench-suite/run.sh all`, or one
+  surface e.g. `tools/bench-suite/run.sh writer latex`. **Hard-requires** `hyperfine`, `jq`, `.oracle/`;
+  builds the release binary itself. Machine-specific; nothing committed but `docs/BENCHMARKS.md`.
 - Fuzz a reader (nightly + `cargo-fuzz`): `cargo +nightly fuzz run commonmark` (see `fuzz/README.md`)
 - Coverage gate (offline product crates, floored at 90%):
   `cargo llvm-cov --workspace --summary-only --fail-under-lines 90` (run

--- a/corpus/bench/seed.md
+++ b/corpus/bench/seed.md
@@ -1,0 +1,73 @@
+# Surveying the river delta
+
+The estuary widens here, where the slow water folds back on itself and the
+reeds stand in shallow ranks. A surveyor walking the bank counts the channels
+by eye, then again with instruments, and the two tallies rarely agree on the
+first pass. *Patience* is the only reliable tool, and **a steady hand** records
+what patience finds. The work is unglamorous: stakes, string, a notebook gone
+soft at the corners, and the long arithmetic of `mean ± deviation` done twice.
+
+## Methods in the field
+
+Each morning begins with a calibration. We level the instrument against a fixed
+mark, note the temperature, and only then begin to read. The procedure matters
+less for any single measurement than for the *consistency* it imposes across a
+season of them — consistency is what turns a heap of numbers into a record.
+
+A short walk upstream reaches the gauging station, an unremarkable hut with a
+remarkable view. Inside, the logbook runs back decades; outside, the [river
+gauge](https://example.org/gauge) ticks over in centimetres. Compare the two and
+you learn how much a place can change while seeming to stay still.
+
+### What the notebook holds
+
+- Stage height, read to the millimetre and rounded honestly.
+- Water temperature, because density is not a constant.
+- Weather, in plain words: *overcast*, *gusting*, *still*.
+- Anything unusual, however small — a smell, a colour, a drifting log.
+
+The list is short on purpose. A field notebook that asks for everything gets
+nothing; one that asks for little gets filled. The discipline is in the asking.
+
+When the season turns, the entries grow denser:
+
+1. First the routine readings, taken at the same hour each day.
+2. Then the supplementary set, taken whenever the stage moves sharply.
+3. Finally the reconciliation, where yesterday's figures are checked against
+   today's and the discrepancies are chased down one by one.
+
+> The river does not keep our hours, and it does not round to the millimetre.
+> What we record is a negotiation between the water's indifference and our need
+> to write something down. The honest surveyor admits as much in the margin.
+
+## A note on instruments
+
+Two instruments, nominally identical, will disagree. The disagreement is not a
+defect but a measurement in its own right — of drift, of wear, of the small
+violences of transport. We keep both, and we keep their quarrel in the record:
+
+```rust
+fn reconcile(a: f64, b: f64) -> Reading {
+    let mean = (a + b) / 2.0;
+    let spread = (a - b).abs();
+    Reading { mean, spread, trustworthy: spread < TOLERANCE }
+}
+```
+
+The indented form, older and stubborn, still appears in the archived sheets:
+
+    stage = datum + offset
+    flow  = stage * width * velocity
+
+Read an autolink as what it is: <https://example.org/archive>. Read an entity
+as the character it names — a fraction &frac12;, a dash &mdash; set off mid
+sentence, an ampersand &amp; standing on its own. The text means what it says.
+
+A photograph helps where words fail: ![weir at low water](weir.jpg). It is not
+evidence, exactly, but it is a witness, and witnesses are worth keeping.
+
+---
+
+Close the notebook gently. The corner is soft, the string is wound, the stakes
+are pulled and stacked. Tomorrow the river will be a little different and the
+arithmetic will start again, twice, until the two tallies agree.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,150 @@
+# Benchmarks — carta vs pandoc
+
+**Reference machine:** Apple M1 Pro (10 cores), 16 GB RAM, macOS 26.5 (arm64)
+**carta:** commit `5e110f9`, release build (`cargo build --release`)
+**pandoc:** 3.10 (pinned oracle)
+**Driver:** hyperfine 1.20.0, warmup 3, 12 runs
+
+## Headline
+
+- **~10–30× faster** end-to-end across formats and sizes.
+- **~69× smaller** binary (2.6 MB vs 179.8 MB).
+- **~3–14× less peak memory** (thanks to no Haskell GC runtime).
+
+## How to read this
+
+Both tools run with identical `-f/-t` flags; pandoc is configured so both tools produce equivalent output and do
+equivalent work. Times are wall-clock end-to-end (process start included). `speedup` = pandoc mean ÷
+carta mean. `MB/s` is carta throughput over the actual input size. RSS is peak resident memory from a
+single `/usr/bin/time` run.
+
+## reader — commonmark → json
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 13 KB  |     3.32 ms ± 0.21  |    46.24 ms ± 3.03  |   13.9x |        3.8 |    4.0 MB |   107.8 MB |
+| 101 KB |     7.95 ms ± 0.65  |    94.85 ms ± 2.85  |   11.9x |       12.4 |   11.4 MB |   121.8 MB |
+| 1 MB   |    59.29 ms ± 2.83  |   565.85 ms ± 27.53 |    9.5x |       16.9 |   90.7 MB |   225.8 MB |
+
+## reader — html → json
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 14 KB  |     2.95 ms ± 0.14  |    56.51 ms ± 1.04  |   19.1x |        4.8 |    3.9 MB |   108.8 MB |
+| 112 KB |     7.37 ms ± 0.24  |   180.08 ms ± 2.31  |   24.4x |       14.8 |   12.2 MB |   133.8 MB |
+| 1 MB   |    87.89 ms ± 4.30  |  1290.49 ms ± 51.57 |   14.7x |       12.6 |   97.4 MB |   428.6 MB |
+
+## writer — json → html
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 12 KB  |     2.43 ms ± 0.19  |    30.67 ms ± 0.88  |   12.6x |        5.0 |    2.5 MB |    41.2 MB |
+| 113 KB |     2.69 ms ± 0.10  |    32.27 ms ± 3.22  |   12.0x |       40.9 |    3.1 MB |    61.8 MB |
+| 1 MB   |     5.81 ms ± 0.14  |   104.59 ms ± 1.97  |   18.0x |      191.9 |    7.3 MB |   122.9 MB |
+
+## writer — json → latex
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 12 KB  |     2.03 ms ± 0.04  |    30.63 ms ± 0.88  |   15.1x |        5.9 |    2.5 MB |    40.3 MB |
+| 113 KB |     2.54 ms ± 0.07  |    30.79 ms ± 0.72  |   12.1x |       43.3 |    3.2 MB |    44.9 MB |
+| 1 MB   |     6.02 ms ± 0.20  |   106.91 ms ± 4.19  |   17.8x |      185.2 |    7.7 MB |   122.5 MB |
+
+## writer — json → rst
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 12 KB  |     2.93 ms ± 1.02  |    31.97 ms ± 0.82  |   10.9x |        4.1 |    2.6 MB |    39.5 MB |
+| 113 KB |     3.14 ms ± 0.18  |    31.83 ms ± 1.94  |   10.1x |       35.1 |    3.3 MB |    41.2 MB |
+| 1 MB   |     6.58 ms ± 0.17  |    96.64 ms ± 5.70  |   14.7x |      169.5 |    7.4 MB |   122.3 MB |
+
+## writer — json → plain
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 12 KB  |     2.57 ms ± 0.32  |    31.30 ms ± 0.58  |   12.2x |        4.7 |    2.5 MB |    39.8 MB |
+| 113 KB |     2.82 ms ± 0.31  |    37.52 ms ± 6.68  |   13.3x |       39.0 |    3.2 MB |    62.6 MB |
+| 1 MB   |     5.92 ms ± 0.17  |    97.81 ms ± 5.92  |   16.5x |      188.3 |    7.4 MB |   122.7 MB |
+
+## writer — json → commonmark
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 12 KB  |     2.20 ms ± 0.11  |    31.47 ms ± 0.55  |   14.3x |        5.5 |    2.5 MB |    41.8 MB |
+| 113 KB |     2.67 ms ± 0.18  |    46.79 ms ± 6.04  |   17.5x |       41.2 |    3.2 MB |    63.4 MB |
+| 1 MB   |     6.22 ms ± 0.22  |   192.11 ms ± 3.32  |   30.9x |      179.2 |    7.6 MB |   123.6 MB |
+
+## writer — json → mediawiki
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 12 KB  |     2.39 ms ± 0.13  |    31.41 ms ± 0.68  |   13.1x |        5.0 |    2.5 MB |    39.6 MB |
+| 113 KB |     2.63 ms ± 0.10  |    31.76 ms ± 1.41  |   12.1x |       41.9 |    3.2 MB |    43.1 MB |
+| 1 MB   |     6.65 ms ± 0.39  |    99.14 ms ± 6.39  |   14.9x |      167.7 |    7.4 MB |   122.2 MB |
+
+## writer — json → native
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 12 KB  |     2.30 ms ± 0.27  |    31.47 ms ± 0.70  |   13.7x |        5.2 |    2.5 MB |    39.0 MB |
+| 113 KB |     3.19 ms ± 0.11  |    43.18 ms ± 1.67  |   13.5x |       34.5 |    3.4 MB |    42.8 MB |
+| 1 MB   |     7.40 ms ± 0.49  |   178.13 ms ± 5.86  |   24.1x |      150.8 |   10.0 MB |   143.1 MB |
+
+## writer — json → json
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 12 KB  |     2.12 ms ± 0.14  |    31.29 ms ± 0.80  |   14.8x |        5.7 |    2.3 MB |    38.8 MB |
+| 113 KB |     2.59 ms ± 0.24  |    31.70 ms ± 1.13  |   12.3x |       42.6 |    2.9 MB |    40.0 MB |
+| 1 MB   |     5.62 ms ± 0.25  |    91.64 ms ± 1.92  |   16.3x |      198.6 |    7.1 MB |   122.0 MB |
+
+## e2e — commonmark → html
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 13 KB  |     3.40 ms ± 0.18  |    57.82 ms ± 4.13  |   17.0x |        3.8 |    4.0 MB |   108.7 MB |
+| 101 KB |    10.57 ms ± 6.16  |   136.78 ms ± 6.58  |   12.9x |        9.3 |   11.5 MB |   122.8 MB |
+| 1 MB   |    65.90 ms ± 3.05  |  1001.05 ms ± 14.12 |   15.2x |       15.2 |   86.8 MB |   240.8 MB |
+
+## e2e — commonmark → latex
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 13 KB  |     3.35 ms ± 0.26  |    58.78 ms ± 4.68  |   17.5x |        3.8 |    4.1 MB |   108.2 MB |
+| 101 KB |     8.56 ms ± 0.20  |   166.88 ms ± 98.27 |   19.5x |       11.5 |   11.8 MB |   122.2 MB |
+| 1 MB   |    69.61 ms ± 15.61 |  1018.11 ms ± 87.37 |   14.6x |       14.4 |   87.2 MB |   259.3 MB |
+
+## e2e — commonmark → rst
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 13 KB  |     3.38 ms ± 0.17  |    47.35 ms ± 5.21  |   14.0x |        3.8 |    4.1 MB |   106.9 MB |
+| 101 KB |     9.44 ms ± 0.33  |   120.07 ms ± 3.16  |   12.7x |       10.5 |   11.5 MB |   122.0 MB |
+| 1 MB   |    76.77 ms ± 3.09  |   868.97 ms ± 40.01 |   11.3x |       13.0 |   87.5 MB |   237.0 MB |
+
+## e2e — commonmark → json
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 13 KB  |     3.03 ms ± 0.22  |    45.73 ms ± 2.76  |   15.1x |        4.2 |    4.0 MB |   107.8 MB |
+| 101 KB |     7.96 ms ± 0.19  |    94.80 ms ± 3.53  |   11.9x |       12.4 |   11.5 MB |   121.8 MB |
+| 1 MB   |    59.26 ms ± 1.23  |   553.80 ms ± 9.05  |    9.3x |       16.9 |   91.6 MB |   225.8 MB |
+
+## startup — commonmark → html (near-empty input)
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 27 B   |     2.11 ms ± 0.19  |    30.94 ms ± 0.75  |   14.7x |        0.0 |    2.2 MB |    41.1 MB |
+
+## startup — commonmark → json (near-empty input)
+
+| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |
+|--------|---------------------|---------------------|---------|------------|-----------|------------|
+| 27 B   |     2.07 ms ± 0.11  |    30.95 ms ± 0.76  |   15.0x |        0.0 |    2.2 MB |    39.4 MB |
+
+## binary size
+
+| binary | size       | ratio |
+|--------|------------|-------|
+| carta  |     2.6 MB |  1.0x |
+| pandoc |   179.8 MB |   69x |

--- a/docs/plans/benchmark-suite.md
+++ b/docs/plans/benchmark-suite.md
@@ -1,0 +1,369 @@
+# Benchmark suite — runtime comparison vs pandoc
+
+Status: **planned** (implementation starting). Delivery: **one PR** off `main`.
+
+This plan is standalone. It assumes no prior context beyond the repo and `AGENTS.md`
+(`.claude/CLAUDE.md`). Read `AGENTS.md` first — the clean-room and source-hygiene rules are
+load-bearing here too: the benchmark tooling lives under `tools/**` and `docs/**`, which are
+sanctioned to name pandoc; **no product source, corpus data file, or build config may.**
+
+> If you are resuming this work after losing context: this document is the complete spec. Read it
+> top to bottom before touching anything. Sections 1–3 are the rationale and the full decision record
+> (every question asked and answered during design); section 4 onward is the buildable design.
+
+---
+
+## 1. Motivation & initial requirement
+
+carta already has a **conformance suite** (`tools/conformance-suite/`) that verifies *correctness* —
+it diffs carta's output against the pinned pandoc oracle across every conversion surface. What it has
+**no** answer for is *performance*: is carta actually faster than pandoc, and by how much, and where?
+
+The original ask, verbatim in intent:
+
+> Implement a benchmark suite to compare our implementation against pandoc itself. Decide how it
+> should look, how it should be called/configured, how it should measure, what it should output.
+
+This document is the result of that design plus a full grilling round to pin the specifics.
+
+**One-line goal:** a manual, on-demand dev tool that runs carta and the pinned pandoc binary on
+equivalent work and reports how much faster (and leaner) carta is, honestly.
+
+---
+
+## 2. First-draft spec (preserved for the record)
+
+The initial rough proposal, before grilling, was:
+
+- **Intent:** measure runtime performance (speed/throughput) of carta vs pandoc; distinct from the
+  conformance suite (correctness). Cheap secondary headline metrics: binary size, startup overhead.
+  Open fork: also add in-process criterion regression benches?
+- **Location:** `tools/bench-suite/`, mirroring `conformance-suite/` (a `run.sh <surface|all>
+  [filter]` dispatcher + a `lib.sh` reusing path discovery).
+- **Driver:** `hyperfine` (warmup, statistics, JSON/markdown export); a new external dep gated like
+  `jq`/`pandoc`. Build carta `--release`.
+- **Metrics:** mean time, throughput (MB/s), speedup (×), standalone startup, binary size; peak RSS
+  as a best-effort stretch goal.
+- **Inputs:** a new `corpus/bench/` of realistically-sized fixtures (authored/generated, clean-room)
+  at S/M/L sizes; optional sweep over the fetched pandoc corpus. Honor `exclusions.tsv`.
+- **Surfaces:** `reader` (X→json), `writer` (json→X), `e2e` (real pairs), `startup`, `size`, `all`.
+- **Invocation:** `run.sh <surface|all> [filter]`; env knobs `BENCH_RUNS`/`BENCH_WARMUP`/
+  `BENCH_SIZES`/`BENCH_OUT`.
+- **Output:** human markdown table → stdout; raw hyperfine JSON → gitignored `target/bench/`;
+  optional regenerated `docs/BENCHMARKS.md` snapshot; not CI-gated.
+
+Everything below supersedes this draft where they differ.
+
+---
+
+## 3. Decision record (the grilling round)
+
+Each decision below is final. The alternatives are recorded so a future reader understands *why* the
+chosen path was chosen and does not relitigate it.
+
+1. **Scope → Comparison only.** Process-level head-to-head vs pandoc; end-to-end timing that includes
+   startup. **No** in-process criterion/divan layer and **no** carta-vs-its-own-past regression
+   tracking — those answer a different question, the conformance suite already guards correctness, and
+   perf-regression-in-CI is a known tar pit. (Rejected: "comparison now, regression later";
+   "both from day one".)
+
+2. **Driver → `hyperfine`, hard dependency.** Warmup, outlier detection, statistics, JSON/markdown
+   export for free. Gated in `require_tools` + `dev-setup.sh` with an install hint, matching the
+   existing oracle-missing pattern. (Rejected: hand-rolled bash timing; soft/optional dependency.)
+
+3. **Fixtures → seeds + runtime scaling.** Commit small authored text seed(s); generate sized
+   variants by concatenation and derive AST inputs via carta at runtime into gitignored
+   `target/bench/`. Small repo footprint. (Rejected: commit full sized files; reuse fetched pandoc
+   corpus only.)
+   - **Corollary (decided inline):** we author only **one** commonmark seed for the *text* surfaces.
+     The reader surface's non-commonmark text inputs (html/native/json) are derived from that seed at
+     runtime via carta itself (`carta -f commonmark -t <fmt>`). carta-generated html is still valid
+     html both parsers ingest, so there is no fairness loss, and the only committed text fixture is one
+     markdown file.
+   - **Critical correction (writer surface):** carta's commonmark reader implements **strict
+     CommonMark**, so an AST *derived from a markdown seed can never contain tables, footnotes,
+     definition lists, math, etc.* — those are extensions the strict reader does not produce. Deriving
+     the writer-surface AST from the seed would therefore never exercise table layout (`grid.rs`) or
+     any other rich path, defeating decision 5. **So the writer-surface AST input is built from the
+     existing `corpus/ast/` fixtures instead** (which already contain tables, footnotes, the full
+     common set — all carta-owned inputs), by concatenating their `blocks` arrays and repeating to
+     size. This is the only way the writer surface exercises the interesting constructs.
+
+4. **Sizes → ~10KB / 100KB / 1MB (three points).** 10KB anchors the **startup-dominated** regime,
+   1MB the **throughput-dominated** regime, 100KB the crossover. Reporting one number hides one
+   regime. 1MB is about as large as a single real document gets; 10MB measures a regime nobody hits.
+   (Rejected: two extremes only; single large; add 10MB.)
+
+5. **Seed shape → one balanced kitchen-sink.** Prose-weighted but containing every major construct
+   (headings, tight+loose lists, links, emphasis, code blocks, blockquotes, tables, footnotes) so the
+   costly paths — notably table layout (`grid.rs`) — are exercised, while output stays one row-set per
+   surface. (Rejected: balanced + dedicated table-heavy seed; per-construct seeds; prose-only. A
+   table-heavy seed is a trivial later add if table perf becomes a specific question.)
+
+6. **Surfaces / matrix → CLI-configurable, with curated defaults.** Do not hardcode the matrix; let
+   the CLI select what to bench, with sensible defaults. Keep all five surfaces (`reader`, `writer`,
+   `e2e`, `startup`, `size`) but curate default pairs rather than running a full cartesian
+   (4 readers × 8 writers × 3 sizes) wall of redundant rows. (Rejected: hardcoded curated pairs;
+   e2e+startup+size only; full cartesian.)
+
+7. **CLI shape → surface+filter, pair escape, env axes.**
+   - `run.sh <surface> [filter]` — conformance-familiar; `writer latex`, `reader commonmark`, `e2e`,
+     `all`.
+   - `run.sh pair <from> <to>` — generic escape hatch to bench *any* combination.
+   - env knobs for orthogonal axes: `BENCH_SIZES`, `BENCH_RUNS`, `BENCH_WARMUP`, `BENCH_OUT`.
+   - **No** config file. (Rejected: surface+filter only; config-file-driven.)
+
+8. **Output → stdout + gitignored JSON + curated docs.** Human markdown table → stdout; raw
+   `hyperfine` JSON → gitignored `target/bench/`; plus a **deliberately-regenerated**
+   `docs/BENCHMARKS.md` (reference machine specs + pandoc version stamped, "indicative,
+   machine-specific" caveat) so there is a citable "~N× faster" headline in the repo. (Rejected:
+   stdout + JSON only — no citable number; auto-commit raw tables — churns, meaningless cross-machine
+   diffs.)
+
+9. **CI → not in CI, manual only.** On-demand dev tool, run locally like `cargo llvm-cov`. No gating,
+   no CI job — avoids the perf-in-CI noise trap. (Rejected: run in CI without gating; run + threshold
+   gate.)
+
+10. **Memory → yes, fully cross-platform.** Peak RSS is a strong differentiator (pandoc carries a
+    Haskell GC runtime; carta does not). Measure it in a separate single-run pass (memory is stable
+    run-to-run, no statistics needed) via `/usr/bin/time`, handling **both** macOS `-l` (reports
+    bytes) and GNU `-v` (reports KB). (Rejected: defer to v2; macOS-only best-effort.)
+
+11. **Startup fairness → raw e2e + explicit startup line.** Report real end-to-end mean at every size
+    (what users feel) plus a standalone startup figure. **Never** publish a synthetic
+    "end-to-end minus startup" number — subtracting two noisy means is statistically unsound and
+    invites cherry-picking. The size curve + the explicit startup line let the reader infer
+    startup-vs-throughput. (Rejected: also report processing-only; large-size-only/ignore startup.)
+
+12. **Fairness flags → reuse `oracle_norm`.** Apply the conformance suite's pandoc-side normalization
+    (`--syntax-highlighting=none` for html/latex, `--mathjax` for html) so both tools do equivalent
+    work producing equivalent output. Leaving pandoc's default syntax highlighting on would time
+    pandoc doing work carta skips, inflating carta's win on code-heavy input. (Rejected: bench pandoc
+    defaults; report both normalized and default.)
+
+13. **Build → auto-build release at startup.** Run `cargo build --release -p carta-cli` before
+    benching (no-op when fresh). Eliminates the stale/debug-binary footgun — publishing a number off
+    the wrong binary is worse than a few seconds of build check. The pandoc oracle stays
+    require-and-fail (we don't build it). (Rejected: require pre-built + fail with hint.)
+
+14. **Seed construct scope → restrict to the universally-renderable set.** The seed contains only
+    constructs every benched target can render today (drop math/figure/image-dimensions/task-list —
+    see `corpus/exclusions.tsv`), so every size×target runs cleanly with **zero** skip logic. The seed
+    auto-grows as exclusions clear. (Rejected: rich seed + per-target skip; per-target seed variants.)
+
+**Placement details decided inline (not separate questions):**
+
+- Seed lives at `corpus/bench/seed.md` (one authored commonmark seed; `corpus/` is already "inputs we
+  own"). Generated sized variants, derived AST/text inputs, and raw JSON all go to gitignored
+  `target/bench/`.
+- **Generator footgun (resolved by authoring):** concatenating the seed N times could collide
+  footnote/reference-definition labels across copies. Avoided entirely by authoring `seed.md`
+  **inline-only** — no reference-style links, no footnotes (neither is strict CommonMark anyway, so
+  carta's reader would not parse them). Concatenation is then pure repetition with no label rewriting.
+  (The writer-surface AST is built from `corpus/ast/` and likewise just repeats whole blocks.)
+- Input is fed via **stdin redirect** (`< file`), matching the conformance suite, to avoid file-read
+  path differences between the two binaries.
+
+---
+
+## 4. Architecture
+
+Mirror `tools/conformance-suite/` so the two tools feel like siblings.
+
+```
+tools/bench-suite/
+  run.sh              # dispatcher: run.sh <surface|all> [filter] | run.sh pair <from> <to>
+  lib.sh              # shared primitives (see §5); reuses conformance path/oracle_norm conventions
+  gen-fixtures.sh     # build sized + derived inputs into $BENCH_OUT (idempotent)
+  surfaces/
+    reader.sh         # <fmt> -> json, per reader format
+    writer.sh         # json -> <target>, per writer target
+    e2e.sh            # curated real pairs (commonmark -> html/latex/rst/json)
+    startup.sh        # near-empty input across a few pairs; isolates RTS spin-up
+    size.sh           # binary sizes only, no timing
+  README.md           # how to run, prerequisites, what each surface measures
+corpus/bench/
+  seed.md             # the single authored kitchen-sink commonmark seed (committed)
+docs/BENCHMARKS.md    # deliberately-regenerated, caveated headline results (committed)
+```
+
+Gitignored (add to `.gitignore`): `target/bench/` (sized inputs, derived inputs, raw hyperfine JSON,
+scratch).
+
+### Format matrix (authoritative — from the registry)
+
+Readers: `commonmark` (alias `markdown`), `json`, `native`, `html`.
+Writers: `html` (alias `html5`), `json`, `plain`, `native`, `latex`, `commonmark`, `rst`, `mediawiki`.
+
+Both binaries are invoked with **identical** `-f/-t` flags. For `commonmark` we use `-f commonmark`
+on both (pandoc's CommonMark reader, *not* its extended `markdown`) so the workloads match.
+
+### Curated defaults
+
+- `reader` default formats: `commonmark` (the only non-trivial parser) and `html`. (`json`/`native`
+  readers are simple; bench them only via explicit filter / `pair`.)
+- `writer` default targets: **all 8** (the diverse, interesting half).
+- `e2e` default pairs: `commonmark→html`, `commonmark→latex`, `commonmark→rst`, `commonmark→json`.
+- `startup` default pairs: `commonmark→html`, `commonmark→json` on a near-empty (~1 line) input.
+- All defaults are overridable by `[filter]` or `pair`.
+
+---
+
+## 5. `lib.sh` — shared primitives
+
+Reuse the conformance suite's proven shapes; do not import its file (keep the tools independent), but
+copy the small, stable primitives and adapt.
+
+- **Path discovery:** `ROOT`, `ORACLE="$ROOT/.oracle/bin/pandoc"`,
+  `OX="${OXIDOC_BIN:-$ROOT/target/release/carta}"` (note: **release**, not debug),
+  `CORPUS="$ROOT/corpus"`, `BENCH_OUT="${BENCH_OUT:-$ROOT/target/bench}"`.
+- **`require_tools`:** assert `hyperfine`, `/usr/bin/time`, the pandoc oracle, and `jq` (for parsing
+  hyperfine JSON if needed) are present; fail loudly with provisioning hints. Do **not** assert the
+  carta binary — we build it (next).
+- **`ensure_release_binary`:** run `cargo build --release -p carta-cli` (quiet); abort on failure.
+- **`oracle_norm <target>`:** identical to conformance — `html|html5 → --syntax-highlighting=none
+  --mathjax`; `latex → --syntax-highlighting=none`; else empty. Applied to the **pandoc side only**.
+- **`oracle_version`:** read `.oracle/PANDOC_VERSION` (already recorded by `install-pandoc.sh`) for
+  stamping output.
+- **Env knobs with defaults:** `BENCH_SIZES="10k,100k,1m"`, `BENCH_WARMUP=3`, `BENCH_RUNS` (empty →
+  hyperfine adaptive; floor via `--min-runs 10` when set), `BENCH_OUT` (above).
+- **`bench_pair <mode> <label> <input_file> <oracle_args> <carta_args>`:** the core timing call —
+  shells out to `hyperfine` with `--warmup "$BENCH_WARMUP"`, `--shell=none` (avoid shell-spawn
+  overhead; pass argv directly), `--export-json "$BENCH_OUT/<label>.json"`, and **two named
+  commands**: `pandoc <oracle_args> < input` and `carta <carta_args> < input`. Because `--shell=none`
+  cannot do stdin redirection, feed input via hyperfine's `--input <file>` (applies to every command)
+  — confirm the installed hyperfine supports `--input`; if not, fall back to `--shell=default` with
+  `"$ORACLE $oargs < $input"`. Parse the JSON to extract mean±σ/min for the table.
+- **`measure_rss <cmd...> < input`:** single-run peak RSS. Detect the `/usr/bin/time` flavor once
+  (`time_flavor`): try `/usr/bin/time -l true` (BSD/macOS, prints "maximum resident set size" in
+  **bytes**) vs `/usr/bin/time -v true` (GNU, prints "Maximum resident set size (kbytes)"). Normalize
+  both to bytes. If neither parses, skip RSS with a one-line notice.
+- **Tally/report helpers:** mirror conformance (`PASS/FAIL/ERR/SKIP`, `report`, `tally_group`) but a
+  bench "failure" means a binary errored or hyperfine failed — not an output diff. Surfaces print one
+  human table per group and write raw JSON to `$BENCH_OUT`.
+
+---
+
+## 6. `gen-fixtures.sh` — input generation (idempotent)
+
+Produces everything under `$BENCH_OUT/fixtures/`. Re-runnable; regenerates only missing files unless
+`BENCH_REGEN=1`.
+
+1. **Parse `BENCH_SIZES`** (`10k,100k,1m` → bytes: 10240, 102400, 1048576; accept `k`/`m` suffixes).
+2. **Build sized commonmark inputs.** For each target size `T`, concatenate `corpus/bench/seed.md`
+   `ceil(T / seedBytes)` times (pure repetition — the seed is inline-only, no labels to collide).
+   Write `$BENCH_OUT/fixtures/commonmark.<size>.md`. Record exact byte length (used for MB/s).
+3. **Derive reader inputs** for non-commonmark reader formats, per size, via carta:
+   `carta -f commonmark -t html  < commonmark.<size>.md > html.<size>.html`
+   `carta -f commonmark -t native < ... > native.<size>.native`
+   `carta -f commonmark -t json   < ... > json.<size>.json`
+4. **Build writer-surface AST input** per size from `corpus/ast/` (NOT from the seed — see §3
+   correction). Use a **fixed curated subset** of `corpus/ast/*/*.json` (a representative ~15-block mix
+   that includes a few tables near the front so even the smallest size exercises table layout), all
+   drawn from the universally-renderable set (no figure/image-dimensions/math/task-list, the union of
+   `corpus/exclusions.tsv`, so it renders cleanly across all 8 targets). The full corpus would make the
+   base ~128KB — too coarse for a 10KB floor — hence a curated ~20KB base. With `jq -s`, collect the
+   subset's `blocks` into one base array `B` (length `L`, serialized `baseBytes`). For each target size
+   `T`: pick `N = ceil(T / (baseBytes/L))` and emit a Document
+   `{ "pandoc-api-version": <from a source file>, "meta": {}, "blocks": [range(N)] | map(B[. % L]) }`
+   to `$BENCH_OUT/fixtures/ast.<size>.json` (cycling the base to hit ~`T` bytes at a block boundary).
+   The writer surface feeds this same json to both `carta -f json -t <target>` and
+   `pandoc -f json -t <target>`. (Cycling whole blocks needs no label rewriting; duplicate footnote
+   identifiers across copies are tolerated by both writers and irrelevant to timing.) Throughput for
+   the writer surface uses the **AST json byte size** as input bytes.
+5. **Startup input:** a fixed ~1-line `startup.md` (and its derived `startup.ast.json`).
+
+All derived files are carta's own output → clean-room safe, never committed.
+
+---
+
+## 7. Surfaces
+
+Every surface: `conf_reset`, generate/ensure fixtures, loop the relevant (pair × size), call
+`bench_pair`, optionally `measure_rss` once per (pair × largest size), print a markdown table, write
+JSON. Honor curated defaults; accept a `[filter]` to narrow.
+
+- **`reader.sh [format]`** — for each reader format (default `commonmark`,`html`) × size:
+  `bench_pair text "reader/<fmt>/<size>" <input> "-f <fmt> -t json" "-f <fmt> -t json"`.
+  (Comparison is timing-only; `text`/`json` mode just controls table labeling.)
+- **`writer.sh [target]`** — for each writer target (default all 8) × size, input = `ast.<size>.json`
+  (built from `corpus/ast/`, §6 step 4): oracle args `-f json -t <target> $(oracle_norm <target>)`,
+  carta args `-f json -t <target>`.
+- **`e2e.sh [pair]`** — for each default pair (or one `from→to`) × size, input = `commonmark.<size>.md`
+  (or the right reader input): oracle args `-f <from> -t <to> $(oracle_norm <to>)`, carta args
+  `-f <from> -t <to>`.
+- **`startup.sh [pair]`** — default pairs on `startup.md`; this is the explicit startup figure.
+- **`size.sh`** — no timing: print `stat`-based byte sizes of `$ORACLE` and `$OX`, plus the ratio.
+  (macOS `stat -f%z`, GNU `stat -c%s` — detect like the time flavor.)
+
+`run.sh pair <from> <to>` routes to a generic e2e-style run over all sizes for an arbitrary pair,
+generating any missing input on demand.
+
+---
+
+## 8. Output format
+
+**Per-surface markdown table to stdout** (one block per surface/group):
+
+```
+## writer — json → latex   (pandoc 3.10, normalized)
+
+| size  | carta mean±σ   | pandoc mean±σ  | speedup | carta MB/s | carta RSS | pandoc RSS |
+|-------|----------------|----------------|---------|------------|-----------|------------|
+| 10KB  | 0.6 ms ± 0.1   | 28.4 ms ± 1.2  |  47.3×  |    16.6    |   4.1 MB  |  61.8 MB   |
+| 100KB | 2.9 ms ± 0.2   | 31.0 ms ± 0.9  |  10.7×  |    34.5    |   6.0 MB  |  72.4 MB   |
+| 1MB   | 24.1 ms ± 0.6  | 70.2 ms ± 1.8  |   2.9×  |    41.5    |  18.2 MB  | 140.1 MB   |
+```
+
+Plus a **startup** block (its own table) and a **size** block (binary sizes). `speedup` = pandoc mean
+/ carta mean. `MB/s` = input bytes / carta mean. RSS columns omitted with a note if the platform's
+`/usr/bin/time` flavor is unrecognized. **No** startup-subtracted column anywhere.
+
+**Raw JSON:** hyperfine's `--export-json` per (pair × size) under `$BENCH_OUT/*.json` (gitignored).
+
+**`docs/BENCHMARKS.md`:** regenerated deliberately (e.g. `run.sh all > docs/BENCHMARKS.md` is *not*
+the mechanism — instead a `--emit-doc` flag or a small wrapper writes a stamped document). Must carry,
+at the top: reference machine (CPU, RAM, OS), carta version/commit, pandoc version, date, and a bold
+caveat: *"Indicative only — numbers are machine-specific and will differ on your hardware."* Never
+written by CI; regenerated by hand when a headline refresh is wanted.
+
+---
+
+## 9. Clean-room & hygiene checklist (do not skip)
+
+- Bench tooling and `docs/BENCHMARKS.md` may name pandoc (they are under `tools/**` / `docs/**`).
+- `corpus/bench/seed.md` is a **corpus data file** → **no** upstream provenance in it (it is just
+  markdown we author; that is naturally fine).
+- No committed file contains pandoc-generated output. Derived inputs are carta's own output and live
+  only in gitignored `target/bench/`.
+- `.gitignore`: add `target/bench/` (covered already if `target/` is ignored — verify).
+- `git add` only the explicit new paths; never `-A`/`.`/`-u` (repo is multi-agent).
+
+---
+
+## 10. Implementation order
+
+1. `corpus/bench/seed.md` — author the kitchen-sink seed (universal construct set only).
+2. `tools/bench-suite/lib.sh` — path discovery, `require_tools`, `ensure_release_binary`,
+   `oracle_norm`, env knobs, `time_flavor`/`measure_rss`, `bench_pair`, table helpers.
+3. `tools/bench-suite/gen-fixtures.sh` — sized + derived inputs.
+4. `tools/bench-suite/run.sh` — dispatcher (`<surface|all> [filter]`, `pair <from> <to>`).
+5. Surfaces: `size.sh` (simplest, no timing) → `startup.sh` → `reader.sh` → `writer.sh` → `e2e.sh`.
+6. `tools/bench-suite/README.md` — prerequisites, usage, what each surface measures, the fairness
+   notes (oracle_norm, startup honesty).
+7. `tools/dev-setup.sh` — add a `hyperfine` presence check.
+8. Smoke-run locally (`.oracle/` + `hyperfine` present); generate an initial `docs/BENCHMARKS.md`.
+9. Update `AGENTS.md` "Build & test" / "Commands" with a one-line bench entry.
+
+Commit as conventional, one logical change per commit (`test`/`build`/`chore`/`docs` scopes as fit;
+the suite itself is tooling — `build(bench)` or `chore(bench)` is reasonable). Push only when asked.
+
+---
+
+## 11. Open soft spots (flagged, decided enough to build)
+
+- **Exact seed construct mix** and the **curated `e2e` default-pair list** are the two things most
+  worth a human glance before/while building — both are easily adjusted later without structural
+  change.
+- **hyperfine `--input` / `--shell=none` stdin handling** — verify against the installed hyperfine
+  version during step 2; fall back to `--shell=default` with quoted redirection if needed.

--- a/tools/bench-suite/README.md
+++ b/tools/bench-suite/README.md
@@ -1,0 +1,73 @@
+# Benchmark suite
+
+Times `carta` against the pinned pandoc binary on **equivalent work** and reports how much faster (and
+leaner) carta is. This is a manual, on-demand dev tool — the sibling of `tools/conformance-suite/`,
+which checks *correctness*. It is **not** part of `cargo test` and **not** run in CI (perf on shared
+runners is too noisy to gate). Results are machine-specific; nothing it produces is committed except
+the deliberately-regenerated `docs/BENCHMARKS.md`.
+
+See `docs/plans/benchmark-suite.md` for the full design and the decision record behind it.
+
+## Prerequisites
+
+- **hyperfine** — `brew install hyperfine` (or `cargo install hyperfine`). The timing driver.
+- **jq** — builds fixtures and parses results.
+- **`.oracle/`** — the pinned pandoc binary: `tools/install-pandoc.sh`.
+- The carta release binary is built automatically (`cargo build --release -p carta-cli`).
+
+## Usage
+
+```sh
+tools/bench-suite/run.sh all                 # every surface
+tools/bench-suite/run.sh writer              # one surface, default targets
+tools/bench-suite/run.sh writer latex        # narrow to one target
+tools/bench-suite/run.sh reader commonmark   # one reader format
+tools/bench-suite/run.sh e2e commonmark:html # one from:to pair
+tools/bench-suite/run.sh pair commonmark mediawiki  # arbitrary pair, all sizes
+tools/bench-suite/run.sh size                # binary sizes only (no timing)
+```
+
+### Surfaces
+
+| surface   | measures                                                                 |
+|-----------|--------------------------------------------------------------------------|
+| `reader`  | `<fmt> → json` parsing (default: commonmark, html)                        |
+| `writer`  | `json → <target>` rendering (all 8 targets; rich AST incl. tables)        |
+| `e2e`     | full `from → to` conversion — what users actually run                     |
+| `startup` | near-empty conversion — isolates process spin-up (the fairness baseline)  |
+| `size`    | binary sizes (no timing)                                                  |
+
+### Tunables (env)
+
+| var            | default     | meaning                                             |
+|----------------|-------------|-----------------------------------------------------|
+| `BENCH_SIZES`  | `10k,100k,1m` | input sizes to sweep (`k`/`m` = KiB/MiB)           |
+| `BENCH_WARMUP` | `3`         | hyperfine warmup runs                               |
+| `BENCH_RUNS`   | *(adaptive)*| fixed run count (else hyperfine decides)            |
+| `BENCH_OUT`    | `target/bench` | output dir for fixtures + raw hyperfine JSON     |
+| `BENCH_REGEN`  | `0`         | set `1` to rebuild fixtures from scratch            |
+
+## How it stays fair
+
+- **Identical `-f/-t` flags** on both binaries; for commonmark we use `-f commonmark` (not pandoc's
+  extended markdown) so the workloads match.
+- **pandoc is normalized** (`--syntax-highlighting=none`, `--mathjax` for HTML) so both produce
+  equivalent output — otherwise we'd be timing pandoc doing work carta skips.
+- **Three sizes.** Small inputs are *startup-dominated* (pandoc's runtime spin-up dwarfs the work);
+  large inputs are *throughput-dominated*. The `startup` surface reports the spin-up cost explicitly.
+  Read the small-input gap as mostly startup and the large-input gap as real throughput — there is no
+  synthetic "startup-subtracted" number, by design.
+- **Release build**, always rebuilt before timing so numbers never come from a stale or debug binary.
+
+## Output
+
+Markdown tables to stdout; raw hyperfine JSON per case under `$BENCH_OUT` (gitignored). To refresh the
+committed headline document, regenerate `docs/BENCHMARKS.md` by hand and stamp it with this machine's
+specs, the carta commit, and the pandoc version — never automate it.
+
+## Fixtures
+
+One authored seed (`corpus/bench/seed.md`, strict CommonMark) is repeated to size for the reader/e2e
+inputs; the other reader formats are derived from it via carta. The writer surface uses a curated
+subset of `corpus/ast/` (rich constructs incl. tables) cycled to size. All generated/derived inputs
+live in the gitignored output dir — none are committed, and none are pandoc output.

--- a/tools/bench-suite/gen-fixtures.sh
+++ b/tools/bench-suite/gen-fixtures.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Generate benchmark inputs into $FIXTURES (gitignored). Idempotent: existing files are reused unless
+# BENCH_REGEN=1. Produces, per size in BENCH_SIZES:
+#   commonmark.<size>.md      seed.md repeated to ~size              (reader/e2e input)
+#   html|native|json.<size>.* the seed input rendered by carta      (reader input, derived)
+#   ast.<size>.json           curated corpus AST cycled to ~size     (writer input)
+# Plus fixed near-empty startup inputs. Derived inputs are carta's own output and never committed.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+regen="${BENCH_REGEN:-0}"
+fresh() { [ "$regen" != "1" ] && [ -s "$1" ]; }
+
+seed_bytes=$(wc -c <"$SEED" | tr -d ' ')
+
+# Build the curated AST base once; emit base blocks JSON and record its size/length.
+base_blocks="$FIXTURES/.ast-base.json"
+if ! fresh "$base_blocks"; then
+  files=""
+  for rel in $WRITER_AST_FILES; do files="$files $CORPUS/ast/$rel.json"; done
+  # shellcheck disable=SC2086
+  jq -s 'map(.blocks) | add' $files >"$base_blocks"
+fi
+base_len=$(jq 'length' "$base_blocks")
+base_bytes=$(wc -c <"$base_blocks" | tr -d ' ')
+api_src="$CORPUS/ast/common/paragraph.json"
+
+gen_commonmark() { # <out> <target_bytes>
+  local out="$1" target="$2" copies
+  fresh "$out" && return 0
+  copies=$(( (target + seed_bytes - 1) / seed_bytes ))
+  [ "$copies" -lt 1 ] && copies=1
+  : >"$out"
+  local i=0
+  while [ "$i" -lt "$copies" ]; do cat "$SEED" >>"$out"; i=$((i + 1)); done
+}
+
+gen_ast() { # <out> <target_bytes>
+  local out="$1" target="$2" per n
+  fresh "$out" && return 0
+  per=$(( base_bytes / base_len ))
+  [ "$per" -lt 1 ] && per=1
+  n=$(( (target + per - 1) / per ))
+  [ "$n" -lt 1 ] && n=1
+  jq -n --argjson b "$(cat "$base_blocks")" --argjson n "$n" \
+    --argjson ver "$(jq '.["pandoc-api-version"]' "$api_src")" \
+    '{ "pandoc-api-version": $ver, meta: {}, blocks: ([range($n)] | map($b[. % ($b|length)])) }' \
+    >"$out"
+}
+
+derive() { # <in> <fmt> <out>
+  fresh "$3" && return 0
+  "$OX" -f commonmark -t "$2" <"$1" >"$3"
+}
+
+for size in $(sizes_list); do
+  bytes=$(size_to_bytes "$size")
+  md="$FIXTURES/commonmark.$size.md"
+  gen_commonmark "$md" "$bytes"
+  derive "$md" html   "$FIXTURES/html.$size.html"
+  derive "$md" native "$FIXTURES/native.$size.native"
+  derive "$md" json   "$FIXTURES/json.$size.json"
+  gen_ast "$FIXTURES/ast.$size.json" "$bytes"
+done
+
+# Near-empty startup inputs.
+startup_md="$FIXTURES/startup.md"
+if ! fresh "$startup_md"; then printf 'A startup probe paragraph.\n' >"$startup_md"; fi
+derive "$startup_md" json "$FIXTURES/startup.ast.json"
+
+echo "fixtures ready in $FIXTURES" >&2

--- a/tools/bench-suite/gen-fixtures.sh
+++ b/tools/bench-suite/gen-fixtures.sh
@@ -48,9 +48,14 @@ gen_ast() { # <out> <target_bytes>
     >"$out"
 }
 
+gen_rc=0
 derive() { # <in> <fmt> <out>
   fresh "$3" && return 0
-  "$OX" -f commonmark -t "$2" <"$1" >"$3"
+  if ! "$OX" -f commonmark -t "$2" <"$1" >"$3"; then
+    echo "error: failed to derive $(basename "$3") via carta -t $2" >&2
+    rm -f "$3"
+    gen_rc=1
+  fi
 }
 
 for size in $(sizes_list); do
@@ -68,4 +73,5 @@ startup_md="$FIXTURES/startup.md"
 if ! fresh "$startup_md"; then printf 'A startup probe paragraph.\n' >"$startup_md"; fi
 derive "$startup_md" json "$FIXTURES/startup.ast.json"
 
+[ "$gen_rc" -eq 0 ] || exit 1
 echo "fixtures ready in $FIXTURES" >&2

--- a/tools/bench-suite/lib.sh
+++ b/tools/bench-suite/lib.sh
@@ -195,11 +195,9 @@ table_header() {
   echo "|--------|---------------------|---------------------|---------|------------|-----------|------------|"
 }
 
-# Per-group error tally: each surface resets before its table, then folds any errors into SUITE_RC.
-group_reset() { ERR=0; }
-note_err() { ERR=$((ERR + 1)); echo "ERR  $1: $2" >&2; }
+# Any benchmark error flips the suite return code; each surface exits with it.
 SUITE_RC=0
-tally_group() { [ "${ERR:-0}" -gt 0 ] && SUITE_RC=1; return 0; }
+note_err() { SUITE_RC=1; echo "ERR  $1: $2" >&2; }
 
 # Comma list -> space list (for iterating BENCH_SIZES).
 sizes_list() { printf '%s\n' "$BENCH_SIZES" | tr ',' ' '; }

--- a/tools/bench-suite/lib.sh
+++ b/tools/bench-suite/lib.sh
@@ -1,6 +1,6 @@
-# Shared primitives for the benchmark suite: path discovery, release-build, oracle normalization,
-# timing via hyperfine, peak-RSS measurement, and table formatting. Sourced by run.sh, gen-fixtures.sh
-# and every surface.
+# Benchmark-suite primitives: release-build, timing via hyperfine, peak-RSS measurement, and table
+# formatting. Path anchors and the oracle contract come from tools/shared.sh. Sourced by run.sh,
+# gen-fixtures.sh and every surface.
 #
 # The suite times carta against the pinned pandoc binary on equivalent work — identical -f/-t flags,
 # pandoc normalized so both produce the same output (no syntax highlighting, MathJax for HTML). It
@@ -15,11 +15,9 @@ BENCH_LIB_SOURCED=1
 export LC_ALL=C
 
 BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT="$(cd "$BENCH_DIR/../.." && pwd)"
-ORACLE="$ROOT/.oracle/bin/pandoc"
+. "$BENCH_DIR/../shared.sh"
 ORACLE_VERSION_FILE="$ROOT/.oracle/PANDOC_VERSION"
 OX="${OXIDOC_BIN:-$ROOT/target/release/carta}"
-CORPUS="$ROOT/corpus"
 SEED="$CORPUS/bench/seed.md"
 
 # Tunables (env-overridable).
@@ -78,16 +76,6 @@ ensure_release_binary() {
 }
 
 oracle_version() { [ -f "$ORACLE_VERSION_FILE" ] && cat "$ORACLE_VERSION_FILE" || echo "unknown"; }
-
-# pandoc flags that neutralize target nondeterminism carta does not reproduce, so both tools do the
-# same work: HTML suppresses syntax highlighting and renders math via MathJax; LaTeX suppresses
-# highlighting. Applied to the pandoc side only.
-oracle_norm() {
-  case "$1" in
-    html | html5) echo "--syntax-highlighting=none --mathjax" ;;
-    latex) echo "--syntax-highlighting=none" ;;
-  esac
-}
 
 # Parse one size token (e.g. 10k, 100k, 1m, 2048) into bytes on stdout.
 size_to_bytes() {

--- a/tools/bench-suite/lib.sh
+++ b/tools/bench-suite/lib.sh
@@ -169,7 +169,6 @@ bench_pair() {
   p_rss=$(measure_rss "$input" $ORACLE $oargs)
 
   emit_row "$label" "$bytes" "$x_mean" "$x_sd" "$p_mean" "$p_sd" "$x_rss" "$p_rss"
-  PASS=$((PASS + 1))
 }
 
 # Render one table row from raw seconds/bytes. Derives speedup, throughput, and human units.
@@ -196,8 +195,8 @@ table_header() {
   echo "|--------|---------------------|---------------------|---------|------------|-----------|------------|"
 }
 
-# Per-group tally and failure logging.
-conf_reset() { PASS=0 FAIL=0 ERR=0; }
+# Per-group error tally: each surface resets before its table, then folds any errors into SUITE_RC.
+group_reset() { ERR=0; }
 note_err() { ERR=$((ERR + 1)); echo "ERR  $1: $2" >&2; }
 SUITE_RC=0
 tally_group() { [ "${ERR:-0}" -gt 0 ] && SUITE_RC=1; return 0; }

--- a/tools/bench-suite/lib.sh
+++ b/tools/bench-suite/lib.sh
@@ -1,0 +1,219 @@
+# Shared primitives for the benchmark suite: path discovery, release-build, oracle normalization,
+# timing via hyperfine, peak-RSS measurement, and table formatting. Sourced by run.sh, gen-fixtures.sh
+# and every surface.
+#
+# The suite times carta against the pinned pandoc binary on equivalent work — identical -f/-t flags,
+# pandoc normalized so both produce the same output (no syntax highlighting, MathJax for HTML). It
+# never diffs output; correctness is the conformance suite's job. Results are machine-specific and are
+# never committed (raw JSON lands in the gitignored output dir).
+
+# Guard against double-sourcing.
+[ -n "${BENCH_LIB_SOURCED:-}" ] && return 0
+BENCH_LIB_SOURCED=1
+
+# Deterministic number formatting (no locale decimal commas) and stable tool output.
+export LC_ALL=C
+
+BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$BENCH_DIR/../.." && pwd)"
+ORACLE="$ROOT/.oracle/bin/pandoc"
+ORACLE_VERSION_FILE="$ROOT/.oracle/PANDOC_VERSION"
+OX="${OXIDOC_BIN:-$ROOT/target/release/carta}"
+CORPUS="$ROOT/corpus"
+SEED="$CORPUS/bench/seed.md"
+
+# Tunables (env-overridable).
+BENCH_SIZES="${BENCH_SIZES:-10k,100k,1m}"
+BENCH_WARMUP="${BENCH_WARMUP:-3}"
+BENCH_RUNS="${BENCH_RUNS:-}" # empty => hyperfine adaptive (with a min-runs floor)
+BENCH_OUT="${BENCH_OUT:-$ROOT/target/bench}"
+FIXTURES="$BENCH_OUT/fixtures"
+mkdir -p "$BENCH_OUT" "$FIXTURES"
+
+# Curated AST subset for the writer surface (see docs/plans/benchmark-suite.md §6.4). A representative
+# mix from the universally-renderable set, tables placed early so even the smallest size exercises
+# table layout. Order is load-bearing: cycling truncates at a block boundary from the front.
+WRITER_AST_FILES="
+common/paragraph
+common/headers
+table/table-simple
+common/bullet-list-loose
+common/blockquote
+table/table-aligned
+common/code-block-lang
+common/ordered-nested
+common/emphasis-family
+table/table-colspan
+common/link-title-attr
+common/raw-html-block
+common/definition-list-loose
+"
+
+# Fail loudly with provisioning hints when a prerequisite is missing.
+require_tools() {
+  local missing=0
+  if ! command -v hyperfine >/dev/null 2>&1; then
+    printf 'error: hyperfine not found on PATH\n  install it: brew install hyperfine  (or: cargo install hyperfine)\n' >&2
+    missing=1
+  fi
+  if [ ! -x "$ORACLE" ]; then
+    printf 'error: pandoc oracle not found at %s\n  provision it: tools/install-pandoc.sh\n' "$ORACLE" >&2
+    missing=1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'error: jq not found on PATH (used to build fixtures and parse results)\n' >&2
+    missing=1
+  fi
+  [ "$missing" -eq 0 ] || exit 1
+}
+
+# Build the optimized binary the suite measures. A no-op when already fresh; guarantees we never
+# publish numbers from a stale or debug build.
+ensure_release_binary() {
+  echo "building carta --release ..." >&2
+  if ! (cd "$ROOT" && cargo build --release -p carta-cli >&2); then
+    echo "error: failed to build carta --release" >&2
+    exit 1
+  fi
+}
+
+oracle_version() { [ -f "$ORACLE_VERSION_FILE" ] && cat "$ORACLE_VERSION_FILE" || echo "unknown"; }
+
+# pandoc flags that neutralize target nondeterminism carta does not reproduce, so both tools do the
+# same work: HTML suppresses syntax highlighting and renders math via MathJax; LaTeX suppresses
+# highlighting. Applied to the pandoc side only.
+oracle_norm() {
+  case "$1" in
+    html | html5) echo "--syntax-highlighting=none --mathjax" ;;
+    latex) echo "--syntax-highlighting=none" ;;
+  esac
+}
+
+# Parse one size token (e.g. 10k, 100k, 1m, 2048) into bytes on stdout.
+size_to_bytes() {
+  local s="$1" n unit
+  n="${s%[kKmM]}"
+  unit="${s#"$n"}"
+  case "$unit" in
+    k | K) echo $((n * 1024)) ;;
+    m | M) echo $((n * 1024 * 1024)) ;;
+    *) echo "$n" ;;
+  esac
+}
+
+# Human-readable byte count (e.g. 1.5 MB) on stdout.
+human_bytes() {
+  awk -v b="$1" 'BEGIN {
+    if (b >= 1048576) printf "%.1f MB", b/1048576;
+    else if (b >= 1024) printf "%.1f KB", b/1024;
+    else printf "%d B", b;
+  }'
+}
+
+# Detect the /usr/bin/time flavor once: BSD/macOS (`-l`, RSS in bytes) vs GNU (`-v`, RSS in kbytes).
+# Sets TIME_FLAG and TIME_RSS_SCALE, or TIME_FLAG="" when neither works (RSS then unavailable).
+detect_time_flavor() {
+  [ -n "${TIME_FLAG+x}" ] && return 0
+  if /usr/bin/time -l true >/dev/null 2>&1; then
+    TIME_FLAG="-l"
+    TIME_RSS_SCALE=1
+  elif /usr/bin/time -v true >/dev/null 2>&1; then
+    TIME_FLAG="-v"
+    TIME_RSS_SCALE=1024
+  else
+    TIME_FLAG=""
+    TIME_RSS_SCALE=1
+  fi
+}
+
+# Peak RSS in bytes for one run of a command reading `input` on stdin; empty string if unmeasurable.
+# Usage: measure_rss <input_file> <argv...>
+measure_rss() {
+  detect_time_flavor
+  [ -n "$TIME_FLAG" ] || { echo ""; return; }
+  local input="$1"
+  shift
+  local report value
+  # /usr/bin/time writes its report to stderr; the program's stdout is discarded.
+  report=$({ /usr/bin/time "$TIME_FLAG" "$@" <"$input" >/dev/null; } 2>&1)
+  value=$(printf '%s\n' "$report" | grep -i 'maximum resident set size' | grep -oE '[0-9]+' | head -1)
+  [ -n "$value" ] || { echo ""; return; }
+  echo $((value * TIME_RSS_SCALE))
+}
+
+# Time carta vs pandoc on one (input, flag-pair) and append a result row to the current table.
+# Reads input via hyperfine's --input so both commands see identical stdin with --shell=none.
+# Usage: bench_pair <label> <input_file> <input_bytes> <oracle_args> <carta_args>
+bench_pair() {
+  local label="$1" input="$2" bytes="$3" oargs="$4" xargs="$5"
+  local json="$BENCH_OUT/$(printf '%s' "$label" | tr '/ ' '__').json"
+  local runs_arg=""
+  [ -n "$BENCH_RUNS" ] && runs_arg="--min-runs $BENCH_RUNS --max-runs $BENCH_RUNS"
+  # shellcheck disable=SC2086
+  if ! hyperfine --shell=none --warmup "$BENCH_WARMUP" $runs_arg \
+    --input "$input" --export-json "$json" \
+    --command-name carta  "$OX $xargs" \
+    --command-name pandoc "$ORACLE $oargs" \
+    >/dev/null 2>"$BENCH_OUT/.hf.err"; then
+    note_err "$label" "$(head -n 3 "$BENCH_OUT/.hf.err")"
+    return
+  fi
+  local x_mean x_sd p_mean p_sd
+  x_mean=$(jq -r '.results[] | select(.command=="carta")  | .mean'   "$json")
+  x_sd=$(jq   -r '.results[] | select(.command=="carta")  | .stddev' "$json")
+  p_mean=$(jq -r '.results[] | select(.command=="pandoc") | .mean'   "$json")
+  p_sd=$(jq   -r '.results[] | select(.command=="pandoc") | .stddev' "$json")
+
+  local x_rss p_rss
+  x_rss=$(measure_rss "$input" $OX $xargs)
+  p_rss=$(measure_rss "$input" $ORACLE $oargs)
+
+  emit_row "$label" "$bytes" "$x_mean" "$x_sd" "$p_mean" "$p_sd" "$x_rss" "$p_rss"
+  PASS=$((PASS + 1))
+}
+
+# Render one table row from raw seconds/bytes. Derives speedup, throughput, and human units.
+emit_row() {
+  local label="$1" bytes="$2" xm="$3" xsd="$4" pm="$5" psd="$6" xr="$7" pr="$8"
+  awk -v label="$label" -v bytes="$bytes" -v xm="$xm" -v xsd="$xsd" -v pm="$pm" -v psd="$psd" \
+      -v xr="$xr" -v pr="$pr" '
+    function ms(s) { return sprintf("%.2f", s*1000) }
+    function mb(b) { if (b=="" || b=="null") return "-"; if (b>=1048576) return sprintf("%.1f MB", b/1048576); if (b>=1024) return sprintf("%.1f KB", b/1024); return sprintf("%d B", b) }
+    BEGIN {
+      sz = (bytes>=1048576) ? sprintf("%.0f MB", bytes/1048576) : (bytes>=1024 ? sprintf("%.0f KB", bytes/1024) : sprintf("%d B", bytes));
+      speedup = (xm>0) ? sprintf("%.1fx", pm/xm) : "-";
+      thru = (xm>0) ? sprintf("%.1f", (bytes/1048576)/xm) : "-";
+      printf "| %-6s | %8s ms ± %-5s | %8s ms ± %-5s | %7s | %10s | %9s | %10s |\n",
+        sz, ms(xm), ms(xsd), ms(pm), ms(psd), speedup, thru, mb(xr), mb(pr);
+    }'
+}
+
+table_header() {
+  echo
+  echo "## $1"
+  echo
+  echo "| size   | carta mean ± σ      | pandoc mean ± σ     | speedup | carta MB/s | carta RSS | pandoc RSS |"
+  echo "|--------|---------------------|---------------------|---------|------------|-----------|------------|"
+}
+
+# Per-group tally and failure logging.
+conf_reset() { PASS=0 FAIL=0 ERR=0; }
+note_err() { ERR=$((ERR + 1)); echo "ERR  $1: $2" >&2; }
+SUITE_RC=0
+tally_group() { [ "${ERR:-0}" -gt 0 ] && SUITE_RC=1; return 0; }
+
+# Comma list -> space list (for iterating BENCH_SIZES).
+sizes_list() { printf '%s\n' "$BENCH_SIZES" | tr ',' ' '; }
+
+# Path of the generated input file for a reader format at a given size.
+fixture_for() { # <fmt> <size>
+  case "$1" in
+    commonmark | markdown) echo "$FIXTURES/commonmark.$2.md" ;;
+    html | html5) echo "$FIXTURES/html.$2.html" ;;
+    native) echo "$FIXTURES/native.$2.native" ;;
+    json) echo "$FIXTURES/json.$2.json" ;;
+  esac
+}
+
+# Byte length of a file (whitespace-trimmed).
+file_bytes() { wc -c <"$1" | tr -d ' '; }

--- a/tools/bench-suite/run.sh
+++ b/tools/bench-suite/run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Benchmark-suite dispatcher: time carta against the pinned pandoc binary on equivalent work.
+#
+# Usage:
+#   run.sh <surface> [filter]   run one surface (reader|writer|e2e|startup|size),
+#                               optional filter narrows it (a format, target, or from:to pair)
+#   run.sh pair <from> <to>     benchmark one arbitrary conversion end-to-end across all sizes
+#   run.sh all                  run every surface
+#
+# Prerequisites (hard): hyperfine, jq, and the gitignored .oracle/ pandoc binary. The carta release
+# binary is built automatically. Results are machine-specific and printed as markdown tables; raw
+# hyperfine JSON lands in $BENCH_OUT (gitignored). Tunables via env: BENCH_SIZES, BENCH_WARMUP,
+# BENCH_RUNS, BENCH_OUT. See README.md.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$DIR/lib.sh"
+SURFACES="reader writer e2e startup size"
+
+[ $# -ge 1 ] || { echo "usage: run.sh <surface|all|pair> [args]" >&2; exit 2; }
+
+require_tools
+ensure_release_binary
+bash "$DIR/gen-fixtures.sh" || exit 1
+
+echo "# carta vs pandoc $(oracle_version) — $(date '+%Y-%m-%d')"
+
+run_surface() {
+  local surface="$1"
+  shift
+  local script="$DIR/surfaces/$surface.sh"
+  if [ ! -f "$script" ]; then
+    echo "error: unknown surface '$surface' (expected one of: $SURFACES all pair)" >&2
+    return 2
+  fi
+  bash "$script" "$@"
+}
+
+case "$1" in
+  all)
+    rc=0
+    for surface in $SURFACES; do run_surface "$surface" || rc=1; done
+    exit "$rc"
+    ;;
+  pair)
+    [ $# -eq 3 ] || { echo "usage: run.sh pair <from> <to>" >&2; exit 2; }
+    run_surface e2e "$2:$3"
+    ;;
+  *)
+    run_surface "$@"
+    ;;
+esac

--- a/tools/bench-suite/surfaces/e2e.sh
+++ b/tools/bench-suite/surfaces/e2e.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# End-to-end surface: time a full `from -> to` conversion (the command users actually run) for carta
+# vs pandoc, per size. pandoc is normalized so both do equivalent work.
+# Usage: surfaces/e2e.sh [from:to]   (no arg = curated default pairs)
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+PAIRS="commonmark:html commonmark:latex commonmark:rst commonmark:json"
+[ $# -gt 0 ] && PAIRS="$1"
+
+for pair in $PAIRS; do
+  from="${pair%%:*}"
+  to="${pair##*:}"
+  conf_reset
+  table_header "e2e — $from → $to"
+  norm="$(oracle_norm "$to")"
+  for size in $(sizes_list); do
+    input="$(fixture_for "$from" "$size")"
+    [ -s "$input" ] || continue
+    bench_pair "e2e/$from-$to/$size" "$input" "$(file_bytes "$input")" \
+      "-f $from -t $to $norm" "-f $from -t $to"
+  done
+  tally_group
+done
+
+exit "$SUITE_RC"

--- a/tools/bench-suite/surfaces/e2e.sh
+++ b/tools/bench-suite/surfaces/e2e.sh
@@ -11,7 +11,7 @@ PAIRS="commonmark:html commonmark:latex commonmark:rst commonmark:json"
 for pair in $PAIRS; do
   from="${pair%%:*}"
   to="${pair##*:}"
-  conf_reset
+  group_reset
   table_header "e2e — $from → $to"
   norm="$(oracle_norm "$to")"
   for size in $(sizes_list); do

--- a/tools/bench-suite/surfaces/e2e.sh
+++ b/tools/bench-suite/surfaces/e2e.sh
@@ -11,7 +11,6 @@ PAIRS="commonmark:html commonmark:latex commonmark:rst commonmark:json"
 for pair in $PAIRS; do
   from="${pair%%:*}"
   to="${pair##*:}"
-  group_reset
   table_header "e2e — $from → $to"
   norm="$(oracle_norm "$to")"
   for size in $(sizes_list); do
@@ -20,7 +19,6 @@ for pair in $PAIRS; do
     bench_pair "e2e/$from-$to/$size" "$input" "$(file_bytes "$input")" \
       "-f $from -t $to $norm" "-f $from -t $to"
   done
-  tally_group
 done
 
 exit "$SUITE_RC"

--- a/tools/bench-suite/surfaces/reader.sh
+++ b/tools/bench-suite/surfaces/reader.sh
@@ -8,7 +8,6 @@ FORMATS="commonmark html"
 [ $# -gt 0 ] && FORMATS="$1"
 
 for fmt in $FORMATS; do
-  group_reset
   table_header "reader — $fmt → json"
   for size in $(sizes_list); do
     input="$(fixture_for "$fmt" "$size")"
@@ -16,7 +15,6 @@ for fmt in $FORMATS; do
     bench_pair "reader/$fmt/$size" "$input" "$(file_bytes "$input")" \
       "-f $fmt -t json" "-f $fmt -t json"
   done
-  tally_group
 done
 
 exit "$SUITE_RC"

--- a/tools/bench-suite/surfaces/reader.sh
+++ b/tools/bench-suite/surfaces/reader.sh
@@ -8,7 +8,7 @@ FORMATS="commonmark html"
 [ $# -gt 0 ] && FORMATS="$1"
 
 for fmt in $FORMATS; do
-  conf_reset
+  group_reset
   table_header "reader — $fmt → json"
   for size in $(sizes_list); do
     input="$(fixture_for "$fmt" "$size")"

--- a/tools/bench-suite/surfaces/reader.sh
+++ b/tools/bench-suite/surfaces/reader.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Reader surface: time `<fmt> -> json` parsing for carta vs pandoc, per size.
+# Usage: surfaces/reader.sh [format]   (no arg = curated default formats)
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+FORMATS="commonmark html"
+[ $# -gt 0 ] && FORMATS="$1"
+
+for fmt in $FORMATS; do
+  conf_reset
+  table_header "reader — $fmt → json"
+  for size in $(sizes_list); do
+    input="$(fixture_for "$fmt" "$size")"
+    [ -s "$input" ] || continue
+    bench_pair "reader/$fmt/$size" "$input" "$(file_bytes "$input")" \
+      "-f $fmt -t json" "-f $fmt -t json"
+  done
+  tally_group
+done
+
+exit "$SUITE_RC"

--- a/tools/bench-suite/surfaces/size.sh
+++ b/tools/bench-suite/surfaces/size.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Size surface: report binary sizes (no timing). pandoc carries a Haskell runtime and a large feature
+# set; carta is a single statically-focused binary. A cheap, stable headline.
+# Usage: surfaces/size.sh
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+# stat byte size, portable across BSD (-f%z) and GNU (-c%s).
+stat_bytes() { stat -f%z "$1" 2>/dev/null || stat -c%s "$1" 2>/dev/null; }
+
+xb=$(stat_bytes "$OX")
+pb=$(stat_bytes "$ORACLE")
+
+echo
+echo "## binary size"
+echo
+echo "| binary | size       | ratio |"
+echo "|--------|------------|-------|"
+printf '| %-6s | %10s | %5s |\n' "carta"  "$(human_bytes "$xb")" "1.0x"
+printf '| %-6s | %10s | %5s |\n' "pandoc" "$(human_bytes "$pb")" \
+  "$(awk -v p="$pb" -v x="$xb" 'BEGIN { printf "%.0fx", p/x }')"

--- a/tools/bench-suite/surfaces/startup.sh
+++ b/tools/bench-suite/surfaces/startup.sh
@@ -12,7 +12,6 @@ PAIRS="commonmark:html commonmark:json"
 for pair in $PAIRS; do
   from="${pair%%:*}"
   to="${pair##*:}"
-  group_reset
   table_header "startup — $from → $to (near-empty input)"
   norm="$(oracle_norm "$to")"
   input="$FIXTURES/startup.md"
@@ -20,7 +19,6 @@ for pair in $PAIRS; do
   [ -s "$input" ] || continue
   bench_pair "startup/$from-$to" "$input" "$(file_bytes "$input")" \
     "-f $from -t $to $norm" "-f $from -t $to"
-  tally_group
 done
 
 exit "$SUITE_RC"

--- a/tools/bench-suite/surfaces/startup.sh
+++ b/tools/bench-suite/surfaces/startup.sh
@@ -12,7 +12,7 @@ PAIRS="commonmark:html commonmark:json"
 for pair in $PAIRS; do
   from="${pair%%:*}"
   to="${pair##*:}"
-  conf_reset
+  group_reset
   table_header "startup — $from → $to (near-empty input)"
   norm="$(oracle_norm "$to")"
   input="$FIXTURES/startup.md"

--- a/tools/bench-suite/surfaces/startup.sh
+++ b/tools/bench-suite/surfaces/startup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Startup surface: time a near-empty conversion to isolate process spin-up (pandoc's runtime vs
+# carta's). This is the explicit startup figure that keeps the small-input comparison honest — the
+# bulk of any small-input gap is this, not parsing.
+# Usage: surfaces/startup.sh [from:to]   (no arg = curated default pairs)
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+PAIRS="commonmark:html commonmark:json"
+[ $# -gt 0 ] && PAIRS="$1"
+
+for pair in $PAIRS; do
+  from="${pair%%:*}"
+  to="${pair##*:}"
+  conf_reset
+  table_header "startup — $from → $to (near-empty input)"
+  norm="$(oracle_norm "$to")"
+  input="$FIXTURES/startup.md"
+  [ "$from" = json ] && input="$FIXTURES/startup.ast.json"
+  [ -s "$input" ] || continue
+  bench_pair "startup/$from-$to" "$input" "$(file_bytes "$input")" \
+    "-f $from -t $to $norm" "-f $from -t $to"
+  tally_group
+done
+
+exit "$SUITE_RC"

--- a/tools/bench-suite/surfaces/writer.sh
+++ b/tools/bench-suite/surfaces/writer.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Writer surface: time `json -> <target>` rendering for carta vs pandoc, per size. Input is the
+# curated AST (corpus/ast subset cycled to size); pandoc is normalized so both do equivalent work.
+# Usage: surfaces/writer.sh [target]   (no arg = every writer target)
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+TARGETS="html latex rst plain commonmark mediawiki native json"
+[ $# -gt 0 ] && TARGETS="$1"
+
+for target in $TARGETS; do
+  conf_reset
+  table_header "writer — json → $target"
+  norm="$(oracle_norm "$target")"
+  for size in $(sizes_list); do
+    input="$FIXTURES/ast.$size.json"
+    [ -s "$input" ] || continue
+    bench_pair "writer/$target/$size" "$input" "$(file_bytes "$input")" \
+      "-f json -t $target $norm" "-f json -t $target"
+  done
+  tally_group
+done
+
+exit "$SUITE_RC"

--- a/tools/bench-suite/surfaces/writer.sh
+++ b/tools/bench-suite/surfaces/writer.sh
@@ -9,7 +9,6 @@ TARGETS="html latex rst plain commonmark mediawiki native json"
 [ $# -gt 0 ] && TARGETS="$1"
 
 for target in $TARGETS; do
-  group_reset
   table_header "writer — json → $target"
   norm="$(oracle_norm "$target")"
   for size in $(sizes_list); do
@@ -18,7 +17,6 @@ for target in $TARGETS; do
     bench_pair "writer/$target/$size" "$input" "$(file_bytes "$input")" \
       "-f json -t $target $norm" "-f json -t $target"
   done
-  tally_group
 done
 
 exit "$SUITE_RC"

--- a/tools/bench-suite/surfaces/writer.sh
+++ b/tools/bench-suite/surfaces/writer.sh
@@ -9,7 +9,7 @@ TARGETS="html latex rst plain commonmark mediawiki native json"
 [ $# -gt 0 ] && TARGETS="$1"
 
 for target in $TARGETS; do
-  conf_reset
+  group_reset
   table_header "writer — json → $target"
   norm="$(oracle_norm "$target")"
   for size in $(sizes_list); do

--- a/tools/conformance-suite/lib.sh
+++ b/tools/conformance-suite/lib.sh
@@ -1,5 +1,5 @@
-# Shared primitives for the conformance suite: path discovery, oracle normalization, output
-# comparison, spec-example extraction, and result tallying. Sourced by run.sh and every surface.
+# Conformance-suite primitives: output comparison, spec-example extraction, and result tallying. Path
+# anchors and the oracle contract come from tools/shared.sh. Sourced by run.sh and every surface.
 #
 # The suite diffs carta against the pinned pandoc binary across each conversion surface. pandoc's
 # output is the reference; on any non-`json` target it carries a single trailing newline that is
@@ -11,11 +11,9 @@
 CONF_LIB_SOURCED=1
 
 CONF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT="$(cd "$CONF_DIR/../.." && pwd)"
-ORACLE="$ROOT/.oracle/bin/pandoc"
+. "$CONF_DIR/../shared.sh"
 OX="${OXIDOC_BIN:-$ROOT/target/debug/carta}"
 SPEC="$ROOT/vendor/commonmark/spec.txt"
-CORPUS="$ROOT/corpus"
 EXCLUSIONS="$CORPUS/exclusions.tsv"
 FETCHED="$ROOT/.oracle/tests/test"
 WORK="${CONF_WORK:-${TMPDIR:-/tmp}/carta-conformance}"
@@ -37,16 +35,6 @@ require_tools() {
     missing=1
   fi
   [ "$missing" -eq 0 ] || exit 1
-}
-
-# Oracle flags that neutralize target nondeterminism carta does not reproduce: HTML suppresses
-# syntax highlighting and renders math via MathJax; LaTeX suppresses syntax highlighting. Applied to
-# the pandoc side only.
-oracle_norm() {
-  case "$1" in
-    html | html5) echo "--syntax-highlighting=none --mathjax" ;;
-    latex) echo "--syntax-highlighting=none" ;;
-  esac
 }
 
 # A target whose output is compared structurally as JSON rather than byte-for-byte.

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -27,6 +27,7 @@ check cargo-llvm-cov "cargo install cargo-llvm-cov --locked"
 check typos "cargo install typos-cli --locked"
 check cargo-deny "cargo install cargo-deny --locked"
 check jq "install jq via your package manager (e.g. brew install jq) — used by tools/conformance-suite"
+check hyperfine "brew install hyperfine (or cargo install hyperfine) — used by tools/bench-suite"
 
 if [ ! -x "$repo_root/.oracle/bin/pandoc" ]; then
   echo "• oracle binary not installed — run tools/install-pandoc.sh"

--- a/tools/shared.sh
+++ b/tools/shared.sh
@@ -1,0 +1,21 @@
+# Common harness primitives for the tools/ suites: repo path anchors, the pinned pandoc oracle
+# location, and the normalization flags that put carta and pandoc on equivalent work. Sourced by each
+# suite's lib.sh so the oracle contract is defined once. Idempotent.
+
+[ -n "${TOOLS_SHARED_SOURCED:-}" ] && return 0
+TOOLS_SHARED_SOURCED=1
+
+SHARED_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SHARED_DIR/.." && pwd)"
+ORACLE="$ROOT/.oracle/bin/pandoc"
+CORPUS="$ROOT/corpus"
+
+# pandoc flags that neutralize target nondeterminism carta does not reproduce, so both tools do the
+# same work: HTML suppresses syntax highlighting and renders math via MathJax; LaTeX suppresses
+# highlighting. Applied to the pandoc side only.
+oracle_norm() {
+  case "$1" in
+    html | html5) echo "--syntax-highlighting=none --mathjax" ;;
+    latex) echo "--syntax-highlighting=none" ;;
+  esac
+}


### PR DESCRIPTION
Adds a benchmark suite to `tools` to compare carta speed, bundle size and memory footprint against pandoc.