### PR TITLE
feat(tools): make conformance-suite failures debuggable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,26 @@ jobs:
       - name: Build carta
         run: cargo build -p carta
       - name: Run conformance suite
+        env:
+          CONF_WORK: ${{ runner.temp }}/conformance
         run: tools/conformance-suite/run.sh all
+      - name: Show failing-case details
+        if: failure()
+        env:
+          CONF_WORK: ${{ runner.temp }}/conformance
+        run: |
+          for log in "$CONF_WORK"/*.log; do
+            [ -s "$log" ] || continue
+            echo "===== $log ====="
+            head -n 200 "$log"
+          done
+      - name: Upload conformance logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-logs
+          path: ${{ runner.temp }}/conformance/*.log
+          if-no-files-found: ignore
 
   coverage:
     name: coverage (≥90%)

--- a/tools/bench-suite/lib.sh
+++ b/tools/bench-suite/lib.sh
@@ -17,7 +17,7 @@ export LC_ALL=C
 BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$BENCH_DIR/../shared.sh"
 ORACLE_VERSION_FILE="$ROOT/.oracle/PANDOC_VERSION"
-OX="${OXIDOC_BIN:-$ROOT/target/release/carta}"
+OX="${CARTA_BIN:-${OXIDOC_BIN:-$ROOT/target/release/carta}}"
 SEED="$CORPUS/bench/seed.md"
 
 # Tunables (env-overridable).

--- a/tools/bench-suite/lib.sh
+++ b/tools/bench-suite/lib.sh
@@ -17,7 +17,7 @@ export LC_ALL=C
 BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$BENCH_DIR/../shared.sh"
 ORACLE_VERSION_FILE="$ROOT/.oracle/PANDOC_VERSION"
-OX="${CARTA_BIN:-${OXIDOC_BIN:-$ROOT/target/release/carta}}"
+OX="${CARTA_BIN:-$ROOT/target/release/carta}"
 SEED="$CORPUS/bench/seed.md"
 
 # Tunables (env-overridable).

--- a/tools/conformance-suite/README.md
+++ b/tools/conformance-suite/README.md
@@ -24,6 +24,30 @@ RESULT <surface> <group> pass=N fail=N err=N skip=N
 
 `run.sh` exits non-zero if any surface recorded a `fail` or `err`. **The suite is expected to be red until carta reaches full parity** — every `fail` is a real conformance gap the suite has surfaced, and CI gates on them so they cannot regress further or be forgotten.
 
+## Reproducing one failure
+
+When a group records a `fail` or `err`, the surface prints the path to its full log:
+
+```
+RESULT writer html pass=120 fail=3 err=0 skip=5
+  details: /tmp/carta-conformance/writer-html.log
+```
+
+Each log entry carries the case label, the two exact `repro:` invocations (oracle and carta), and the full diff (bounded at 200 lines). The workflow to iterate on one divergence:
+
+1. Run the surface and read the `details:` log to find the failing case's stem.
+2. Rerun the surface narrowed to that one case — pass the case stem as a second argument:
+
+   ```sh
+   tools/conformance-suite/run.sh writer html my-case   # only corpus/ast/*/my-case.json
+   tools/conformance-suite/run.sh reader latex my-case   # only corpus/text/latex/my-case.*
+   ```
+
+   The stem is the corpus filename without its extension (`corpus/ast/<feature>/<stem>.json`, `corpus/text/<fmt>/<stem>.<ext>`).
+3. Copy the `repro:` lines from the log and run them by hand to iterate on the divergence.
+
+Case narrowing is currently wired for the `reader` and `writer` surfaces only.
+
 ## Requirements
 
 The gitignored `.oracle/` tree must be provisioned, plus `jq`:
@@ -37,7 +61,7 @@ tools/fetch-pandoc-tests.sh    # .oracle/tests/test (native corpus + command tes
 
 ## Environment
 
-- `OXIDOC_BIN` — path to the carta binary (default `target/debug/carta`).
+- `CARTA_BIN` — path to the carta binary (default `target/debug/carta`). The former name `OXIDOC_BIN` still works as a fallback.
 - `CONF_WORK` — scratch + per-case diff logs (default `$TMPDIR/carta-conformance`).
 
 ## Surfaces

--- a/tools/conformance-suite/README.md
+++ b/tools/conformance-suite/README.md
@@ -61,7 +61,7 @@ tools/fetch-pandoc-tests.sh    # .oracle/tests/test (native corpus + command tes
 
 ## Environment
 
-- `CARTA_BIN` — path to the carta binary (default `target/debug/carta`). The former name `OXIDOC_BIN` still works as a fallback.
+- `CARTA_BIN` — path to the carta binary (default `target/debug/carta`).
 - `CONF_WORK` — scratch + per-case diff logs (default `$TMPDIR/carta-conformance`).
 
 ## Surfaces

--- a/tools/conformance-suite/lib.sh
+++ b/tools/conformance-suite/lib.sh
@@ -12,7 +12,7 @@ CONF_LIB_SOURCED=1
 
 CONF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$CONF_DIR/../shared.sh"
-OX="${OXIDOC_BIN:-$ROOT/target/debug/carta}"
+OX="${CARTA_BIN:-${OXIDOC_BIN:-$ROOT/target/debug/carta}}"
 SPEC="$ROOT/vendor/commonmark/spec.txt"
 EXCLUSIONS="$CORPUS/exclusions.tsv"
 FETCHED="$ROOT/.oracle/tests/test"
@@ -68,7 +68,9 @@ compare_json() {
   jq -S . "$1" >"$a" 2>/dev/null || { echo "oracle JSON unparsable"; return 1; }
   jq -S . "$2" >"$b" 2>/dev/null || { echo "carta JSON unparsable"; return 1; }
   cmp -s "$a" "$b" && return 0
-  diff "$a" "$b" | head -n 8
+  # Bound the diff so a pathological (megabyte) mismatch stays reviewable; 200 lines is enough to
+  # see a structural divergence whole.
+  diff "$a" "$b" | head -n 200
   return 1
 }
 
@@ -81,7 +83,7 @@ compare_ipynb() {
   jq -S '(.cells[]?.id) |= "id"' "$1" >"$a" 2>/dev/null || { echo "oracle notebook unparsable"; return 1; }
   jq -S '(.cells[]?.id) |= "id"' "$2" >"$b" 2>/dev/null || { echo "carta notebook unparsable"; return 1; }
   cmp -s "$a" "$b" && return 0
-  diff "$a" "$b" | head -n 8
+  diff "$a" "$b" | head -n 200
   return 1
 }
 
@@ -90,7 +92,7 @@ compare_ipynb() {
 # Renders the diff through `cat -A` so whitespace and line ends are visible.
 compare_bytes() {
   cmp -s "$1" "$2" && return 0
-  diff <(cat -A "$1") <(cat -A "$2") | head -n 8
+  diff <(cat -A "$1") <(cat -A "$2") | head -n 200
   return 1
 }
 
@@ -100,7 +102,7 @@ compare_text() {
   a=$(cat "$1"; printf x); a=${a%x}; a=${a%$'\n'}
   b=$(cat "$2"; printf x); b=${b%x}; b=${b%$'\n'}
   [ "$a" = "$b" ] && return 0
-  diff <(printf '%s\n' "$a") <(printf '%s\n' "$b") | head -n 8
+  diff <(printf '%s\n' "$a") <(printf '%s\n' "$b") | head -n 200
   return 1
 }
 
@@ -119,7 +121,12 @@ report() { echo "RESULT $1 $2 pass=$PASS fail=$FAIL err=$ERR skip=$SKIP"; }
 # Suite-level return code, raised to 1 by any group that recorded a failure or error. A surface
 # script seeds it to 0, calls tally_group after each report, and exits with it.
 SUITE_RC=0
-tally_group() { if [ "$FAIL" -gt 0 ] || [ "$ERR" -gt 0 ]; then SUITE_RC=1; fi; }
+tally_group() {
+  if [ "$FAIL" -gt 0 ] || [ "$ERR" -gt 0 ]; then
+    SUITE_RC=1
+    echo "  details: $SURFACE_LOG" >&2
+  fi
+}
 
 # One differential case: convert `input` with the oracle and with carta, then compare.
 # Usage: run_diff <json|text> <label> <input_file> <oracle_arg_string> <carta_arg_string>
@@ -127,6 +134,9 @@ tally_group() { if [ "$FAIL" -gt 0 ] || [ "$ERR" -gt 0 ]; then SUITE_RC=1; fi; }
 run_diff() {
   local mode="$1" label="$2" input="$3" oargs="$4" xargs="$5"
   local ofile="$WORK/.run.oracle" xfile="$WORK/.run.ox" efile="$WORK/.run.err"
+  # The two exact invocations, so a log entry is a self-contained repro.
+  local repro="repro: $ORACLE $oargs <$input
+       $OX $xargs <$input"
   # shellcheck disable=SC2086
   if ! "$ORACLE" $oargs <"$input" >"$ofile" 2>/dev/null; then
     SKIP=$((SKIP + 1))
@@ -134,14 +144,16 @@ run_diff() {
   fi
   # shellcheck disable=SC2086
   if ! "$OX" $xargs <"$input" >"$xfile" 2>"$efile"; then
-    note_err "$label" "$(head -n 3 "$efile")"
+    note_err "$label" "$repro
+$(head -n 3 "$efile")"
     return
   fi
   local detail
   if detail=$("compare_$mode" "$ofile" "$xfile"); then
     PASS=$((PASS + 1))
   else
-    note_fail "$label" "$detail"
+    note_fail "$label" "$repro
+$detail"
   fi
 }
 

--- a/tools/conformance-suite/lib.sh
+++ b/tools/conformance-suite/lib.sh
@@ -12,7 +12,7 @@ CONF_LIB_SOURCED=1
 
 CONF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$CONF_DIR/../shared.sh"
-OX="${CARTA_BIN:-${OXIDOC_BIN:-$ROOT/target/debug/carta}}"
+OX="${CARTA_BIN:-$ROOT/target/debug/carta}"
 SPEC="$ROOT/vendor/commonmark/spec.txt"
 EXCLUSIONS="$CORPUS/exclusions.tsv"
 FETCHED="$ROOT/.oracle/tests/test"

--- a/tools/conformance-suite/surfaces/reader.sh
+++ b/tools/conformance-suite/surfaces/reader.sh
@@ -5,13 +5,17 @@
 # `pandoc -f <fmt> -t json` (jq -S). For commonmark, additionally run every worked example from the
 # CommonMark spec as a dedicated group so the spec-parity count stays visible.
 #
-# Usage: surfaces/reader.sh [format]   (no arg = every reader format)
+# Usage: surfaces/reader.sh [format] [case]   (no arg = every reader format; case = one corpus stem)
 set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 require_tools
 
 FORMATS="commonmark html native json csv tsv opml rst ipynb mediawiki dokuwiki jira man latex org"
 [ $# -gt 0 ] && FORMATS="$1"
+CASE="${2:-}"
+
+# The case-stem of a corpus file: its basename with the extension stripped.
+stem() { local b; b="$(basename "$1")"; echo "${b%.*}"; }
 
 for fmt in $FORMATS; do
   dir="$CORPUS/text/$fmt"
@@ -19,6 +23,7 @@ for fmt in $FORMATS; do
   conf_reset "reader-$fmt"
   for input in "$dir"/*; do
     [ -f "$input" ] || continue
+    [ -n "$CASE" ] && [ "$(stem "$input")" != "$CASE" ] && continue
     run_diff json "reader/$fmt/$(basename "$input")" "$input" "-f $fmt -t json" "-f $fmt -t json"
   done
   report reader "$fmt"
@@ -36,6 +41,7 @@ if echo "$FORMATS" | grep -qw commonmark && [ -d "$CORPUS/text-ext" ]; then
     spec="$(basename "$spec_dir")"
     for input in "$spec_dir"/*; do
       [ -f "$input" ] || continue
+      [ -n "$CASE" ] && [ "$(stem "$input")" != "$CASE" ] && continue
       run_diff json "reader-ext/$spec/$(basename "$input")" "$input" "-f $spec -t json" "-f $spec -t json"
     done
   done
@@ -50,6 +56,7 @@ if echo "$FORMATS" | grep -qw commonmark; then
   conf_reset "reader-commonmark-spec"
   for input in "$specdir"/*.md; do
     [ -f "$input" ] || continue
+    [ -n "$CASE" ] && [ "$(stem "$input")" != "$CASE" ] && continue
     run_diff json "reader/commonmark-spec/$(basename "$input")" "$input" "-f commonmark -t json" "-f commonmark -t json"
   done
   report reader commonmark-spec

--- a/tools/conformance-suite/surfaces/writer.sh
+++ b/tools/conformance-suite/surfaces/writer.sh
@@ -8,7 +8,7 @@
 # (target, feature) pairs from exclusions.tsv are skipped and counted. On a full run (no target
 # argument) the extension-toggle group below also runs.
 #
-# Usage: surfaces/writer.sh [target]   (no arg = every writer target)
+# Usage: surfaces/writer.sh [target] [case]   (no arg = every writer target; case = one corpus stem)
 set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 require_tools
@@ -16,6 +16,7 @@ require_tools
 TARGETS="html html4 latex rst plain commonmark commonmark_x markdown markdown_github markdown_phpextra markdown_mmd markdown_strict gfm mediawiki native json typst dokuwiki jira asciidoc man opml org beamer revealjs ipynb"
 EXT_RUN=1
 [ $# -gt 0 ] && { TARGETS="$1"; EXT_RUN=0; }
+CASE="${2:-}"
 
 for target in $TARGETS; do
   conf_reset "writer-$target"
@@ -23,6 +24,7 @@ for target in $TARGETS; do
   mode="$(compare_mode "$target")"
   for input in "$CORPUS"/ast/*/*.json; do
     [ -f "$input" ] || continue
+    [ -n "$CASE" ] && [ "$(basename "$input" .json)" != "$CASE" ] && continue
     feature="$(basename "$(dirname "$input")")"
     if is_excluded "$target" "$feature" "$(basename "$input" .json)"; then
       SKIP=$((SKIP + 1))


### PR DESCRIPTION
## Summary

Conformance failures were nearly opaque: diffs truncated to 8 lines, no way to rerun one case, logs discarded in CI. Failure logs now carry full (200-line-bounded) diffs plus exact repro commands, the reader/writer surfaces take a case-stem argument, CI dumps and uploads the logs on failure, and the stale `OXIDOC_BIN` binary override is replaced by `CARTA_BIN`.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed. (Shell tooling — verified behaviorally: forced-failure run, single-case narrowing, and a full `run.sh all` with tallies identical to `main`.)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.