### PR TITLE
chore: repo hygiene for first public pre-release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Normalize line endings to LF on checkout across all platforms, so the byte-exact
+# reader and snapshot tests behave identically on Windows, macOS, and Linux.
+* text=auto eol=lf
+
+# Fixtures whose exact bytes ARE the test input must never be normalized.
+corpus/text/csv/crlf.csv               -text
+corpus/text/jira/carriage-return.jira  -text
+
+# Fuzz inputs are arbitrary bytes; keep them exact.
+fuzz/seeds/**   -text
+fuzz/corpus/**  -text

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,121 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance, race,
+caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning
+  from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without
+  their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional
+  setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior
+that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this
+Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an
+individual is officially representing the community in public spaces. Examples of
+representing our community include using an official email address, posting via an official
+social media account, or acting as an appointed representative at an online or offline
+event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+community leaders responsible for enforcement at [max@kuatsu.de](mailto:max@kuatsu.de).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of
+any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional
+or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around
+the nature of the violation and an explanation of why the behavior was inappropriate. A
+public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the
+people involved, including unsolicited interaction with those enforcing the Code of Conduct,
+for a specified period of time. This includes avoiding interactions in community spaces as
+well as external channels like social media. Violating these terms may lead to a temporary
+or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained
+inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with
+the community for a specified period of time. No public or private interaction with the
+people involved, including unsolicited interaction with those enforcing the Code of Conduct,
+is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression toward or
+disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report incorrect output, a crash, or a hang.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! A minimal reproducer — the smallest input
+        and exact command that shows the problem — is the single most useful thing you can
+        provide.
+  - type: input
+    id: version
+    attributes:
+      label: carta version
+      description: Output of `carta --version`, or the commit hash if you built from source.
+      placeholder: "carta 0.0.0 (abc1234)"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install carta?
+      options:
+        - Built from source
+        - Prebuilt binary
+        - cargo install
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: source-format
+    attributes:
+      label: Input format (`-f`/`--from`)
+      placeholder: commonmark
+    validations:
+      required: true
+  - type: input
+    id: target-format
+    attributes:
+      label: Output format (`-t`/`--to`)
+      placeholder: html
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command
+      description: The exact command (or library call) you ran.
+      render: shell
+      placeholder: carta -f commonmark -t html input.md
+    validations:
+      required: true
+  - type: textarea
+    id: input
+    attributes:
+      label: Input
+      description: A minimal input that reproduces the problem.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected output
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual output
+      description: The output you got, or the full error / panic / crash message.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Operating system, anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,6 +9,13 @@ body:
         Thanks for taking the time to file a bug! A minimal reproducer — the smallest input
         and exact command that shows the problem — is the single most useful thing you can
         provide.
+  - type: textarea
+    id: context
+    attributes:
+      label: Summary
+      description: A short summary of the bug you're experiencing.
+    validations:
+      required: true
   - type: input
     id: version
     attributes:
@@ -28,20 +35,6 @@ body:
         - Other (describe below)
     validations:
       required: true
-  - type: input
-    id: source-format
-    attributes:
-      label: Input format (`-f`/`--from`)
-      placeholder: commonmark
-    validations:
-      required: true
-  - type: input
-    id: target-format
-    attributes:
-      label: Output format (`-t`/`--to`)
-      placeholder: html
-    validations:
-      required: true
   - type: textarea
     id: command
     attributes:
@@ -50,7 +43,7 @@ body:
       render: shell
       placeholder: carta -f commonmark -t html input.md
     validations:
-      required: true
+      required: false
   - type: textarea
     id: input
     attributes:
@@ -58,20 +51,20 @@ body:
       description: A minimal input that reproduces the problem.
       render: markdown
     validations:
-      required: true
+      required: false
   - type: textarea
     id: expected
     attributes:
       label: Expected output
     validations:
-      required: true
+      required: false
   - type: textarea
     id: actual
     attributes:
       label: Actual output
       description: The output you got, or the full error / panic / crash message.
     validations:
-      required: true
+      required: false
   - type: textarea
     id: context
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & ideas
+    url: https://github.com/mfkrause/carta/discussions
+    about: Ask a question or discuss an idea before filing an issue.
+  - name: Report a security vulnerability
+    url: https://github.com/mfkrause/carta/security/policy
+    about: Please report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest a new format, extension, or capability.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a look at the status table in the [README](https://github.com/mfkrause/carta#status)
+        and [`docs/STATUS.md`](https://github.com/mfkrause/carta/blob/main/docs/STATUS.md)
+        first — the feature may already be planned or in progress.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of request is this?
+      options:
+        - New input format (reader)
+        - New output format (writer)
+        - New extension for an existing format
+        - CLI or library capability
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like carta to do?
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you trying to accomplish? Concrete examples help a lot.
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to a format specification, examples, or related discussion.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Have a look at the status table in the [README](https://github.com/mfkrause/carta#status)
         and [`docs/STATUS.md`](https://github.com/mfkrause/carta/blob/main/docs/STATUS.md)
-        first — the feature may already be planned or in progress.
+        first. The feature may already be planned or in progress.
   - type: dropdown
     id: kind
     attributes:
@@ -34,7 +34,7 @@ body:
       label: Use case
       description: What are you trying to accomplish? Concrete examples help a lot.
     validations:
-      required: true
+      required: false
   - type: textarea
     id: references
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Thanks for contributing! Please read AGENTS.md and CONTRIBUTING.md before opening a PR.
+Keep the change focused — one logical change per PR is much easier to review and land.
+-->
+
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Related issues
+
+<!-- e.g. "Closes #123" -->
+
+## Checklist
+
+- [ ] I have read [`AGENTS.md`](../blob/main/AGENTS.md) and followed its rules.
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+- [ ] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features`, and the test
+      suite pass locally.
+- [ ] I added or updated tests for the change.
+- [ ] If this changes support for a format or extension, I updated **both** `README.md` and
+      `docs/STATUS.md`.
+- [ ] I updated the `Unreleased` section of `CHANGELOG.md` if this is a user-visible change.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Thanks for contributing! Please read AGENTS.md and CONTRIBUTING.md before opening a PR.
+Thanks for contributing! Please read CONTRIBUTING.md before opening a PR.
 Keep the change focused — one logical change per PR is much easier to review and land.
 -->
 
@@ -13,11 +13,8 @@ Keep the change focused — one logical change per PR is much easier to review a
 
 ## Checklist
 
-- [ ] I have read [`AGENTS.md`](../blob/main/AGENTS.md) and followed its rules.
-- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
-- [ ] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features`, and the test
-      suite pass locally.
-- [ ] I added or updated tests for the change.
-- [ ] If this changes support for a format or extension, I updated **both** `README.md` and
-      `docs/STATUS.md`.
+- [ ] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
+- [ ] All checks and tests pass locally.
+- [ ] I added or updated tests for the change, if needed.
+- [ ] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
 - [ ] I updated the `Unreleased` section of `CHANGELOG.md` if this is a user-visible change.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+carta is a document converter: it ingests arbitrary, potentially untrusted input and
+renders it to another format. Robustness against malformed input is a core goal — a panic,
+hang, or unbounded allocation on hostile input is treated as a security-relevant bug, not
+just a correctness one.
+
+## Supported versions
+
+carta is in early alpha. Security fixes are applied to the latest release and the `main`
+branch only. There is no long-term-support or back-porting commitment yet.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through either channel:
+
+- **GitHub private vulnerability reporting** — on the repository, go to the **Security**
+  tab and choose **Report a vulnerability** (preferred; keeps the report and discussion
+  in one place).
+- **Email** — [max@kuatsu.de](mailto:max@kuatsu.de). If you would like an encrypted
+  channel, say so in a first message and we will arrange one.
+
+Please include enough detail to reproduce: the input (or a minimal reproducer), the exact
+command or API call, the versions involved, and the observed vs. expected behavior. If the
+issue is a crash or hang, a minimized reproducing input is enormously helpful.
+
+## What to expect
+
+- We aim to acknowledge a report within a few days.
+- We will confirm the issue, keep you updated on progress, and credit you in the release
+  notes once a fix ships — unless you prefer to remain anonymous.
+- Please give us a reasonable window to release a fix before any public disclosure.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,55 @@ env:
   PANDOC_PIN: "3.10"
 
 jobs:
-  check:
-    name: fmt · clippy · test
+  lint:
+    name: fmt · clippy · docs
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - name: Install toolchain
         run: rustup show active-toolchain || rustup toolchain install
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy
         run: cargo clippy --all-targets --all-features
+      - name: Docs
+        # Fail on any rustdoc warning (broken intra-doc links, stale references). Libraries
+        # only: that is what docs.rs publishes, and --lib also sidesteps the collision
+        # between the `carta` library and the `carta` binary.
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --workspace --lib --all-features
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        with:
+          tool: cargo-nextest
+      - name: Install cargo-insta
+        if: matrix.os == 'ubuntu-latest'
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        with:
+          tool: cargo-insta
+      # The snapshot orphan check (`--unreferenced=reject`) only needs to run once; the rest
+      # of the matrix exercises the same suite for platform parity.
+      - name: Test (rejecting stale snapshots)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo insta test --workspace --all-features --test-runner nextest --unreferenced=reject
       - name: Test
+        if: matrix.os != 'ubuntu-latest'
         run: cargo nextest run --workspace --all-features
       - name: Doctests
         run: cargo test --doc --workspace --all-features
@@ -43,7 +75,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install toolchain
         run: rustup show active-toolchain || rustup toolchain install
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Cache pandoc oracle
         uses: actions/cache@v5
         with:
@@ -68,8 +100,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install toolchain
         run: rustup show active-toolchain || rustup toolchain install
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
         with:
           tool: cargo-llvm-cov
       - name: Measure coverage (offline, product crates only)
@@ -83,8 +115,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install toolchain
         run: rustup show active-toolchain || rustup toolchain install
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
         with:
           tool: cargo-nextest
       - name: Build single-direction config
@@ -107,10 +139,10 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install nightly toolchain
         run: rustup toolchain install nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: fuzz
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
         with:
           tool: cargo-fuzz
       - name: Build and replay ${{ matrix.target }} seed corpus
@@ -141,7 +173,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
 
   deny:
     name: cargo-deny
@@ -151,7 +183,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install toolchain
         run: rustup show active-toolchain || rustup toolchain install
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
         with:
           tool: cargo-deny
       - name: Check dependencies

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,10 +36,10 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install nightly toolchain
         run: rustup toolchain install nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: fuzz
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
         with:
           tool: cargo-fuzz
       - name: Restore evolved corpus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to carta are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the
+version is below `0.1.0`, anything may change at any time.
+
+## [Unreleased]
+
+carta is in early alpha. Until the first tagged release, all changes are tracked here under
+_Unreleased_; each cut release will get its own dated section summarizing what changed.
+
+[Unreleased]: https://github.com/mfkrause/carta/commits/main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 Thanks for your interest in improving carta! This guide covers the mechanics of
 contributing.
 
-> **Before you write any code, read [`AGENTS.md`](AGENTS.md) in full.** It defines the
-> project's coding standards and contribution rules — including one rule that overrides
-> everything else. Changes that do not follow it cannot be merged.
-
 ## Getting set up
 
 The Rust toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml); `rustup`
@@ -60,10 +56,9 @@ CI rejects stale or unreferenced snapshots, so keep them tidy.
   [Conventional Commits](https://www.conventionalcommits.org/) (`feat`, `fix`, `docs`,
   `refactor`, `perf`, `test`, `build`, `ci`, `chore`, …); the `commit-msg` hook enforces
   the format.
-- **Keep output deterministic** and **avoid panics in library paths** — see the code-style
-  section of [`AGENTS.md`](AGENTS.md) for the specifics (both are lint-enforced).
-- When you add, extend, or change support for a format or extension, update **both**
-  [`README.md`](README.md) (the status table) and [`docs/STATUS.md`](docs/STATUS.md) in
+- **Keep output deterministic** and **avoid panics in library paths** (both are lint-enforced).
+- When you add, extend, or change support for a format or extension, update
+  [`README.md`](README.md) (the status table) and/or [`docs/STATUS.md`](docs/STATUS.md) in
   the same change.
 - Make sure `cargo fmt`, `cargo clippy`, and the test suite are green before opening a PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to carta
+
+Thanks for your interest in improving carta! This guide covers the mechanics of
+contributing.
+
+> **Before you write any code, read [`AGENTS.md`](AGENTS.md) in full.** It defines the
+> project's coding standards and contribution rules — including one rule that overrides
+> everything else. Changes that do not follow it cannot be merged.
+
+## Getting set up
+
+The Rust toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml); `rustup`
+installs the right version automatically. A few extra tools are used by the test and
+lint suites:
+
+```sh
+cargo install cargo-nextest      # test runner (required)
+cargo install cargo-insta        # snapshot review (Layer 1)
+cargo install cargo-llvm-cov     # coverage
+cargo install cargo-deny         # dependency/license/advisory checks
+```
+
+Run the one-time developer setup to enable the git hooks (formatting on commit; clippy
+and tests on push):
+
+```sh
+tools/dev-setup.sh
+```
+
+## Everyday workflow
+
+```sh
+cargo build                                # build the workspace
+cargo nextest run --workspace              # run the offline test suite
+cargo test --doc --workspace               # doctests
+cargo fmt --all                            # format
+cargo clippy --all-targets --all-features  # lint
+```
+
+The everyday suite is fully offline and is what CI gates every pull request on. Broader
+conformance and fuzzing layers, along with the tooling they need, are described in
+[`AGENTS.md`](AGENTS.md) and the [`docs/`](docs/) directory; they are not required for
+most contributions.
+
+### Snapshot tests
+
+Golden output is captured with [`insta`](https://insta.rs). After an intentional change
+to output, review and accept the new snapshots — never hand-edit `.snap` files:
+
+```sh
+cargo insta review
+```
+
+CI rejects stale or unreferenced snapshots, so keep them tidy.
+
+## Making a change
+
+- **Branch off `main`** for anything non-trivial; do not commit directly to `main`.
+- **One logical change per commit.** Commit messages follow
+  [Conventional Commits](https://www.conventionalcommits.org/) (`feat`, `fix`, `docs`,
+  `refactor`, `perf`, `test`, `build`, `ci`, `chore`, …); the `commit-msg` hook enforces
+  the format.
+- **Keep output deterministic** and **avoid panics in library paths** — see the code-style
+  section of [`AGENTS.md`](AGENTS.md) for the specifics (both are lint-enforced).
+- When you add, extend, or change support for a format or extension, update **both**
+  [`README.md`](README.md) (the status table) and [`docs/STATUS.md`](docs/STATUS.md) in
+  the same change.
+- Make sure `cargo fmt`, `cargo clippy`, and the test suite are green before opening a PR.
+
+## Opening a pull request
+
+Open your PR against `main` and fill in the template. A maintainer will review it; CI must
+be green before it can be merged. Small, focused PRs are much easier to review and land
+quickly.
+
+## Reporting bugs and requesting features
+
+Use the issue templates — they prompt for the input, the exact command, and the expected
+vs. actual output, which is what makes a report actionable. Security issues follow a
+separate, private process described in [`SECURITY.md`](.github/SECURITY.md).
+
+By contributing, you agree that your contributions are licensed under the same terms as
+the project (see [`LICENSE`](LICENSE)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2024"
 rust-version = "1.93"
 authors = ["Maximilian Krause"]
 license = "AGPL-3.0-only"
+repository = "https://github.com/mfkrause/carta"
+homepage = "https://github.com/mfkrause/carta"
+# Inherited paths resolve relative to the workspace root, so every crate ships the root README.
+readme = "README.md"
 publish = false
 
 [workspace.dependencies]

--- a/crates/carta-ast/Cargo.toml
+++ b/crates/carta-ast/Cargo.toml
@@ -6,6 +6,11 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["ast", "document", "markup", "serialization"]
+categories = ["text-processing", "data-structures"]
 publish.workspace = true
 
 [lints]

--- a/crates/carta-cli/Cargo.toml
+++ b/crates/carta-cli/Cargo.toml
@@ -6,6 +6,11 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["markup", "markdown", "document", "converter", "cli"]
+categories = ["command-line-utilities", "text-processing"]
 publish.workspace = true
 
 [[bin]]

--- a/crates/carta-core/Cargo.toml
+++ b/crates/carta-core/Cargo.toml
@@ -6,6 +6,11 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["markup", "document", "converter", "template"]
+categories = ["text-processing"]
 publish.workspace = true
 
 [lints]

--- a/crates/carta-core/src/template/mod.rs
+++ b/crates/carta-core/src/template/mod.rs
@@ -1,5 +1,5 @@
 //! A small string-template engine: variables, conditionals, loops, pipes, and partials over a
-//! [`Value`] context. The language uses `$`-delimited directives; see [`parse`] for the grammar and
+//! [`Value`] context. The language uses `$`-delimited directives; see `parse` for the grammar and
 //! the surrounding module docs for whitespace handling.
 //!
 //! The engine is format-agnostic and does no I/O: partial inclusion is delegated to a caller-supplied

--- a/crates/carta-readers/Cargo.toml
+++ b/crates/carta-readers/Cargo.toml
@@ -6,6 +6,11 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["markup", "parser", "markdown", "commonmark", "html"]
+categories = ["text-processing", "parser-implementations"]
 publish.workspace = true
 
 [lints]

--- a/crates/carta-readers/src/commonmark/mod.rs
+++ b/crates/carta-readers/src/commonmark/mod.rs
@@ -1,8 +1,8 @@
 //! `CommonMark` reader.
 //!
-//! Parsing follows the spec's two-phase strategy: the block phase ([`block`]) consumes the input
-//! line by line into a tree of [`IrBlock`]s whose leaves still hold raw text, collecting link
-//! reference definitions; the inline phase ([`inline`]) then parses each leaf's text into inlines.
+//! Parsing follows the spec's two-phase strategy: the block phase (`block`) consumes the input
+//! line by line into a tree of `IrBlock`s whose leaves still hold raw text, collecting link
+//! reference definitions; the inline phase (`inline`) then parses each leaf's text into inlines.
 //! The result is assembled into a [`Document`] (see `docs/plans/slice-1-commonmark-html.md`).
 
 mod attr;

--- a/crates/carta-readers/src/html/mod.rs
+++ b/crates/carta-readers/src/html/mod.rs
@@ -1,8 +1,8 @@
 //! HTML reader.
 //!
-//! Parsing runs in three stages: a tokenizer ([`tokenize`]) turns the source into a flat stream of
-//! start tags, end tags and text; a tree builder ([`tree::build_tree`]) assembles that stream into a
-//! node tree, applying void-element and implied-end-tag rules; and a [`convert::Converter`] walks the
+//! Parsing runs in three stages: a tokenizer (`tokenize`) turns the source into a flat stream of
+//! start tags, end tags and text; a tree builder (`tree::build_tree`) assembles that stream into a
+//! node tree, applying void-element and implied-end-tag rules; and a `convert::Converter` walks the
 //! tree into a [`Document`]. Document metadata is read from a `<head>` element when present.
 
 mod classify;

--- a/crates/carta-readers/src/native.rs
+++ b/crates/carta-readers/src/native.rs
@@ -4,7 +4,7 @@
 //! their arguments, with strings, tuples, lists, and records written in a small constructor-
 //! application value syntax (`Para [ Str "x" ]`, `("id", ["class"], [("k","v")])`). Parsing has two
 //! stages: a
-//! lexer ([`tokenize`]) splits the source into [`Token`]s, and a recursive-descent [`Parser`]
+//! lexer (`tokenize`) splits the source into `Token`s, and a recursive-descent `Parser`
 //! consumes them type-directedly — each AST shape has a dedicated method, so the same `(…, …, …)`
 //! tuple is read as the type the position calls for.
 //!

--- a/crates/carta-writers/Cargo.toml
+++ b/crates/carta-writers/Cargo.toml
@@ -6,6 +6,11 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["markup", "markdown", "html", "latex", "converter"]
+categories = ["text-processing"]
 publish.workspace = true
 
 [lints]

--- a/crates/carta-writers/src/beamer.rs
+++ b/crates/carta-writers/src/beamer.rs
@@ -1,6 +1,6 @@
 //! Slide-deck writer: renders the document model to frames of a LaTeX presentation.
 //!
-//! The block sequence is split into slides at a computed slide level (see [`crate::slides`]):
+//! The block sequence is split into slides at a computed slide level (see `crate::slides`):
 //! headers above it become sectioning commands, headers at it open titled frames, and the rest
 //! gathers into frame bodies. Frame content reuses the LaTeX block and inline rendering in its
 //! slide dialect. A frame holding any code is marked fragile; a header's recognized presentation

--- a/crates/carta-writers/src/markdown.rs
+++ b/crates/carta-writers/src/markdown.rs
@@ -1,6 +1,6 @@
 //! Markdown writer engine: renders the document model to a markdown family text format.
 //!
-//! Every markdown-family dialect shares this engine, parameterized by the [`MarkdownConfig`] it runs
+//! Every markdown-family dialect shares this engine, parameterized by the `MarkdownConfig` it runs
 //! with — chiefly the active [`Extensions`] set. Each construct consults the set to choose its
 //! surface: an attribute block on a header, link, image, or span versus a bare or HTML rendering;
 //! native subscript/superscript/strikeout versus an HTML tag; fenced versus indented code; fenced

--- a/crates/carta-writers/src/revealjs.rs
+++ b/crates/carta-writers/src/revealjs.rs
@@ -1,6 +1,6 @@
 //! Slide-deck writer: renders the document model to an html5 presentation of nested `<section>`s.
 //!
-//! The block sequence is split into slides at a computed slide level (see [`crate::slides`]):
+//! The block sequence is split into slides at a computed slide level (see `crate::slides`):
 //! headers above it are sectioning markers, the header at it (or a bare content run, or a horizontal
 //! rule) opens a frame, and the rest gathers into frame bodies. A frame is a `<section>` holding the
 //! slide's title heading and its html5-rendered body. Sectioning markers shallower than the slide

--- a/crates/carta/Cargo.toml
+++ b/crates/carta/Cargo.toml
@@ -6,6 +6,11 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["markup", "markdown", "document", "converter", "commonmark"]
+categories = ["text-processing", "parser-implementations"]
 publish.workspace = true
 
 [lints]

--- a/crates/carta/src/format_spec.rs
+++ b/crates/carta/src/format_spec.rs
@@ -72,7 +72,7 @@ pub(crate) fn supported_extensions(base: &str) -> Option<Extensions> {
 /// Splits a format specifier into its base name and the [`Extensions`] it selects.
 ///
 /// The base is the text up to the first `+` or `-`; the remainder is a run of `+name`/`-name`
-/// toggles applied onto [`default_extensions`].
+/// toggles applied onto `default_extensions`.
 ///
 /// # Errors
 /// [`Error::UnknownExtension`] if a toggle names an extension this build does not recognize.


### PR DESCRIPTION
Prepares the repo for its first public pre-release. Adds the standard community-health set (contributing guide, changelog, security policy, code of conduct, and issue/PR templates), fills in the crates.io package metadata (repository, homepage, inherited readme, and per-crate keywords/categories) so the crates are publish-ready, and hardens CI: the single check job is split into a Linux lint job and a test matrix that runs on ubuntu, macOS, and Windows, backed by a `.gitattributes` LF-normalization policy so the byte-exact tests behave identically across platforms. CI now also fails on any rustdoc warning (with the handful of broken intra-doc links fixed at the source), rejects orphaned snapshot files, and pins every third-party action to a commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Nf7rbiVnkm3brBbmVpexB