### PR TITLE
perf(commonmark): linear delimiter-stack inline resolution

### DIFF
--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -887,3 +887,273 @@ mod tests {
         assert_eq!(task_marker_replacement("plain"), None);
     }
 }
+
+#[cfg(test)]
+mod inline_tests {
+    use std::collections::BTreeMap;
+
+    use carta_ast::{Attr, Inline, Target};
+
+    use super::{LinkDef, RefMap, parse_inlines};
+    use carta_core::{Extension, Extensions};
+
+    fn no_ext() -> Extensions {
+        Extensions::empty()
+    }
+
+    fn exts(list: &[Extension]) -> Extensions {
+        Extensions::from_list(list)
+    }
+
+    fn empty_refs() -> RefMap {
+        BTreeMap::new()
+    }
+
+    fn ref_map(entries: &[(&str, &str)]) -> RefMap {
+        let mut m = BTreeMap::new();
+        for (k, v) in entries {
+            m.insert(
+                k.to_string(),
+                LinkDef {
+                    url: v.to_string(),
+                    title: String::new(),
+                },
+            );
+        }
+        m
+    }
+
+    fn p(text: &str) -> Vec<Inline> {
+        parse_inlines(text, &empty_refs(), no_ext())
+    }
+
+    fn pe(text: &str, ext: Extensions) -> Vec<Inline> {
+        parse_inlines(text, &empty_refs(), ext)
+    }
+
+    fn str(s: &str) -> Inline {
+        Inline::Str(s.to_owned())
+    }
+
+    fn link(content: Vec<Inline>, url: &str) -> Inline {
+        Inline::Link(
+            Attr::default(),
+            content,
+            Target {
+                url: url.to_owned(),
+                title: String::new(),
+            },
+        )
+    }
+
+    fn image(alt: Vec<Inline>, url: &str) -> Inline {
+        Inline::Image(
+            Attr::default(),
+            alt,
+            Target {
+                url: url.to_owned(),
+                title: String::new(),
+            },
+        )
+    }
+
+    // --- Emphasis and strong ---
+
+    #[test]
+    fn nested_emphasis_and_strong() {
+        // *a **b** c* → Emph([a, Strong([b]), c])
+        assert_eq!(
+            p("*a **b** c*"),
+            vec![Inline::Emph(vec![
+                str("a"),
+                Inline::Space,
+                Inline::Strong(vec![str("b")]),
+                Inline::Space,
+                str("c"),
+            ])]
+        );
+    }
+
+    #[test]
+    fn mixed_asterisk_and_underscore() {
+        // *a _b_ c* → Emph([a, Emph([b]), c])
+        assert_eq!(
+            p("*a _b_ c*"),
+            vec![Inline::Emph(vec![
+                str("a"),
+                Inline::Space,
+                Inline::Emph(vec![str("b")]),
+                Inline::Space,
+                str("c"),
+            ])]
+        );
+    }
+
+    #[test]
+    fn triple_asterisk_produces_emph_of_strong() {
+        // ***a*** → Emph([Strong([a])])
+        assert_eq!(
+            p("***a***"),
+            vec![Inline::Emph(vec![Inline::Strong(vec![str("a")])])]
+        );
+    }
+
+    #[test]
+    fn rule_of_3_prevents_outer_strong() {
+        // **a*b** — the `*` closer + `**` opener sum is 3 which would violate rule-of-3 when one
+        // side can both open and close, so the `*b` ends up literal inside Strong.
+        assert_eq!(
+            p("**a*b**"),
+            vec![Inline::Strong(vec![str("a*b")])]
+        );
+    }
+
+    #[test]
+    fn rule_of_3_prevents_inner_strong() {
+        // *a**b* — **b closes with * giving sum=3 but both must be mult-of-3 which they aren't,
+        // so the **b is left literal.
+        assert_eq!(p("*a**b*"), vec![Inline::Emph(vec![str("a**b")])]);
+    }
+
+    #[test]
+    fn unmatched_openers_become_literal() {
+        assert_eq!(p("*a"), vec![str("*a")]);
+        assert_eq!(p("a*"), vec![str("a*")]);
+        // **a* — the single * can close an emphasis inside the **, leaving ** - 1 = * literal
+        assert_eq!(p("**a*"), vec![str("*"), Inline::Emph(vec![str("a")])]);
+    }
+
+    #[test]
+    fn underscore_intraword_stays_literal() {
+        // `_` between word chars cannot open or close (spec §6.3 rules).
+        assert_eq!(p("a_b_c"), vec![str("a_b_c")]);
+        assert_eq!(p("_a_b"), vec![str("_a_b")]);
+    }
+
+    // --- Links and images ---
+
+    #[test]
+    fn inline_link_and_image() {
+        assert_eq!(p("[a](u)"), vec![link(vec![str("a")], "u")]);
+        assert_eq!(p("![i](u)"), vec![image(vec![str("i")], "u")]);
+    }
+
+    #[test]
+    fn reference_link_with_and_without_ref() {
+        // Without ref: stays literal.
+        assert_eq!(p("[a][r]"), vec![str("[a][r]")]);
+        // With ref defined: resolves.
+        let refs = ref_map(&[("r", "http://r")]);
+        let result = parse_inlines("[a][r]", &refs, no_ext());
+        assert_eq!(result, vec![link(vec![str("a")], "http://r")]);
+    }
+
+    #[test]
+    fn nested_bracket_in_link_text() {
+        // [[a]](u) — the inner [a] becomes a literal `[a]` in the link text because it has no
+        // matching target of its own, and the outer pair provides the `(u)` target.
+        assert_eq!(
+            p("[[a]](u)"),
+            vec![link(vec![str("[a]")], "u")]
+        );
+    }
+
+    #[test]
+    fn unmatched_brackets_are_literal() {
+        assert_eq!(p("]]]"), vec![str("]]]")]);
+    }
+
+    #[test]
+    fn link_suppresses_earlier_bracket_openers() {
+        // [a [b](u) c](v) — the inner [b](u) is a valid link; its `[` opener then causes
+        // the outer `[a ` opener to be deactivated (it cannot form a link containing a link),
+        // so the outer `[` and `](v)` stay literal.
+        assert_eq!(
+            p("[a [b](u) c](v)"),
+            vec![
+                str("[a"),
+                Inline::Space,
+                link(vec![str("b")], "u"),
+                Inline::Space,
+                str("c](v)"),
+            ]
+        );
+    }
+
+    #[test]
+    fn emphasis_inside_link_text() {
+        assert_eq!(
+            p("[*a*](u)"),
+            vec![link(vec![Inline::Emph(vec![str("a")])], "u")]
+        );
+    }
+
+    // --- Extension delimiters ---
+
+    #[test]
+    fn strikeout_double_tilde() {
+        assert_eq!(
+            pe("~~a~~", exts(&[Extension::Strikeout])),
+            vec![Inline::Strikeout(vec![str("a")])]
+        );
+    }
+
+    #[test]
+    fn subscript_single_tilde() {
+        assert_eq!(
+            pe("~a~", exts(&[Extension::Subscript])),
+            vec![Inline::Subscript(vec![str("a")])]
+        );
+    }
+
+    #[test]
+    fn superscript_caret() {
+        assert_eq!(
+            pe("^a^", exts(&[Extension::Superscript])),
+            vec![Inline::Superscript(vec![str("a")])]
+        );
+    }
+
+    #[test]
+    fn double_tilde_with_subscript_only_becomes_nested_subscript() {
+        // Strikeout off, subscript on: ~~a~~ is two nested subscripts (each `~` consumed one).
+        assert_eq!(
+            pe("~~a~~", exts(&[Extension::Subscript])),
+            vec![Inline::Subscript(vec![Inline::Subscript(vec![str("a")])])]
+        );
+    }
+
+    #[test]
+    fn single_tilde_skipped_when_strikeout_only() {
+        // `~a~~b~~` with strikeout on but subscript off: length-1 run has no strikeout mapping
+        // (`match_use_count` returns None), so it stays literal; `~~b~~` matches as strikeout.
+        assert_eq!(
+            pe("~a~~b~~", exts(&[Extension::Strikeout])),
+            vec![str("~a"), Inline::Strikeout(vec![str("b")])]
+        );
+    }
+
+    #[test]
+    fn unmatched_tilde_run_stays_literal_when_strikeout_only() {
+        // `~~a~` — the single `~` is a closer that can't find an opener (the `~~` needs length-2
+        // pair and subscript is off), so the whole thing stays literal.
+        assert_eq!(
+            pe("~~a~", exts(&[Extension::Strikeout])),
+            vec![str("~~a~")]
+        );
+    }
+
+    #[test]
+    fn mixed_asterisk_and_strikeout() {
+        assert_eq!(
+            pe("*a ~~b~~ c*", exts(&[Extension::Strikeout])),
+            vec![Inline::Emph(vec![
+                str("a"),
+                Inline::Space,
+                Inline::Strikeout(vec![str("b")]),
+                Inline::Space,
+                str("c"),
+            ])]
+        );
+    }
+}

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -587,8 +587,12 @@ fn process_emphasis(nodes: &mut Vec<Node>, stack_bottom: usize, ext: Extensions)
         let Some(current_entry) = delims.get(current) else {
             break;
         };
-        let (closer_ch, closer_count, closer_can_open, closer_can_close) =
-            (current_entry.ch, current_entry.count, current_entry.can_open, current_entry.can_close);
+        let (closer_ch, closer_count, closer_can_open, closer_can_close) = (
+            current_entry.ch,
+            current_entry.count,
+            current_entry.can_open,
+            current_entry.can_close,
+        );
         let closer_ni = current_entry.node_index;
         if !closer_can_close {
             current += 1;
@@ -706,8 +710,7 @@ fn process_emphasis(nodes: &mut Vec<Node>, stack_bottom: usize, ext: Extensions)
         //   after remove(closer) if empty: -1
         //   after remove(opener) if empty: -1
         // Total shift = (opener_ni - closer_ni + 2) - closer_empty - opener_empty.
-        let above_shift = 2_isize
-            + (opener_ni.cast_signed() - closer_ni.cast_signed())
+        let above_shift = 2_isize + (opener_ni.cast_signed() - closer_ni.cast_signed())
             - isize::from(closer_empty)
             - isize::from(opener_empty);
 
@@ -1212,10 +1215,7 @@ mod inline_tests {
     fn rule_of_3_prevents_outer_strong() {
         // **a*b** — the `*` closer + `**` opener sum is 3 which would violate rule-of-3 when one
         // side can both open and close, so the `*b` ends up literal inside Strong.
-        assert_eq!(
-            p("**a*b**"),
-            vec![Inline::Strong(vec![str("a*b")])]
-        );
+        assert_eq!(p("**a*b**"), vec![Inline::Strong(vec![str("a*b")])]);
     }
 
     #[test]
@@ -1262,10 +1262,7 @@ mod inline_tests {
     fn nested_bracket_in_link_text() {
         // [[a]](u) — the inner [a] becomes a literal `[a]` in the link text because it has no
         // matching target of its own, and the outer pair provides the `(u)` target.
-        assert_eq!(
-            p("[[a]](u)"),
-            vec![link(vec![str("[a]")], "u")]
-        );
+        assert_eq!(p("[[a]](u)"), vec![link(vec![str("[a]")], "u")]);
     }
 
     #[test]
@@ -1347,10 +1344,7 @@ mod inline_tests {
     fn unmatched_tilde_run_stays_literal_when_strikeout_only() {
         // `~~a~` — the single `~` is a closer that can't find an opener (the `~~` needs length-2
         // pair and subscript is off), so the whole thing stays literal.
-        assert_eq!(
-            pe("~~a~", exts(&[Extension::Strikeout])),
-            vec![str("~~a~")]
-        );
+        assert_eq!(pe("~~a~", exts(&[Extension::Strikeout])), vec![str("~~a~")]);
     }
 
     #[test]
@@ -1381,11 +1375,7 @@ mod inline_tests {
         assert_eq!(
             p("![[[foo](uri1)](uri2)](uri3)"),
             vec![image(
-                vec![
-                    str("["),
-                    link(vec![str("foo")], "uri1"),
-                    str("](uri2)"),
-                ],
+                vec![str("["), link(vec![str("foo")], "uri1"), str("](uri2)"),],
                 "uri3",
             )]
         );

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -153,8 +153,6 @@ struct Delimiter {
     count: usize,
     can_open: bool,
     can_close: bool,
-    /// For `[` / `![` openers used by link resolution; inactive once consumed or deactivated.
-    active: bool,
     /// Whether this is an image opener (`![`).
     image: bool,
     /// Source index just past a bracket opener, where its raw label text begins. Unused otherwise.
@@ -169,6 +167,7 @@ fn parse_inlines(text: &str, refs: &RefMap, ext: Extensions) -> Vec<Inline> {
         nodes: Vec::new(),
         refs,
         ext,
+        bracket_stack: Vec::new(),
     };
     parser.run();
     let mut nodes = parser.nodes;
@@ -182,6 +181,9 @@ struct InlineParser<'a> {
     nodes: Vec<Node>,
     refs: &'a RefMap,
     ext: Extensions,
+    /// Indices into `nodes` for each open `[` or `![` delimiter, in parse order. O(1) lookup of
+    /// the most recent bracket opener instead of a backward scan through all nodes.
+    bracket_stack: Vec<usize>,
 }
 
 impl InlineParser<'_> {
@@ -370,19 +372,19 @@ impl InlineParser<'_> {
             count,
             can_open,
             can_close,
-            active: true,
             image: false,
             text_start: self.pos,
         }));
     }
 
     fn push_open_bracket(&mut self, image: bool) {
+        let node_index = self.nodes.len();
+        self.bracket_stack.push(node_index);
         self.nodes.push(Node::Delimiter(Delimiter {
             ch: b'[',
             count: 1,
             can_open: true,
             can_close: false,
-            active: true,
             image,
             text_start: self.pos,
         }));
@@ -390,19 +392,14 @@ impl InlineParser<'_> {
 
     fn close_bracket(&mut self) {
         self.pos += 1;
-        let Some(opener_index) = self.last_bracket_opener() else {
+        let Some(&opener_index) = self.bracket_stack.last() else {
             self.push_text(']');
             return;
         };
         let is_image = matches!(self.nodes.get(opener_index), Some(Node::Delimiter(d)) if d.image);
-        let active = matches!(self.nodes.get(opener_index), Some(Node::Delimiter(d)) if d.active);
-        if !active {
-            self.literalize_bracket(opener_index);
-            self.push_text(']');
-            return;
-        }
 
         if let Some((target, next)) = self.try_link_target(opener_index) {
+            self.bracket_stack.pop();
             self.pos = next;
             self.build_link(opener_index, is_image, target);
             if !is_image {
@@ -411,6 +408,7 @@ impl InlineParser<'_> {
             return;
         }
         // Not a valid link: the opener reverts to its literal `[` / `![`, and `]` stays literal.
+        self.bracket_stack.pop();
         self.literalize_bracket(opener_index);
         self.push_text(']');
     }
@@ -425,22 +423,28 @@ impl InlineParser<'_> {
         }
     }
 
-    fn last_bracket_opener(&self) -> Option<usize> {
-        self.nodes
-            .iter()
-            .enumerate()
-            .rev()
-            .find_map(|(i, node)| matches!(node, Node::Delimiter(d) if d.ch == b'[').then_some(i))
-    }
-
+    /// Deactivate all non-image `[` openers before `before` in the node list, preventing them
+    /// from forming links that would contain the link just built. Deactivated openers are
+    /// removed from the bracket stack and converted to literal text immediately, so future
+    /// `]` characters cannot accidentally revive them.
     fn deactivate_earlier_brackets(&mut self, before: usize) {
-        for node in self.nodes.get_mut(..before).into_iter().flatten() {
-            if let Node::Delimiter(d) = node
-                && d.ch == b'['
-                && !d.image
-            {
-                d.active = false;
+        // Walk the stack; entries with node_index < before are the earlier openers.
+        // Iterate forward; when we remove an entry, the next entry shifts into position `i`,
+        // so we do not increment in that case.
+        let mut i = 0;
+        while i < self.bracket_stack.len() {
+            let Some(ni) = self.bracket_stack.get(i).copied() else {
+                break;
+            };
+            if ni < before {
+                let is_image = matches!(self.nodes.get(ni), Some(Node::Delimiter(d)) if d.image);
+                if !is_image {
+                    self.bracket_stack.remove(i);
+                    self.literalize_bracket(ni);
+                    continue; // don't increment — next entry shifted into position i
+                }
             }
+            i += 1;
         }
     }
 
@@ -488,6 +492,9 @@ impl InlineParser<'_> {
     fn build_link(&mut self, opener_index: usize, is_image: bool, target: Target) {
         let mut inner: Vec<Node> = self.nodes.split_off(opener_index + 1);
         self.nodes.pop(); // remove the opener delimiter
+        // Any bracket stack entries that pointed into the split-off range are now part of the
+        // inner node list passed to process_emphasis; they no longer belong to the outer parse.
+        self.bracket_stack.retain(|&ni| ni < opener_index);
         process_emphasis(&mut inner, 0, self.ext);
         let content = collapse(inner);
         let inline = if is_image {
@@ -506,77 +513,265 @@ fn def_target(def: &LinkDef) -> Target {
     }
 }
 
+/// A record in the delimiter list used by [`process_emphasis`].
+#[derive(Debug, Clone)]
+struct DelimEntry {
+    /// Index into `nodes` where this delimiter lives.
+    node_index: usize,
+    ch: u8,
+    count: usize,
+    can_open: bool,
+    can_close: bool,
+}
+
 /// Resolve emphasis/strong (`*`/`_`) and format (`~`/`^`) delimiters in `nodes`, starting at
 /// `stack_bottom`.
 ///
-/// All four delimiter kinds share one matching loop: a closer pairs with the nearest preceding
-/// opener of the same character that passes the rule of 3, and the pair is wrapped, decremented, and
-/// (when emptied) dropped. They differ only in how a matched pair's length maps to a node — see
-/// [`match_use_count`] and [`wrap_emphasis`].
+/// Implements the linear algorithm from the spec ("An algorithm for parsing nested emphasis and
+/// links", `CommonMark` spec §A): a single left-to-right pass over closers, with per-bucket
+/// `openers_bottom` lower bounds that prevent re-scanning already-rejected opener ranges.
+///
+/// All four delimiter kinds share one matching loop. They differ only in how a matched pair's
+/// length maps to a node — see [`match_use_count`] and [`wrap_emphasis`].
+// `opener_di` (delimiter-list index) and `opener_ni` (node index) are intentionally close names
+// for two distinct indices into two distinct arrays.
+#[allow(clippy::similar_names, clippy::too_many_lines)]
 fn process_emphasis(nodes: &mut Vec<Node>, stack_bottom: usize, ext: Extensions) {
-    let mut closer = stack_bottom;
-    while closer < nodes.len() {
-        let closer_ch = match nodes.get(closer) {
-            Some(Node::Delimiter(d)) if d.can_close && is_delimiter_char(d.ch) => d.ch,
-            _ => {
-                closer += 1;
+    // Build the delimiter list: one entry per Node::Delimiter in [stack_bottom..] that is an
+    // emphasis-class delimiter (not a bracket opener).
+    let mut delims: Vec<DelimEntry> = nodes
+        .iter()
+        .enumerate()
+        .skip(stack_bottom)
+        .filter_map(|(ni, node)| match node {
+            Node::Delimiter(d) if is_delimiter_char(d.ch) => Some(DelimEntry {
+                node_index: ni,
+                ch: d.ch,
+                count: d.count,
+                can_open: d.can_open,
+                can_close: d.can_close,
+            }),
+            _ => None,
+        })
+        .collect();
+
+    // `openers_bottom[bucket]` is the minimum delimiter-list index to search for an opener.
+    //
+    // Bucket key: `(char_index, count_mod3, can_also_open, long_enough_for_two)`.
+    // The first three fields follow the spec directly (§A: "indexed to the length of the
+    // closing delimiter run modulo 3 and to whether the closing delimiter can also be an opener").
+    // The fourth — `closer_count >= 2` — is required for `~` when strikeout is on but subscript
+    // is off: `match_use_count` returns `None` for a length-1 tilde pair, so a length-1 closer
+    // must not share an `openers_bottom` slot with a length-2+ closer. Any future delimiter kind
+    // whose opener acceptance depends on a count threshold must derive its slot key from the same
+    // invariant: two closers may share a slot only if every opener accepts or rejects them
+    // identically.
+    let mut openers_bottom = std::collections::BTreeMap::<(u8, usize, bool, bool), usize>::new();
+
+    let mut current = 0usize; // index into `delims`, advances only forward
+
+    while current < delims.len() {
+        let Some(current_entry) = delims.get(current) else {
+            break;
+        };
+        let (closer_ch, closer_count, closer_can_open, closer_can_close) =
+            (current_entry.ch, current_entry.count, current_entry.can_open, current_entry.can_close);
+        let closer_ni = current_entry.node_index;
+        if !closer_can_close {
+            current += 1;
+            continue;
+        }
+
+        let bucket = (
+            closer_ch,
+            closer_count % 3,
+            closer_can_open,
+            closer_count >= 2,
+        );
+        let bottom = *openers_bottom.get(&bucket).unwrap_or(&0);
+
+        // Scan backward from just before `current` down to `bottom` for a matching opener.
+        let mut found: Option<usize> = None; // delimiter-list index of the matched opener
+        let mut scan = current;
+        while scan > bottom {
+            scan -= 1;
+            let Some(entry) = delims.get(scan) else {
+                break;
+            };
+            if !entry.can_open || entry.ch != closer_ch {
                 continue;
             }
-        };
-        let closer_count = delimiter_count(nodes, closer);
-
-        // Find a matching opener below: same character, rule of 3 satisfied, and a length pairing
-        // that the enabled extensions actually map to a node.
-        let mut opener = None;
-        let mut index = closer;
-        while index > stack_bottom {
-            index -= 1;
-            if let Some(Node::Delimiter(d)) = nodes.get(index)
-                && d.can_open
-                && d.ch == closer_ch
-                && emphasis_match(d, nodes, closer)
-                && let Some(use_count) = match_use_count(d.count, closer_count, closer_ch, ext)
-            {
-                opener = Some((index, use_count));
+            // Rule of 3 and match_use_count check — we need a temporary Delimiter value to
+            // reuse `emphasis_match`, which borrows `nodes` by index.
+            let use_count = match_use_count(entry.count, closer_count, closer_ch, ext);
+            if use_count.is_none() {
+                // `match_use_count` rejected this opener; keep scanning — do not advance
+                // `openers_bottom` for this slot just because one opener was rejected.
+                continue;
+            }
+            // Re-derive the Delimiter from `nodes` for the rule-of-3 check.
+            let ni = entry.node_index;
+            let rule_ok = match nodes.get(ni) {
+                Some(Node::Delimiter(d)) => emphasis_match(d, nodes, closer_ni),
+                _ => false,
+            };
+            if rule_ok {
+                found = Some(scan);
                 break;
             }
         }
-        let Some((opener_index, use_count)) = opener else {
-            // No opener; if this delimiter also can't open, it's inert.
-            if let Some(Node::Delimiter(d)) = nodes.get(closer)
-                && !d.can_open
-            {
-                convert_delimiter_to_text(nodes, closer);
+
+        let Some(opener_di) = found else {
+            // No opener found: advance openers_bottom to exclude this closer's position in future
+            // searches for the same bucket.
+            openers_bottom.insert(bucket, current);
+            // A delimiter that can't open is now known to be inert as a closer too.
+            if !closer_can_open {
+                // convert_delimiter_to_text replaces the node variant in-place; no index shift.
+                convert_delimiter_to_text(nodes, closer_ni);
             }
-            closer += 1;
+            current += 1;
             continue;
         };
 
-        // Wrap the nodes strictly between opener and closer, then place the wrapped inline back
-        // between the two (now adjacent) delimiters before trimming their counts.
-        let inner: Vec<Node> = nodes.drain(opener_index + 1..closer).collect();
+        // --- Match found: splice nodes and update the delimiter list ---
+
+        let Some(opener_entry) = delims.get(opener_di) else {
+            break;
+        };
+        let (opener_ni, opener_count) = (opener_entry.node_index, opener_entry.count);
+
+        // Retrieve use_count (already validated above).
+        let use_count = match_use_count(opener_count, closer_count, closer_ch, ext).unwrap_or(1);
+
+        // Drain all nodes strictly between opener and closer into `content`, collapse, and wrap.
+        let inner: Vec<Node> = nodes.drain(opener_ni + 1..closer_ni).collect();
         let content = collapse(inner);
         let wrapped = wrap_emphasis(closer_ch, use_count, content);
-        let wrapped_index = opener_index + 1;
-        nodes.insert(wrapped_index, Node::Inline(wrapped));
+        // Insert the wrapped inline where the inner content was.
+        nodes.insert(opener_ni + 1, Node::Inline(wrapped));
 
-        // Decrement counts and drop emptied delimiters, closer first so the opener index holds.
-        let closer_index = wrapped_index + 1;
-        decrement_delimiter(nodes, closer_index, use_count);
-        decrement_delimiter(nodes, opener_index, use_count);
-        let mut removable = [closer_index, opener_index];
-        removable.sort_unstable_by(|a, b| b.cmp(a));
-        for index in removable {
-            if matches!(nodes.get(index), Some(Node::Delimiter(d)) if d.count == 0) {
-                nodes.remove(index);
+        // After drain(opener_ni+1..closer_ni) and insert(opener_ni+1), the closer node is at
+        // opener_ni + 2. We then conditionally remove the closer and opener delimiter nodes,
+        // which shifts remaining node_index values. Track all of that in one place.
+        let new_closer_ni = opener_ni + 2;
+
+        // Decrement delimiter counts (closer first; it's at the higher index).
+        decrement_delimiter(nodes, new_closer_ni, use_count);
+        decrement_delimiter(nodes, opener_ni, use_count);
+
+        // Reflect decrements back into `delims`.
+        let new_closer_count = closer_count.saturating_sub(use_count);
+        let new_opener_count = opener_count.saturating_sub(use_count);
+        if let Some(e) = delims.get_mut(current) {
+            e.count = new_closer_count;
+        }
+        if let Some(e) = delims.get_mut(opener_di) {
+            e.count = new_opener_count;
+        }
+
+        // Drop emptied delimiter nodes from `nodes`, highest index first so lower indices hold.
+        let closer_empty = new_closer_count == 0;
+        let opener_empty = new_opener_count == 0;
+        if closer_empty {
+            nodes.remove(new_closer_ni);
+        }
+        if opener_empty {
+            nodes.remove(opener_ni);
+        }
+
+        // Compute the total shift experienced by node indices that were strictly above closer_ni
+        // in the original node vector, after all four operations (drain, insert, remove×0/1/2):
+        //
+        //   drain(opener_ni+1..closer_ni): removes (closer_ni - opener_ni - 1) nodes above opener_ni
+        //   insert at opener_ni+1: adds 1 node above opener_ni
+        //   remove(new_closer_ni) if closer_empty: removes 1 node that was at new_closer_ni
+        //   remove(opener_ni) if opener_empty: removes 1 node at opener_ni (below closer)
+        //
+        // For a node_index N > closer_ni (i.e., above the old closer):
+        //   after drain+insert: new pos = N + opener_ni - closer_ni + 2
+        //   after remove(closer) if empty: -1
+        //   after remove(opener) if empty: -1
+        // Total shift = (opener_ni - closer_ni + 2) - closer_empty - opener_empty.
+        let above_shift = 2_isize
+            + (opener_ni.cast_signed() - closer_ni.cast_signed())
+            - isize::from(closer_empty)
+            - isize::from(opener_empty);
+
+        // The surviving closer's final node_index (only relevant when !closer_empty):
+        //   after drain+insert it's at new_closer_ni = opener_ni+2;
+        //   after remove(opener) if empty: it shifts to opener_ni+1.
+        let final_closer_ni = opener_ni + 1 + usize::from(!opener_empty);
+
+        // Update the delimiter list:
+        // Step A: remove inner delimiter entries (consumed into the wrapped span).
+        delims.drain(opener_di + 1..current);
+        // After this drain, the old `current` entry is now at opener_di + 1.
+        let current_di_after = opener_di + 1;
+
+        // Step B: remove the closer and opener entries from `delims` if they are now empty.
+        // Closer is at current_di_after; remove it first (higher index).
+        if closer_empty {
+            delims.remove(current_di_after);
+        }
+        if opener_empty {
+            delims.remove(opener_di);
+        }
+
+        // Step C: update node_index for all surviving entries.
+        //
+        // After Steps A and B, `delims` contains no entries for the now-wrapped inner span.
+        // The surviving delimiter entries fall into three groups:
+        //   1. Entries at or before opener_di with node_index <= opener_ni: unchanged.
+        //   2. The surviving opener (if !opener_empty) at delimiter index opener_di,
+        //      node_index = opener_ni: already correct.
+        //   3. The surviving closer (if !closer_empty): node_index must be final_closer_ni.
+        //   4. Entries after the match with node_index > closer_ni: shift by above_shift.
+        //
+        // Determine where the "entries after the match" start in the updated delimiter list.
+        let first_after_di = match (opener_empty, closer_empty) {
+            (true, true) => opener_di,
+            (false, true) => opener_di + 1, // opener at opener_di; nothing else in the region
+            (true, false) => {
+                // closer survived at opener_di; update its node_index.
+                if let Some(e) = delims.get_mut(opener_di) {
+                    e.node_index = final_closer_ni;
+                }
+                opener_di + 1
+            }
+            (false, false) => {
+                // opener at opener_di; closer at opener_di + 1; update closer's node_index.
+                if let Some(e) = delims.get_mut(opener_di + 1) {
+                    e.node_index = final_closer_ni;
+                }
+                opener_di + 2
+            }
+        };
+
+        // Apply the total shift to all entries that come after the match region.
+        if above_shift != 0 {
+            for entry in delims.get_mut(first_after_di..).into_iter().flatten() {
+                entry.node_index =
+                    usize::try_from(entry.node_index.cast_signed() + above_shift).unwrap_or(0);
             }
         }
 
-        closer = stack_bottom;
+        // `openers_bottom` entries that pointed into the inner delimiter-list range
+        // [opener_di+1, current] are now stale. Clamp them conservatively to opener_di so future
+        // searches start from a valid position.
+        for v in openers_bottom.values_mut() {
+            if *v > opener_di {
+                *v = opener_di;
+            }
+        }
+
+        // Resume from opener_di: the surviving closer (if any) may still match further openers.
+        current = opener_di;
     }
+
     // Any leftover delimiters become literal text.
-    for index in 0..nodes.len() {
-        convert_delimiter_to_text(nodes, index);
+    for entry in &delims {
+        convert_delimiter_to_text(nodes, entry.node_index);
     }
 }
 
@@ -643,13 +838,6 @@ fn emphasis_match(opener: &Delimiter, nodes: &[Node], closer: usize) -> bool {
         }
     }
     true
-}
-
-fn delimiter_count(nodes: &[Node], index: usize) -> usize {
-    match nodes.get(index) {
-        Some(Node::Delimiter(d)) => d.count,
-        _ => 0,
-    }
 }
 
 fn decrement_delimiter(nodes: &mut [Node], index: usize, by: usize) {

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -756,12 +756,21 @@ fn process_emphasis(nodes: &mut Vec<Node>, stack_bottom: usize, ext: Extensions)
             }
         }
 
-        // `openers_bottom` entries that pointed into the inner delimiter-list range
-        // [opener_di+1, current] are now stale. Clamp them conservatively to opener_di so future
-        // searches start from a valid position.
+        // Adjust `openers_bottom` for the delimiter-list compaction that just happened.
+        //
+        // After `delims.drain(opener_di+1..current)` + conditional removes:
+        //   - Values <= opener_di: unchanged.
+        //   - Values in (opener_di, current): pointed into the now-removed inner span → clamp to
+        //     opener_di (those openers no longer exist in the list).
+        //   - Values >= current: shifted down by (current - opener_di - 1) for the drain, then
+        //     by -1 for each removed endpoint (closer and/or opener).
+        let inner_drain = current - opener_di - 1;
+        let endpoint_removes = usize::from(closer_empty) + usize::from(opener_empty);
         for v in openers_bottom.values_mut() {
-            if *v > opener_di {
+            if *v > opener_di && *v < current {
                 *v = opener_di;
+            } else if *v >= current {
+                *v = v.saturating_sub(inner_drain + endpoint_removes);
             }
         }
 

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -157,6 +157,13 @@ struct Delimiter {
     image: bool,
     /// Source index just past a bracket opener, where its raw label text begins. Unused otherwise.
     text_start: usize,
+    /// Whether this bracket opener is still eligible to form a link or image. Non-bracket
+    /// delimiters leave this `false` (the field is unused for them).
+    ///
+    /// A `[` opener is deactivated when a link is successfully built whose text span contains
+    /// it — a link may not contain another link. On `]`, an inactive opener is popped and
+    /// literalized without attempting any link-target parse (spec §6.3, rule 6).
+    active: bool,
 }
 
 fn parse_inlines(text: &str, refs: &RefMap, ext: Extensions) -> Vec<Inline> {
@@ -374,6 +381,7 @@ impl InlineParser<'_> {
             can_close,
             image: false,
             text_start: self.pos,
+            active: false,
         }));
     }
 
@@ -387,6 +395,7 @@ impl InlineParser<'_> {
             can_close: false,
             image,
             text_start: self.pos,
+            active: true,
         }));
     }
 
@@ -396,7 +405,19 @@ impl InlineParser<'_> {
             self.push_text(']');
             return;
         };
-        let is_image = matches!(self.nodes.get(opener_index), Some(Node::Delimiter(d)) if d.image);
+        let (is_image, is_active) = match self.nodes.get(opener_index) {
+            Some(Node::Delimiter(d)) => (d.image, d.active),
+            _ => (false, false),
+        };
+
+        // An inactive opener cannot form a link. Pop it, literalize, and emit `]` as text —
+        // do not look further down the stack (spec §6.3, rule 6).
+        if !is_active {
+            self.bracket_stack.pop();
+            self.literalize_bracket(opener_index);
+            self.push_text(']');
+            return;
+        }
 
         if let Some((target, next)) = self.try_link_target(opener_index) {
             self.bracket_stack.pop();
@@ -423,28 +444,20 @@ impl InlineParser<'_> {
         }
     }
 
-    /// Deactivate all non-image `[` openers before `before` in the node list, preventing them
-    /// from forming links that would contain the link just built. Deactivated openers are
-    /// removed from the bracket stack and converted to literal text immediately, so future
-    /// `]` characters cannot accidentally revive them.
+    /// Mark all non-image `[` openers that appear before `before` in the node list as inactive,
+    /// preventing them from forming links that would contain the link just built. Inactive openers
+    /// remain on the bracket stack so that a later `]` can consume them one at a time (spec §6.3,
+    /// rule 6): each `]` pops the top inactive entry, literalizes it, and emits `]` as text.
     fn deactivate_earlier_brackets(&mut self, before: usize) {
-        // Walk the stack; entries with node_index < before are the earlier openers.
-        // Iterate forward; when we remove an entry, the next entry shifts into position `i`,
-        // so we do not increment in that case.
-        let mut i = 0;
-        while i < self.bracket_stack.len() {
-            let Some(ni) = self.bracket_stack.get(i).copied() else {
-                break;
-            };
-            if ni < before {
-                let is_image = matches!(self.nodes.get(ni), Some(Node::Delimiter(d)) if d.image);
-                if !is_image {
-                    self.bracket_stack.remove(i);
-                    self.literalize_bracket(ni);
-                    continue; // don't increment — next entry shifted into position i
-                }
+        for &ni in &self.bracket_stack {
+            if ni >= before {
+                continue;
             }
-            i += 1;
+            if let Some(Node::Delimiter(d)) = self.nodes.get_mut(ni)
+                && !d.image
+            {
+                d.active = false;
+            }
         }
     }
 
@@ -1351,6 +1364,30 @@ mod inline_tests {
                 Inline::Space,
                 str("c"),
             ])]
+        );
+    }
+
+    #[test]
+    fn nested_image_with_inner_link_and_deactivated_bracket() {
+        // ![[[foo](uri1)](uri2)](uri3)
+        //
+        // The outermost `![` is an image opener. The first `[` inside is a plain bracket opener.
+        // `[foo](uri1)` matches as a link; that success deactivates the `[` opener between the
+        // image `![` and `[foo]`. The next `]` encounters that deactivated opener: it must pop
+        // it, literalize it, and emit `]` as text — not look further to the image opener below.
+        // Only the final `](uri3)` closes the image.
+        //
+        // Expected: Image(uri3, alt=[Str("["), Link([Str("foo")], uri1), Str("](uri2)")])
+        assert_eq!(
+            p("![[[foo](uri1)](uri2)](uri3)"),
+            vec![image(
+                vec![
+                    str("["),
+                    link(vec![str("foo")], "uri1"),
+                    str("](uri2)"),
+                ],
+                "uri3",
+            )]
         );
     }
 }


### PR DESCRIPTION
Rewrites the CommonMark inline resolver to the spec's linear delimiter-stack algorithm (one left-to-right closer pass with per-class `openers_bottom` bounds) and replaces the per-`]` backward bracket scan with a bracket stack using lazy inactive-opener semantics. `pathological_brackets` now scales linearly (9.5×→3.7×, 23.8 ms→2.7 ms at 32 KiB) with byte-identical output — full conformance suite green, 652/652 spec examples. `emphasis_heavy` remains quadratic (per-match node splices); follow-up tracked in plan 005.