### PR TITLE
test(bench): add criterion suite for readers, writers, and convert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +93,7 @@ dependencies = [
  "carta-core",
  "carta-readers",
  "carta-writers",
+ "criterion",
  "insta",
 ]
 
@@ -132,10 +154,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -195,6 +250,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +373,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "id-arena"
@@ -293,10 +411,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -335,6 +473,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +492,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "prettyplease"
@@ -381,6 +534,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +573,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -499,6 +690,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +746,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasip2"
@@ -596,6 +807,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -705,6 +925,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4", features = ["derive"] }
 unicode-general-category = "1"
 caseless = "0.2"
 insta = "1"
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 
 # Internal crates
 carta = { path = "crates/carta" }

--- a/crates/carta/Cargo.toml
+++ b/crates/carta/Cargo.toml
@@ -37,3 +37,8 @@ carta-writers = { path = "../carta-writers", default-features = false, optional 
 
 [dev-dependencies]
 insta = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "convert"
+harness = false

--- a/crates/carta/benches/convert.rs
+++ b/crates/carta/benches/convert.rs
@@ -15,8 +15,6 @@ const LARGE: usize = 1024 * 1024;
 /// 32 KiB keeps an iteration near one second while still making that worst case unmistakable.
 const ADVERSARIAL_LARGE: usize = 32 * 1024;
 
-/// Repeats `block` until the accumulated string reaches `bytes`, keeping the result within ±10% of
-/// the target by stopping once the threshold is crossed and the final block fits the tolerance.
 fn fill_to(bytes: usize, block: &str) -> String {
     let block = if block.is_empty() { " " } else { block };
     let mut out = String::with_capacity(bytes + block.len());

--- a/crates/carta/benches/convert.rs
+++ b/crates/carta/benches/convert.rs
@@ -1,0 +1,159 @@
+// Benches are not shipped paths, so the panic-discipline lints are relaxed here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::fs;
+
+use carta::{ReaderOptions, WriterOptions, convert, reader_for, writer_for};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+
+/// Small input size: large enough for stable per-iteration timing, small enough to stay fast.
+const SMALL: usize = 10 * 1024;
+/// Large input size: stresses allocation and the hot parse/render loops.
+const LARGE: usize = 1024 * 1024;
+/// Large input size for the adversarial generators. Their inputs drive the inline resolver's worst
+/// case, which is quadratic in delimiter count, so a 1 MiB input would take minutes per iteration;
+/// 32 KiB keeps an iteration near one second while still making that worst case unmistakable.
+const ADVERSARIAL_LARGE: usize = 32 * 1024;
+
+/// Repeats `block` until the accumulated string reaches `bytes`, keeping the result within ±10% of
+/// the target by stopping once the threshold is crossed and the final block fits the tolerance.
+fn fill_to(bytes: usize, block: &str) -> String {
+    let block = if block.is_empty() { " " } else { block };
+    let mut out = String::with_capacity(bytes + block.len());
+    while out.len() < bytes {
+        out.push_str(block);
+    }
+    out
+}
+
+fn prose(bytes: usize) -> String {
+    let block = "The quick brown fox writes *emphasis* and **strong** prose, sprinkled with \
+                 `inline code` and ordinary words that fill the paragraph to a useful length.\n\n";
+    fill_to(bytes, block)
+}
+
+fn links(bytes: usize) -> String {
+    let block = "A paragraph with an [inline link](http://example.com/path \"title\") and a \
+                 [reference link][ref] pointing into the definitions block below.\n\n";
+    let body = fill_to(bytes, block);
+    let mut out = String::with_capacity(body.len() + 64);
+    out.push_str(&body);
+    out.push_str("[ref]: http://example.com/reference \"reference title\"\n");
+    out
+}
+
+fn lists(bytes: usize) -> String {
+    let block = "- top level item\n  - second level item\n    - third level item\n  - back to second\n\
+                 1. ordered top\n   1. ordered second\n      1. ordered third\n\n";
+    fill_to(bytes, block)
+}
+
+fn emphasis_heavy(bytes: usize) -> String {
+    let block = "*a* _b_ **c** __d__ *e* _f_ **g** __h__ ";
+    fill_to(bytes, block)
+}
+
+fn pathological_brackets(bytes: usize) -> String {
+    let block = "[a [b [c ]]]]] [d] ]]]] [e ]] [f [g ";
+    fill_to(bytes, block)
+}
+
+type Generator = fn(usize) -> String;
+
+const GENERATORS: &[(&str, Generator, usize)] = &[
+    ("prose", prose, LARGE),
+    ("links", links, LARGE),
+    ("lists", lists, LARGE),
+    ("emphasis_heavy", emphasis_heavy, ADVERSARIAL_LARGE),
+    ("pathological_brackets", pathological_brackets, ADVERSARIAL_LARGE),
+];
+
+/// Reads every `corpus/text/commonmark/*.md` input and concatenates them, repeating until the
+/// result reaches at least 100 KiB, as a realistic mixed-feature `CommonMark` document.
+fn corpus_mixed() -> String {
+    let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../../corpus/text/commonmark");
+    let mut paths: Vec<_> = fs::read_dir(dir)
+        .expect("corpus/text/commonmark directory is readable")
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    paths.sort();
+    let mut one_pass = String::new();
+    for path in &paths {
+        one_pass.push_str(&fs::read_to_string(path).expect("corpus file is readable"));
+        one_pass.push_str("\n\n");
+    }
+    assert!(!one_pass.is_empty(), "found no corpus/text/commonmark/*.md inputs");
+    fill_to(100 * 1024, &one_pass)
+}
+
+fn read_commonmark(c: &mut Criterion) {
+    let reader = reader_for("commonmark").unwrap();
+    let options = ReaderOptions::default();
+    let mut group = c.benchmark_group("read_commonmark");
+    for &(name, generator, large) in GENERATORS {
+        for (size_label, size) in [("small", SMALL), ("large", large)] {
+            let input = generator(size);
+            group.throughput(Throughput::Bytes(input.len() as u64));
+            group.bench_function(format!("{name}/{size_label}"), |b| {
+                b.iter(|| reader.read(&input, &options).unwrap());
+            });
+        }
+    }
+    group.finish();
+}
+
+fn write_targets(c: &mut Criterion) {
+    let reader = reader_for("commonmark").unwrap();
+    let document = reader.read(&prose(LARGE), &ReaderOptions::default()).unwrap();
+    let options = WriterOptions::default();
+    let targets = [
+        "html",
+        "plain",
+        "commonmark",
+        "rst",
+        "latex",
+        "mediawiki",
+        "native",
+        "json",
+    ];
+    let mut group = c.benchmark_group("write_targets");
+    for target in targets {
+        let writer = writer_for(target).unwrap();
+        group.bench_function(target, |b| {
+            b.iter(|| writer.write(&document, &options).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn convert_end_to_end(c: &mut Criterion) {
+    let reader_options = ReaderOptions::default();
+    let writer_options = WriterOptions::default();
+    let inputs = [("prose", prose(LARGE)), ("lists", lists(LARGE))];
+    let mut group = c.benchmark_group("convert_end_to_end");
+    for (name, input) in &inputs {
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_function(*name, |b| {
+            b.iter(|| {
+                convert("commonmark", "html", input, &reader_options, &writer_options).unwrap()
+            });
+        });
+    }
+    group.finish();
+}
+
+fn read_corpus(c: &mut Criterion) {
+    let reader = reader_for("commonmark").unwrap();
+    let options = ReaderOptions::default();
+    let input = corpus_mixed();
+    let mut group = c.benchmark_group("read_corpus");
+    group.throughput(Throughput::Bytes(input.len() as u64));
+    group.bench_function("commonmark", |b| {
+        b.iter(|| reader.read(&input, &options).unwrap());
+    });
+    group.finish();
+}
+
+criterion_group!(benches, read_commonmark, write_targets, convert_end_to_end, read_corpus);
+criterion_main!(benches);

--- a/crates/carta/benches/convert.rs
+++ b/crates/carta/benches/convert.rs
@@ -63,7 +63,11 @@ const GENERATORS: &[(&str, Generator, usize)] = &[
     ("links", links, LARGE),
     ("lists", lists, LARGE),
     ("emphasis_heavy", emphasis_heavy, ADVERSARIAL_LARGE),
-    ("pathological_brackets", pathological_brackets, ADVERSARIAL_LARGE),
+    (
+        "pathological_brackets",
+        pathological_brackets,
+        ADVERSARIAL_LARGE,
+    ),
 ];
 
 /// Reads every `corpus/text/commonmark/*.md` input and concatenates them, repeating until the
@@ -81,7 +85,10 @@ fn corpus_mixed() -> String {
         one_pass.push_str(&fs::read_to_string(path).expect("corpus file is readable"));
         one_pass.push_str("\n\n");
     }
-    assert!(!one_pass.is_empty(), "found no corpus/text/commonmark/*.md inputs");
+    assert!(
+        !one_pass.is_empty(),
+        "found no corpus/text/commonmark/*.md inputs"
+    );
     fill_to(100 * 1024, &one_pass)
 }
 
@@ -103,7 +110,9 @@ fn read_commonmark(c: &mut Criterion) {
 
 fn write_targets(c: &mut Criterion) {
     let reader = reader_for("commonmark").unwrap();
-    let document = reader.read(&prose(LARGE), &ReaderOptions::default()).unwrap();
+    let document = reader
+        .read(&prose(LARGE), &ReaderOptions::default())
+        .unwrap();
     let options = WriterOptions::default();
     let targets = [
         "html",
@@ -134,7 +143,14 @@ fn convert_end_to_end(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(input.len() as u64));
         group.bench_function(*name, |b| {
             b.iter(|| {
-                convert("commonmark", "html", input, &reader_options, &writer_options).unwrap()
+                convert(
+                    "commonmark",
+                    "html",
+                    input,
+                    &reader_options,
+                    &writer_options,
+                )
+                .unwrap()
             });
         });
     }
@@ -153,5 +169,11 @@ fn read_corpus(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, read_commonmark, write_targets, convert_end_to_end, read_corpus);
+criterion_group!(
+    benches,
+    read_commonmark,
+    write_targets,
+    convert_end_to_end,
+    read_corpus
+);
 criterion_main!(benches);

--- a/plans/001-criterion-bench-suite.md
+++ b/plans/001-criterion-bench-suite.md
@@ -20,6 +20,34 @@
 - **Depends on**: none
 - **Category**: perf
 - **Planned at**: commit `5e110f9`, 2026-06-10 (reconciled at `f5d2e3b`, 2026-06-10 — no in-scope code drift; premise prose refreshed after `tools/bench-suite/` landed)
+- **Executed**: 2026-06-10, commit `57560f1` on branch `advisor/001-criterion-benches` (worktree `agent-a0d07458c7e1fa1d6`), reviewed and approved. Two deviations, both reviewer-sanctioned:
+  - `emphasis_heavy`/`pathological_brackets` use `ADVERSARIAL_LARGE = 32 KiB` instead of 1 MiB — the inline resolver's worst case is quadratic in delimiter count (measured 4× time per input doubling; ~20 min for one 1 MiB parse), which tripped this plan's own ">60 s per iteration set" STOP condition. The quadratic signal plan 003 needs is fully captured at 32 KiB (10 KiB → 107 ms, 32 KiB → 1.17 s).
+  - The smoke command must be scoped: `cargo bench -p carta --bench convert -- --quick`. The unscoped form also runs the lib's libtest harness, which rejects `--quick` (same gotcha as plan 002's smoke test). The command table and done criteria below are amended accordingly.
+- **Baseline** (median estimates from the full run at `57560f1`, recorded here per step 4):
+
+  ```
+  read_commonmark/prose/small                  267.12 µs
+  read_commonmark/prose/large                  35.377 ms
+  read_commonmark/links/small                  273.05 µs
+  read_commonmark/links/large                  29.617 ms
+  read_commonmark/lists/small                  569.38 µs
+  read_commonmark/lists/large                  66.630 ms
+  read_commonmark/emphasis_heavy/small         106.67 ms
+  read_commonmark/emphasis_heavy/large         1.1737 s
+  read_commonmark/pathological_brackets/small  2.6662 ms
+  read_commonmark/pathological_brackets/large  59.682 ms
+  write_targets/html                           31.119 ms
+  write_targets/plain                          13.008 ms
+  write_targets/commonmark                     17.473 ms
+  write_targets/rst                            29.287 ms
+  write_targets/latex                          15.542 ms
+  write_targets/mediawiki                      14.476 ms
+  write_targets/native                         26.741 ms
+  write_targets/json                           10.460 ms
+  convert_end_to_end/prose                     46.936 ms
+  convert_end_to_end/lists                     78.319 ms
+  read_corpus/commonmark                       3.8413 ms
+  ```
 
 ## Why this matters
 
@@ -61,7 +89,7 @@ Repo conventions that apply:
 | Tests | `cargo nextest run --workspace` | all pass |
 | Lint | `cargo clippy --all-targets` | exit 0, no new warnings |
 | Run benches | `cargo bench -p carta` | benches compile and report times |
-| Smoke-run benches fast | `cargo bench -p carta -- --quick` | exit 0 |
+| Smoke-run benches fast | `cargo bench -p carta --bench convert -- --quick` | exit 0 |
 
 ## Scope
 
@@ -158,7 +186,7 @@ Benches are the deliverable; no unit tests required. Confirm the existing suite 
 
 ## Done criteria
 
-- [ ] `cargo bench -p carta -- --quick` exits 0 and lists all four groups
+- [x] `cargo bench -p carta --bench convert -- --quick` exits 0 and lists all four groups
 - [ ] `cargo nextest run --workspace` exits 0
 - [ ] `cargo clippy --all-targets` exits 0 with no new warnings
 - [ ] `grep -ri pandoc crates/carta/benches/` returns no matches

--- a/plans/README.md
+++ b/plans/README.md
@@ -16,13 +16,16 @@ findings are recorded below so they aren't re-audited.
 
 | Plan | Title | Priority | Effort | Depends on | Status |
 |------|-------|----------|--------|------------|--------|
-| 001 | Criterion bench suite (readers/writers/convert + pathological inputs) | P1 | M | — | TODO |
+| 001 | Criterion bench suite (readers/writers/convert + pathological inputs) | P1 | M | — | DONE (commit `57560f1` on `advisor/001-criterion-benches`, reviewed+approved; awaiting operator merge. Adversarial inputs sized 32 KiB — inline resolver is quadratic, see plan's Executed note) |
 | 002 | Release profile tuning (lto, codegen-units=1, strip) | P1 | S | — | DONE (commit `c6bff34` on `worktree-agent-a3cfa78557ce4e2a6`, reviewed+approved; awaiting operator merge) |
 | 003 | Linear delimiter-stack inline emphasis/bracket resolution | P1 | M | 001 | TODO |
 | 004 | Allocation hygiene bundle (6 reader hot-path sites) | P2 | M | 001 (soft) | TODO |
 | 005 | Spike: byte-offset scanning + boxed `Inline` variants (report, not merge) | P2 | M | 001 (hard) | TODO |
+| 006 | CommonMark reader: low-complexity extension set (strikeout, sub/superscript, hard_line_breaks, task_lists, raw_html) | P1 | M | — | DONE |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
+
+Plan 006 is manually authored (feature work, not from the performance improve run) and added later.
 
 ## Dependency notes
 


### PR DESCRIPTION
Adds an offline criterion benchmark suite (`crates/carta/benches/convert.rs`) with deterministic synthetic CommonMark generators, covering the reader, all eight writers, end-to-end convert, and a corpus-backed mixed input. The two adversarial generators (`emphasis_heavy`, `pathological_brackets`) use a 32 KiB large size because the inline resolver's worst case is quadratic in delimiter count (~20 min for a single 1 MiB parse); this is the regression baseline for plan 003. Benches stay out of CI by design (`docs/plans/benchmark-suite.md`, decision 1); baseline medians are recorded in `plans/001-criterion-bench-suite.md`.