### PR TITLE
perf(ast): box the attribute-bearing node payloads

### DIFF
--- a/crates/carta-ast/src/ast.rs
+++ b/crates/carta-ast/src/ast.rs
@@ -90,17 +90,17 @@ node_enum! {
         Plain(Vec<Inline>),
         Para(Vec<Inline>),
         LineBlock(Vec<Vec<Inline>>),
-        CodeBlock(Attr, Text),
+        CodeBlock(Box<Attr>, Text),
         RawBlock(Format, Text),
         BlockQuote(Vec<Block>),
         OrderedList(ListAttributes, Vec<Vec<Block>>),
         BulletList(Vec<Vec<Block>>),
         DefinitionList(Vec<(Vec<Inline>, Vec<Vec<Block>>)>),
-        Header(i32, Attr, Vec<Inline>),
+        Header(i32, Box<Attr>, Vec<Inline>),
         HorizontalRule,
         Table(Box<Table>),
-        Figure(Attr, Caption, Vec<Block>),
-        Div(Attr, Vec<Block>),
+        Figure(Box<Attr>, Box<Caption>, Vec<Block>),
+        Div(Box<Attr>, Vec<Block>),
     }
     tags: BLOCK_TAGS
 }
@@ -119,16 +119,16 @@ node_enum! {
         SmallCaps(Vec<Inline>),
         Quoted(QuoteType, Vec<Inline>),
         Cite(Vec<Citation>, Vec<Inline>),
-        Code(Attr, Text),
+        Code(Box<Attr>, Text),
         Space,
         SoftBreak,
         LineBreak,
         Math(MathType, Text),
         RawInline(Format, Text),
-        Link(Attr, Vec<Inline>, Target),
-        Image(Attr, Vec<Inline>, Target),
+        Link(Box<Attr>, Vec<Inline>, Box<Target>),
+        Image(Box<Attr>, Vec<Inline>, Box<Target>),
         Note(Vec<Block>),
-        Span(Attr, Vec<Inline>),
+        Span(Box<Attr>, Vec<Inline>),
     }
     tags: INLINE_TAGS
 }
@@ -247,7 +247,9 @@ pub struct ColSpec {
 }
 
 /// A table: its attributes, caption, per-column specs, header, bodies, and footer. Boxed inside
-/// [`Block::Table`] so the common, table-free blocks stay small.
+/// [`Block::Table`] so the common, table-free blocks stay small. This is the general rule for the
+/// node enums: attribute-bearing and otherwise heavy payloads are boxed so the common lightweight
+/// variants set each enum's size.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Table {
     pub attr: Attr,
@@ -444,6 +446,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn node_enums_stay_small() {
+        assert!(std::mem::size_of::<Inline>() <= 64);
+        assert!(std::mem::size_of::<Block>() <= 64);
+    }
+
+    #[test]
     fn plain_inlines_unwraps_markup_keeps_quotation_and_drops_passthrough() {
         let inlines = vec![
             Inline::Emph(vec![Inline::Str("emph".to_owned())]),
@@ -452,7 +460,7 @@ mod tests {
                 QuoteType::DoubleQuote,
                 vec![Inline::Strong(vec![Inline::Str("loud".to_owned())])],
             ),
-            Inline::Code(Attr::default(), "code".to_owned()),
+            Inline::Code(Box::default(), "code".to_owned()),
             Inline::Math(MathType::InlineMath, "x".to_owned()),
             Inline::RawInline(Format("html".to_owned()), "<br>".to_owned()),
             Inline::Note(vec![Block::Para(vec![Inline::Str("note".to_owned())])]),

--- a/crates/carta-core/src/sections.rs
+++ b/crates/carta-core/src/sections.rs
@@ -100,7 +100,7 @@ fn number_in(blocks: &mut [Block], counters: &mut Counters) {
                 if let Some(number) = counters.advance(*level, &attr.classes) {
                     attr.attributes.push(("number".to_owned(), number.clone()));
                     let span = Inline::Span(
-                        section_number_attr("header-section-number"),
+                        Box::new(section_number_attr("header-section-number")),
                         vec![Inline::Str(number)],
                     );
                     inlines.splice(0..0, [span, Inline::Space]);
@@ -208,7 +208,7 @@ fn toc_entry(
     let mut content = Vec::new();
     if let Some(number) = number.filter(|_| numbered) {
         content.push(Inline::Span(
-            section_number_attr("toc-section-number"),
+            Box::new(section_number_attr("toc-section-number")),
             vec![Inline::Str(number.to_owned())],
         ));
         content.push(Inline::Space);
@@ -227,12 +227,12 @@ fn toc_entry(
         attributes: Vec::new(),
     };
     vec![Inline::Link(
-        link_attr,
+        Box::new(link_attr),
         content,
-        Target {
+        Box::new(Target {
             url: format!("#{}", attr.id),
             title: String::new(),
-        },
+        }),
     )]
 }
 
@@ -282,11 +282,11 @@ mod tests {
     fn header(level: i32, classes: &[&str], text: &str) -> Block {
         Block::Header(
             level,
-            Attr {
+            Box::new(Attr {
                 id: text.to_lowercase().replace(' ', "-"),
                 classes: classes.iter().map(|class| (*class).to_owned()).collect(),
                 attributes: Vec::new(),
-            },
+            }),
             vec![Inline::Str(text.to_owned())],
         )
     }
@@ -450,18 +450,18 @@ mod tests {
     fn toc_drops_notes_and_unwraps_links() {
         let heading = Block::Header(
             1,
-            Attr {
+            Box::new(Attr {
                 id: "h".to_owned(),
                 ..Attr::default()
-            },
+            }),
             vec![
                 Inline::Link(
-                    Attr::default(),
+                    Box::default(),
                     vec![Inline::Str("text".to_owned())],
-                    Target {
+                    Box::new(Target {
                         url: "x".to_owned(),
                         title: String::new(),
-                    },
+                    }),
                 ),
                 Inline::Note(vec![Block::Para(vec![Inline::Str("note".to_owned())])]),
             ],
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn toc_entry_without_an_id_is_plain_text() {
-        let heading = Block::Header(1, Attr::default(), vec![Inline::Str("Untitled".to_owned())]);
+        let heading = Block::Header(1, Box::default(), vec![Inline::Str("Untitled".to_owned())]);
         let Some(Block::BulletList(items)) = build_toc(&[heading], 3, false, true) else {
             panic!("expected a contents list");
         };

--- a/crates/carta-readers/src/commonmark/autolink.rs
+++ b/crates/carta-readers/src/commonmark/autolink.rs
@@ -107,12 +107,12 @@ fn split_text(text: &str, markdown: bool, out: &mut Vec<Inline>) {
                     m.href
                 };
                 out.push(Inline::Link(
-                    attr,
+                    Box::new(attr),
                     vec![Inline::Str(label)],
-                    Target {
+                    Box::new(Target {
                         url,
                         title: String::new(),
-                    },
+                    }),
                 ));
             }
             emit_from = m.end;
@@ -441,12 +441,12 @@ mod tests {
     fn existing_links_are_not_rescanned() {
         // A link is never nested inside another link: a pre-formed Link is passed through verbatim.
         let inner = Inline::Link(
-            Attr::default(),
+            Box::default(),
             vec![Inline::Str("http://example.com".to_owned())],
-            Target {
+            Box::new(Target {
                 url: "http://example.com".to_owned(),
                 title: String::new(),
-            },
+            }),
         );
         let mut inlines = vec![inner.clone()];
         autolink_inlines(&mut inlines, false);
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn code_is_left_untouched() {
-        let code = Inline::Code(Attr::default(), "http://example.com".to_owned());
+        let code = Inline::Code(Box::default(), "http://example.com".to_owned());
         let mut inlines = vec![code.clone()];
         autolink_inlines(&mut inlines, false);
         assert_eq!(inlines, vec![code]);

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -188,11 +188,13 @@ fn resolve_block(
             let (content, attr) = split_header_attr(text, ext);
             out.push(Block::Header(
                 *level,
-                attr,
+                Box::new(attr),
                 parse_inlines(content, refs, notes, ext),
             ));
         }
-        IrBlock::CodeBlock(attr, text) => out.push(Block::CodeBlock(attr.clone(), text.clone())),
+        IrBlock::CodeBlock(attr, text) => {
+            out.push(Block::CodeBlock(Box::new(attr.clone()), text.clone()));
+        }
         IrBlock::RawHtml(text) => {
             // In the Markdown dialect with `raw_html` off an HTML block degrades to an ordinary
             // paragraph of its literal text; the inline pass keeps the tags as text. The bare
@@ -212,7 +214,7 @@ fn resolve_block(
         IrBlock::ThematicBreak => out.push(Block::HorizontalRule),
         IrBlock::Div(attr, children) => {
             out.push(Block::Div(
-                attr.clone(),
+                Box::new(attr.clone()),
                 resolve_blocks(children, refs, notes, ext),
             ));
         }
@@ -294,7 +296,11 @@ fn para_or_figure(inlines: Vec<Inline>, ext: Extensions) -> Block {
                 long: vec![Block::Plain(alt.clone())],
             };
             let image = Inline::Image(attr, alt, target);
-            Block::Figure(figure_attr, caption, vec![Block::Plain(vec![image])])
+            Block::Figure(
+                Box::new(figure_attr),
+                Box::new(caption),
+                vec![Block::Plain(vec![image])],
+            )
         }
         Ok([only]) => para(vec![only]),
         Err(inlines) => para(inlines),
@@ -1043,7 +1049,7 @@ impl InlineParser<'_> {
         };
         self.pos = index + 1;
         self.nodes.push(Node::Inline(Inline::Span(
-            attr,
+            Box::new(attr),
             vec![Inline::Str(codepoints.to_owned())],
         )));
         true
@@ -1410,7 +1416,7 @@ impl InlineParser<'_> {
                     }
                     let attr = self.take_code_attr();
                     self.nodes.push(Node::Inline(Inline::Code(
-                        attr,
+                        Box::new(attr),
                         normalize_code(&content, self.notes.markdown),
                     )));
                     return;
@@ -1860,7 +1866,8 @@ impl InlineParser<'_> {
         self.nodes.pop(); // remove the opener delimiter
         self.bracket_stack.retain(|&ni| ni < opener_index);
         let content = resolve_inline_nodes(inner, self.ext, self.notes.markdown);
-        self.nodes.push(Node::Inline(Inline::Span(attr, content)));
+        self.nodes
+            .push(Node::Inline(Inline::Span(Box::new(attr), content)));
     }
 
     /// Turn an unmatched bracket opener back into the literal text it stands for.
@@ -2032,9 +2039,9 @@ impl InlineParser<'_> {
         self.bracket_stack.retain(|&ni| ni < opener_index);
         let content = resolve_inline_nodes(inner, self.ext, self.notes.markdown);
         let inline = if is_image {
-            Inline::Image(attr, content, target)
+            Inline::Image(Box::new(attr), content, Box::new(target))
         } else {
-            Inline::Link(attr, content, target)
+            Inline::Link(Box::new(attr), content, Box::new(target))
         };
         self.nodes.push(Node::Inline(inline));
     }
@@ -2594,11 +2601,11 @@ fn resolve_mark(nodes: &mut Vec<Node>, ext: Extensions, markdown: bool) {
         process_emphasis(&mut inner, 0, ext, markdown);
         let content = collapse(inner);
         let span = Inline::Span(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes: vec!["mark".to_string()],
                 attributes: Vec::new(),
-            },
+            }),
             content,
         );
         // After the drain, the closer sits directly after the opener.
@@ -3034,7 +3041,7 @@ fn pair_spans_level(
                         if f.0 == "html" && matches!(classify_span_tag(t), SpanTag::Close))
                     {
                         let _ = input.next();
-                        out.push(Inline::Span(attr, inner));
+                        out.push(Inline::Span(Box::new(attr), inner));
                     } else {
                         // No matching close at this level: the opener reverts to raw, and its
                         // gathered inner content rejoins the stream.
@@ -3520,11 +3527,11 @@ mod tests {
 
     fn emoji_span(name: &str, text: &str) -> Inline {
         Inline::Span(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes: vec!["emoji".to_owned()],
                 attributes: vec![("data-emoji".to_owned(), name.to_owned())],
-            },
+            }),
             vec![Inline::Str(text.to_owned())],
         )
     }
@@ -3587,11 +3594,11 @@ mod tests {
 
     fn mark_span(content: Vec<Inline>) -> Inline {
         Inline::Span(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes: vec!["mark".to_owned()],
                 attributes: Vec::new(),
-            },
+            }),
             content,
         )
     }
@@ -3603,12 +3610,12 @@ mod tests {
         assert_eq!(
             parse_meta_inlines("[==hi==](u)", on, false),
             vec![Inline::Link(
-                Attr::default(),
+                Box::default(),
                 vec![mark_span(vec![Inline::Str("hi".to_owned())])],
-                Target {
+                Box::new(Target {
                     url: "u".to_owned(),
                     title: String::new(),
-                },
+                }),
             )]
         );
     }
@@ -3625,7 +3632,7 @@ mod tests {
         assert_eq!(
             parse_meta_inlines("[a ==b== c]{.x}", on, false),
             vec![Inline::Span(
-                span_attr,
+                Box::new(span_attr),
                 vec![
                     Inline::Str("a".to_owned()),
                     Inline::Space,
@@ -3644,12 +3651,12 @@ mod tests {
         assert_eq!(
             parse_meta_inlines("[==hi==](u)", off, false),
             vec![Inline::Link(
-                Attr::default(),
+                Box::default(),
                 vec![Inline::Str("==hi==".to_owned())],
-                Target {
+                Box::new(Target {
                     url: "u".to_owned(),
                     title: String::new(),
-                },
+                }),
             )]
         );
     }
@@ -3907,23 +3914,23 @@ mod inline_tests {
 
     fn link(content: Vec<Inline>, url: &str) -> Inline {
         Inline::Link(
-            Attr::default(),
+            Box::default(),
             content,
-            Target {
+            Box::new(Target {
                 url: url.to_owned(),
                 title: String::new(),
-            },
+            }),
         )
     }
 
     fn image(alt: Vec<Inline>, url: &str) -> Inline {
         Inline::Image(
-            Attr::default(),
+            Box::default(),
             alt,
-            Target {
+            Box::new(Target {
                 url: url.to_owned(),
                 title: String::new(),
-            },
+            }),
         )
     }
 
@@ -4421,7 +4428,7 @@ mod inline_tests {
     // --- Attributes: spans, inline code, links ---
 
     fn span(attr: Attr, content: Vec<Inline>) -> Inline {
-        Inline::Span(attr, content)
+        Inline::Span(Box::new(attr), content)
     }
 
     fn attr(id: &str, classes: &[&str], kv: &[(&str, &str)]) -> Attr {
@@ -4484,13 +4491,16 @@ mod inline_tests {
     fn inline_code_takes_attributes() {
         assert_eq!(
             pe("`code`{.rust #x}", attrs()),
-            vec![Inline::Code(attr("x", &["rust"], &[]), "code".to_owned())]
+            vec![Inline::Code(
+                Box::new(attr("x", &["rust"], &[])),
+                "code".to_owned()
+            )]
         );
         // A space before the block leaves it unattached (no wrapper artifact is produced).
         assert_eq!(
             pe("`code` x", attrs()),
             vec![
-                Inline::Code(Attr::default(), "code".to_owned()),
+                Inline::Code(Box::default(), "code".to_owned()),
                 Inline::Space,
                 str("x")
             ]
@@ -4500,21 +4510,21 @@ mod inline_tests {
     #[test]
     fn link_and_image_take_attributes() {
         let link_with_attr = Inline::Link(
-            attr("home", &["external"], &[]),
+            Box::new(attr("home", &["external"], &[])),
             vec![str("t")],
-            Target {
+            Box::new(Target {
                 url: "u".to_owned(),
                 title: String::new(),
-            },
+            }),
         );
         assert_eq!(pe("[t](u){.external #home}", attrs()), vec![link_with_attr]);
         let image_with_attr = Inline::Image(
-            attr("", &[], &[("width", "200")]),
+            Box::new(attr("", &[], &[("width", "200")])),
             vec![str("a")],
-            Target {
+            Box::new(Target {
                 url: "i".to_owned(),
                 title: String::new(),
-            },
+            }),
         );
         assert_eq!(pe("![a](i){width=200}", attrs()), vec![image_with_attr]);
     }
@@ -4552,7 +4562,7 @@ mod inline_tests {
     }
 
     fn code(text: &str) -> Inline {
-        Inline::Code(Attr::default(), text.to_owned())
+        Inline::Code(Box::default(), text.to_owned())
     }
 
     #[test]
@@ -4606,10 +4616,10 @@ mod inline_tests {
         assert_eq!(
             pe("`x`{.c}", ext),
             vec![Inline::Code(
-                Attr {
+                Box::new(Attr {
                     classes: vec!["c".to_owned()],
                     ..Attr::default()
-                },
+                }),
                 "x".to_owned()
             )]
         );

--- a/crates/carta-readers/src/commonmark/mod.rs
+++ b/crates/carta-readers/src/commonmark/mod.rs
@@ -616,7 +616,7 @@ mod tests {
         let [Block::Figure(attr, caption, body)] = result.as_slice() else {
             panic!("expected a single figure, got {result:?}");
         };
-        assert_eq!(*attr, carta_ast::Attr::default());
+        assert_eq!(*attr, Box::new(carta_ast::Attr::default()));
         assert!(caption.short.is_none());
         // The caption is a clone of the image's alt inlines wrapped in one `Plain`.
         let [Block::Plain(caption_inlines)] = caption.long.as_slice() else {

--- a/crates/carta-readers/src/commonmark/scan.rs
+++ b/crates/carta-readers/src/commonmark/scan.rs
@@ -7,7 +7,7 @@
 //! block phase reuses the link-reference-definition and unescaping scanners while collecting
 //! definitions.
 
-use carta_ast::{Attr, Inline, Target};
+use carta_ast::{Inline, Target};
 
 use super::LinkDef;
 
@@ -103,7 +103,7 @@ pub(crate) fn scan_autolink(chars: &[char], start: usize) -> Option<(Inline, usi
             title: String::new(),
         };
         return Some((
-            Inline::Link(Attr::default(), vec![Inline::Str(content)], target),
+            Inline::Link(Box::default(), vec![Inline::Str(content)], Box::new(target)),
             after,
         ));
     }
@@ -114,7 +114,7 @@ pub(crate) fn scan_autolink(chars: &[char], start: usize) -> Option<(Inline, usi
             title: String::new(),
         };
         return Some((
-            Inline::Link(Attr::default(), vec![Inline::Str(content)], target),
+            Inline::Link(Box::default(), vec![Inline::Str(content)], Box::new(target)),
             after,
         ));
     }

--- a/crates/carta-readers/src/dokuwiki.rs
+++ b/crates/carta-readers/src/dokuwiki.rs
@@ -161,7 +161,7 @@ fn parse_blocks(lines: &[&str], index: &mut usize, ctx: Ctx, depth: usize) -> Ve
         if let Some((level, title, trailing)) = header_split(line) {
             blocks.push(Block::Header(
                 level,
-                Attr::default(),
+                Box::default(),
                 inline_content(&title, ctx, depth),
             ));
             *index += 1;
@@ -471,7 +471,7 @@ fn parse_raw_region(chars: &[char], start: usize) -> Option<(Block, usize)> {
                 classes: class.into_iter().collect(),
                 ..Default::default()
             };
-            Block::CodeBlock(attr, content)
+            Block::CodeBlock(Box::new(attr), content)
         }
         RawKind::Html => Block::RawBlock(Format("html".to_string()), content),
         RawKind::Php => Block::RawBlock(Format("html".to_string()), format!("<?php {content} ?>")),
@@ -517,7 +517,7 @@ fn parse_indented_code(lines: &[&str], index: &mut usize) -> Block {
         out.push('\n');
         *index += 1;
     }
-    Block::CodeBlock(Attr::default(), out)
+    Block::CodeBlock(Box::default(), out)
 }
 
 /// Parse a thematically grouped run of list lines into one bullet or ordered list.
@@ -1389,7 +1389,7 @@ fn parse_mono(
         if !closed {
             return None;
         }
-        return Some((Inline::Code(Attr::default(), flatten_mono(&inner)), pos));
+        return Some((Inline::Code(Box::default(), flatten_mono(&inner)), pos));
     }
     let close = find_subsequence(chars, begin + 2, "''")?;
     if close <= begin + 2 || is_ws_opt(chars.get(close - 1).copied()) {
@@ -1398,7 +1398,7 @@ fn parse_mono(
     let content = chars.get(begin + 2..close).unwrap_or(&[]);
     let inner = scan_slice(content, ctx, depth + 1);
     Some((
-        Inline::Code(Attr::default(), to_plain_text(&inner)),
+        Inline::Code(Box::default(), to_plain_text(&inner)),
         close + 2,
     ))
 }
@@ -1619,12 +1619,12 @@ fn try_autolink(chars: &[char], pos: usize) -> Option<(Inline, usize)> {
     let url: String = chars.get(pos..end)?.iter().collect();
     Some((
         Inline::Link(
-            Attr::default(),
+            Box::default(),
             vec![Inline::Str(url.clone())],
-            Target {
+            Box::new(Target {
                 url,
                 title: String::new(),
-            },
+            }),
         ),
         end,
     ))
@@ -1760,12 +1760,12 @@ fn parse_link(chars: &[char], start: usize) -> Option<(Inline, usize)> {
     };
     Some((
         Inline::Link(
-            Attr::default(),
+            Box::default(),
             label_inlines,
-            Target {
+            Box::new(Target {
                 url,
                 title: String::new(),
-            },
+            }),
         ),
         close + 2,
     ))
@@ -1827,12 +1827,12 @@ fn parse_media(chars: &[char], start: usize) -> Option<(Inline, usize)> {
 
     let node = match query {
         Some(q) if q.contains("linkonly") => Inline::Link(
-            Attr {
+            Box::new(Attr {
                 classes,
                 ..Default::default()
-            },
+            }),
             alt,
-            target,
+            Box::new(target),
         ),
         Some(q) => {
             let (width, height) = parse_size(q);
@@ -1845,22 +1845,22 @@ fn parse_media(chars: &[char], start: usize) -> Option<(Inline, usize)> {
             }
             attributes.push(("query".to_string(), format!("?{q}")));
             Inline::Image(
-                Attr {
+                Box::new(Attr {
                     classes,
                     attributes,
                     ..Default::default()
-                },
+                }),
                 alt,
-                target,
+                Box::new(target),
             )
         }
         None => Inline::Image(
-            Attr {
+            Box::new(Attr {
                 classes,
                 ..Default::default()
-            },
+            }),
             alt,
-            target,
+            Box::new(target),
         ),
     };
     Some((node, end))
@@ -2101,12 +2101,12 @@ fn angle_email(chars: &[char], start: usize) -> Option<(Inline, usize)> {
     let url = format!("mailto:{inner}");
     Some((
         Inline::Link(
-            Attr::default(),
+            Box::default(),
             vec![Inline::Str(inner)],
-            Target {
+            Box::new(Target {
                 url,
                 title: String::new(),
-            },
+            }),
         ),
         j + 1,
     ))

--- a/crates/carta-readers/src/html/convert.rs
+++ b/crates/carta-readers/src/html/convert.rs
@@ -185,7 +185,7 @@ impl Converter {
             BlockKind::Header(level) => {
                 let inlines = trim_inlines(self.build_inlines(&e.children));
                 let attr = self.header_attr(e, &inlines);
-                out.push(Block::Header(level, attr, inlines));
+                out.push(Block::Header(level, Box::new(attr), inlines));
             }
             BlockKind::BulletList => out.push(Block::BulletList(self.list_items(e))),
             BlockKind::OrderedList => {
@@ -201,7 +201,10 @@ impl Converter {
                     out.push(Block::LineBlock(self.line_block_lines(&e.children)));
                 } else if self.ext.contains(Extension::NativeDivs) {
                     let attr = div_attr(e, sectioning);
-                    out.push(Block::Div(attr, self.child_blocks(&e.children, false)));
+                    out.push(Block::Div(
+                        Box::new(attr),
+                        self.child_blocks(&e.children, false),
+                    ));
                 } else {
                     // `native_divs` off: the wrapper carries no document structure, so its content
                     // is spliced into the surrounding block flow.
@@ -292,7 +295,11 @@ impl Converter {
             }
             content_nodes.push(child);
         }
-        Block::Figure(attr, caption, self.blocks(&content_nodes, true))
+        Block::Figure(
+            Box::new(attr),
+            Box::new(caption),
+            self.blocks(&content_nodes, true),
+        )
     }
 
     fn code_block(e: &Element) -> Block {
@@ -317,7 +324,7 @@ impl Converter {
         if text.ends_with('\n') {
             text.pop();
         }
-        Block::CodeBlock(attr, text)
+        Block::CodeBlock(Box::new(attr), text)
     }
 
     fn table(&mut self, e: &Element) -> Block {
@@ -589,7 +596,7 @@ impl Converter {
                 } else if is_small_caps(e) {
                     out.push(Inline::SmallCaps(inner));
                 } else {
-                    out.push(Inline::Span(extract_attr(e, &[]), inner));
+                    out.push(Inline::Span(Box::new(extract_attr(e, &[])), inner));
                 }
             }
             InlineKind::Bdo => {
@@ -600,13 +607,13 @@ impl Converter {
                         classes: Vec::new(),
                         attributes: vec![("dir".to_string(), dir)],
                     };
-                    out.push(Inline::Span(attr, inner));
+                    out.push(Inline::Span(Box::new(attr), inner));
                 } else {
                     out.extend(inner);
                 }
             }
             InlineKind::SpanClass => {
-                let mut attr = extract_attr(e, &[]);
+                let mut attr = Box::new(extract_attr(e, &[]));
                 attr.classes.insert(0, e.name.clone());
                 out.push(Inline::Span(attr, self.build_inlines(&e.children)));
             }
@@ -675,7 +682,7 @@ impl Converter {
             self.in_code.set(previous);
             codify(out, inner, &attr);
         } else {
-            out.push(Inline::Code(attr, collect_text(e)));
+            out.push(Inline::Code(Box::new(attr), collect_text(e)));
         }
     }
 
@@ -698,9 +705,13 @@ impl Converter {
         }
         let anchor = if let Some(href) = attr_value(e, "href") {
             let title = attr_value(e, "title").unwrap_or_default();
-            Inline::Link(attr, trimmed, Target { url: href, title })
+            Inline::Link(
+                Box::new(attr),
+                trimmed,
+                Box::new(Target { url: href, title }),
+            )
         } else {
-            Inline::Span(attr, trimmed)
+            Inline::Span(Box::new(attr), trimmed)
         };
         out.push(anchor);
         if let Some(trail) = trailing {
@@ -716,7 +727,7 @@ fn codify(out: &mut Vec<Inline>, inlines: Vec<Inline>, attr: &Attr) {
     let mut run = String::new();
     let flush = |run: &mut String, out: &mut Vec<Inline>| {
         if !run.is_empty() {
-            out.push(Inline::Code(attr.clone(), std::mem::take(run)));
+            out.push(Inline::Code(Box::new(attr.clone()), std::mem::take(run)));
         }
     };
     for inline in inlines {
@@ -1205,7 +1216,11 @@ fn image(e: &Element) -> Inline {
     let title = attr_value(e, "title").unwrap_or_default();
     let alt = attr_value(e, "alt").unwrap_or_default();
     let attr = extract_attr(e, &["src", "title", "alt"]);
-    Inline::Image(attr, inlines_from_text(&alt), Target { url, title })
+    Inline::Image(
+        Box::new(attr),
+        inlines_from_text(&alt),
+        Box::new(Target { url, title }),
+    )
 }
 
 fn extract_attr(e: &Element, exclude: &[&str]) -> Attr {

--- a/crates/carta-readers/src/html/mod.rs
+++ b/crates/carta-readers/src/html/mod.rs
@@ -462,10 +462,10 @@ mod tests {
         };
         assert_eq!(
             *target,
-            Target {
+            Box::new(Target {
                 url: "/u".to_string(),
                 title: "T".to_string()
-            }
+            })
         );
         assert!(attr.classes.contains(&"x".to_string()));
     }
@@ -1016,7 +1016,7 @@ mod tests {
                 Inline::Space,
                 Inline::Str("b".to_string()),
                 Inline::Space,
-                Inline::Code(carta_ast::Attr::default(), "c".to_string()),
+                Inline::Code(Box::default(), "c".to_string()),
             ]
         );
     }

--- a/crates/carta-readers/src/ipynb.rs
+++ b/crates/carta-readers/src/ipynb.rs
@@ -272,9 +272,9 @@ fn cell_to_block(cell: &Value, language: &str, options: &ReaderOptions) -> Resul
     };
     let attr = cell_attr(cell, kind);
     let block = match kind {
-        "markdown" => Block::Div(attr, markdown_cell_blocks(cell, options)?),
-        "code" => Block::Div(attr, code_cell_blocks(cell, language)),
-        "raw" => Block::Div(attr, vec![raw_cell_block(cell)]),
+        "markdown" => Block::Div(Box::new(attr), markdown_cell_blocks(cell, options)?),
+        "code" => Block::Div(Box::new(attr), code_cell_blocks(cell, language)),
+        "raw" => Block::Div(Box::new(attr), vec![raw_cell_block(cell)]),
         _ => return Ok(None),
     };
     Ok(Some(block))
@@ -359,7 +359,7 @@ fn code_cell_blocks(cell: &Value, language: &str) -> Vec<Block> {
         classes: vec![language.to_owned()],
         attributes: Vec::new(),
     };
-    let mut blocks = vec![Block::CodeBlock(source_attr, source)];
+    let mut blocks = vec![Block::CodeBlock(Box::new(source_attr), source)];
     if let Some(Value::Array(outputs)) = cell.get("outputs") {
         for output in outputs {
             if let Some(block) = output_to_block(output) {
@@ -408,7 +408,7 @@ fn stream_output(output: &Value) -> Block {
         classes: vec!["output".to_owned(), "stream".to_owned(), name.to_owned()],
         attributes: Vec::new(),
     };
-    Block::Div(attr, vec![Block::CodeBlock(Attr::default(), text)])
+    Block::Div(Box::new(attr), vec![Block::CodeBlock(Box::default(), text)])
 }
 
 /// An `execute_result` or `display_data` output: the richest renderable bundle from its `data`,
@@ -429,7 +429,7 @@ fn result_output(output: &Value, is_result: bool) -> Block {
         attributes,
     };
     Block::Div(
-        attr,
+        Box::new(attr),
         data_to_blocks(output.get("data"), output.get("metadata")),
     )
 }
@@ -465,8 +465,8 @@ fn error_output(output: &Value) -> Block {
         attributes: vec![("ename".to_owned(), ename), ("evalue".to_owned(), evalue)],
     };
     Block::Div(
-        attr,
-        vec![Block::CodeBlock(Attr::default(), strip_ansi(&traceback))],
+        Box::new(attr),
+        vec![Block::CodeBlock(Box::default(), strip_ansi(&traceback))],
     )
 }
 
@@ -499,11 +499,11 @@ fn data_to_blocks(data: Option<&Value>, metadata: Option<&Value>) -> Vec<Block> 
 fn non_image_block(mime: &str, value: &Value) -> Block {
     if is_json_like(mime) {
         return Block::CodeBlock(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes: vec!["json".to_owned()],
                 attributes: Vec::new(),
-            },
+            }),
             json_render(value),
         );
     }
@@ -514,7 +514,7 @@ fn non_image_block(mime: &str, value: &Value) -> Block {
             Block::RawBlock(Format("markdown".to_owned()), multiline_text(Some(value)))
         }
         // The fallthrough is plain text; the preference list only routes the cases above here.
-        _ => Block::CodeBlock(Attr::default(), strip_ansi(&multiline_text(Some(value)))),
+        _ => Block::CodeBlock(Box::default(), strip_ansi(&multiline_text(Some(value)))),
     }
 }
 
@@ -531,12 +531,12 @@ fn image_block(mime: &str, value: &Value, metadata: Option<&Value>) -> Block {
     };
     let name = format!("{}.{}", sha1_hex(&bytes), extension_for_mime(mime));
     Block::Para(vec![Inline::Image(
-        image_attr(mime, metadata),
+        Box::new(image_attr(mime, metadata)),
         Vec::new(),
-        Target {
+        Box::new(Target {
             url: name,
             title: String::new(),
-        },
+        }),
     )])
 }
 

--- a/crates/carta-readers/src/jira.rs
+++ b/crates/carta-readers/src/jira.rs
@@ -279,7 +279,7 @@ impl BlockParser<'_> {
         let (ts, te) = trim(self.chars, self.pos + 3, e);
         let inlines = drop_trailing_break(parse_inlines(self.chars, ts, te));
         self.advance_line();
-        Some(Block::Header(level, Attr::default(), inlines))
+        Some(Block::Header(level, Box::default(), inlines))
     }
 
     fn try_horizontal_rule(&mut self) -> Option<Block> {
@@ -407,7 +407,7 @@ impl BlockParser<'_> {
             classes: Vec::new(),
             attributes: vec![("color".to_string(), value)],
         };
-        Some(Block::Div(attr, inner))
+        Some(Block::Div(Box::new(attr), inner))
     }
 
     // --- tables ------------------------------------------------------------
@@ -577,7 +577,7 @@ impl BlockParser<'_> {
         };
         if let Some((content, resume)) = self.scan_code_content(content_start) {
             self.pos = resume;
-            Some(vec![Block::CodeBlock(attr, content)])
+            Some(vec![Block::CodeBlock(Box::new(attr), content)])
         } else {
             self.pos = self.len();
             Some(Vec::new())
@@ -633,7 +633,7 @@ impl BlockParser<'_> {
         if let Some(close) = find_token(self.chars, content_start, CLOSE) {
             let content = slice_to_string(self.chars, content_start, close);
             self.pos = close + CLOSE.chars().count();
-            vec![Block::CodeBlock(attr, content)]
+            vec![Block::CodeBlock(Box::new(attr), content)]
         } else {
             self.pos = self.len();
             Vec::new()
@@ -688,21 +688,21 @@ impl BlockParser<'_> {
         let mut inner = Vec::new();
         if let Some(title) = title {
             inner.push(Block::Div(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["panelheader".to_string()],
                     attributes: Vec::new(),
-                },
+                }),
                 vec![Block::Plain(vec![Inline::Strong(plain_inlines(&title))])],
             ));
         }
         inner.extend(parse_blocks_from_str(&content));
         Some(vec![Block::Div(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes: vec!["panel".to_string()],
                 attributes,
-            },
+            }),
             inner,
         )])
     }
@@ -1078,12 +1078,12 @@ fn scan_tokens(chars: &[char], lo: usize, hi: usize, autolink: bool, depth: usiz
             push_text(&mut pending, &mut toks);
             let url = slice_to_string(chars, i, end);
             toks.push(Tok::Atom(Inline::Link(
-                Attr::default(),
+                Box::default(),
                 vec![Inline::Str(url.clone())],
-                Target {
+                Box::new(Target {
                     url,
                     title: String::new(),
-                },
+                }),
             )));
             i = end;
             continue;
@@ -1634,7 +1634,7 @@ fn parse_brace_inline(
         let close = match_monospace_close(chars, i, hi)?;
         let inner = inlines_with(chars, i + 2, close, autolink, depth + 1);
         let text = carta_ast::to_plain_text(&inner);
-        return Some((Inline::Code(Attr::default(), text), close + 2));
+        return Some((Inline::Code(Box::default(), text), close + 2));
     }
 
     if matches_at(chars, i, "{color:") {
@@ -1648,7 +1648,7 @@ fn parse_brace_inline(
             classes: Vec::new(),
             attributes: vec![("color".to_string(), value)],
         };
-        return Some((Inline::Span(attr, inner), close + "{color}".len()));
+        return Some((Inline::Span(Box::new(attr), inner), close + "{color}".len()));
     }
 
     if matches_at(chars, i, "{anchor:") {
@@ -1665,7 +1665,7 @@ fn parse_brace_inline(
             classes: Vec::new(),
             attributes: Vec::new(),
         };
-        return Some((Inline::Span(attr, Vec::new()), name_end + 1));
+        return Some((Inline::Span(Box::new(attr), Vec::new()), name_end + 1));
     }
 
     None
@@ -1752,12 +1752,12 @@ fn parse_link(chars: &[char], i: usize, hi: usize, depth: usize) -> Option<(Inli
     };
     Some((
         Inline::Link(
-            attr,
+            Box::new(attr),
             label,
-            Target {
+            Box::new(Target {
                 url,
                 title: String::new(),
-            },
+            }),
         ),
         close + 1,
     ))
@@ -1808,7 +1808,11 @@ fn parse_image(chars: &[char], i: usize, hi: usize) -> Option<(Inline, usize)> {
         None => (Attr::default(), String::new()),
     };
     Some((
-        Inline::Image(attr, Vec::new(), Target { url: src, title }),
+        Inline::Image(
+            Box::new(attr),
+            Vec::new(),
+            Box::new(Target { url: src, title }),
+        ),
         close + 1,
     ))
 }
@@ -1992,7 +1996,7 @@ mod tests {
     fn heading_levels() {
         assert_eq!(
             blocks("h2. Title"),
-            vec![Block::Header(2, Attr::default(), vec![str_node("Title")])]
+            vec![Block::Header(2, Box::default(), vec![str_node("Title")])]
         );
         // Level seven is not a heading.
         assert!(matches!(blocks("h7. Title").as_slice(), [Block::Para(_)]));
@@ -2033,7 +2037,7 @@ mod tests {
     fn monospace_stringifies_inner_markup() {
         assert_eq!(
             para("{{a *b* c}}"),
-            vec![Inline::Code(Attr::default(), "a b c".to_string())]
+            vec![Inline::Code(Box::default(), "a b c".to_string())]
         );
     }
 
@@ -2042,11 +2046,11 @@ mod tests {
         assert_eq!(
             para("{color:red}x{color}"),
             vec![Inline::Span(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: Vec::new(),
                     attributes: vec![("color".to_string(), "red".to_string())],
-                },
+                }),
                 vec![str_node("x")],
             )]
         );
@@ -2062,7 +2066,7 @@ mod tests {
         assert_eq!(
             blocks("{color:red}\nstuff\n{color}"),
             vec![Block::Div(
-                attr,
+                Box::new(attr),
                 vec![Block::Para(vec![Inline::LineBreak, str_node("stuff")])],
             )]
         );
@@ -2079,11 +2083,11 @@ mod tests {
             para("{anchor:foo}bar"),
             vec![
                 Inline::Span(
-                    Attr {
+                    Box::new(Attr {
                         id: "foo".to_string(),
                         classes: Vec::new(),
                         attributes: Vec::new(),
-                    },
+                    }),
                     Vec::new(),
                 ),
                 str_node("bar"),
@@ -2179,12 +2183,12 @@ mod tests {
         assert_eq!(
             para("[home|http://example.com]"),
             vec![Inline::Link(
-                Attr::default(),
+                Box::default(),
                 vec![str_node("home")],
-                Target {
+                Box::new(Target {
                     url: "http://example.com".to_string(),
                     title: String::new(),
-                },
+                }),
             )]
         );
     }
@@ -2194,12 +2198,12 @@ mod tests {
         assert_eq!(
             para("[http://example.com]"),
             vec![Inline::Link(
-                Attr::default(),
+                Box::default(),
                 vec![str_node("http://example.com")],
-                Target {
+                Box::new(Target {
                     url: "http://example.com".to_string(),
                     title: String::new(),
-                },
+                }),
             )]
         );
     }
@@ -2209,16 +2213,16 @@ mod tests {
         assert_eq!(
             para("[^file.txt]"),
             vec![Inline::Link(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["attachment".to_string()],
                     attributes: Vec::new(),
-                },
+                }),
                 vec![str_node("file.txt")],
-                Target {
+                Box::new(Target {
                     url: "file.txt".to_string(),
                     title: String::new(),
-                },
+                }),
             )]
         );
     }
@@ -2231,12 +2235,12 @@ mod tests {
                 str_node("see"),
                 Inline::Space,
                 Inline::Link(
-                    Attr::default(),
+                    Box::default(),
                     vec![str_node("http://example.com")],
-                    Target {
+                    Box::new(Target {
                         url: "http://example.com".to_string(),
                         title: String::new(),
-                    },
+                    }),
                 ),
                 Inline::Space,
                 str_node("here"),
@@ -2249,19 +2253,19 @@ mod tests {
         assert_eq!(
             para("!pic.png|align=right, vspace=4!"),
             vec![Inline::Image(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: Vec::new(),
                     attributes: vec![
                         ("align".to_string(), "right".to_string()),
                         ("vspace".to_string(), "4".to_string()),
                     ],
-                },
+                }),
                 Vec::new(),
-                Target {
+                Box::new(Target {
                     url: "pic.png".to_string(),
                     title: String::new(),
-                },
+                }),
             )]
         );
     }
@@ -2271,16 +2275,16 @@ mod tests {
         assert_eq!(
             para("!pic.png|thumbnail!"),
             vec![Inline::Image(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["thumbnail".to_string()],
                     attributes: Vec::new(),
-                },
+                }),
                 Vec::new(),
-                Target {
+                Box::new(Target {
                     url: "pic.png".to_string(),
                     title: String::new(),
-                },
+                }),
             )]
         );
     }
@@ -2352,11 +2356,11 @@ mod tests {
         assert_eq!(
             blocks("{code}\nint x = 1;\n{code}"),
             vec![Block::CodeBlock(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["java".to_string()],
                     attributes: Vec::new(),
-                },
+                }),
                 "int x = 1;\n".to_string(),
             )]
         );
@@ -2367,11 +2371,11 @@ mod tests {
         assert_eq!(
             blocks("{code:python}\npass\n{code}"),
             vec![Block::CodeBlock(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["python".to_string()],
                     attributes: Vec::new(),
-                },
+                }),
                 "pass\n".to_string(),
             )]
         );
@@ -2381,7 +2385,7 @@ mod tests {
     fn noformat_has_no_language_class() {
         assert_eq!(
             blocks("{noformat}\nraw\n{noformat}"),
-            vec![Block::CodeBlock(Attr::default(), "raw\n".to_string())]
+            vec![Block::CodeBlock(Box::default(), "raw\n".to_string())]
         );
     }
 
@@ -2405,18 +2409,18 @@ mod tests {
         assert_eq!(
             blocks("{panel:title=Note}\nbody\n{panel}"),
             vec![Block::Div(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["panel".to_string()],
                     attributes: Vec::new(),
-                },
+                }),
                 vec![
                     Block::Div(
-                        Attr {
+                        Box::new(Attr {
                             id: String::new(),
                             classes: vec!["panelheader".to_string()],
                             attributes: Vec::new(),
-                        },
+                        }),
                         vec![Block::Plain(vec![Inline::Strong(vec![str_node("Note")])])],
                     ),
                     Block::Para(vec![str_node("body")]),

--- a/crates/carta-readers/src/latex.rs
+++ b/crates/carta-readers/src/latex.rs
@@ -491,11 +491,11 @@ impl Parser {
         }
         Block::Header(
             level,
-            Attr {
+            Box::new(Attr {
                 id,
                 classes,
                 attributes: Vec::new(),
-            },
+            }),
             title,
         )
     }
@@ -572,11 +572,11 @@ impl Parser {
                 let inner = self.parse_blocks(&Stop::Env(env));
                 self.consume_env_marker("\\end");
                 vec![Block::Div(
-                    Attr {
+                    Box::new(Attr {
                         id: String::new(),
                         classes: vec![env.to_owned()],
                         attributes: Vec::new(),
-                    },
+                    }),
                     inner,
                 )]
             }
@@ -587,11 +587,11 @@ impl Parser {
                 let inner = self.parse_blocks(&Stop::Env(env));
                 self.consume_env_marker("\\end");
                 vec![Block::Div(
-                    Attr {
+                    Box::new(Attr {
                         id: String::new(),
                         classes: vec!["minipage".to_owned()],
                         attributes: Vec::new(),
-                    },
+                    }),
                     inner,
                 )]
             }
@@ -628,11 +628,11 @@ impl Parser {
                     let inner = self.parse_blocks(&Stop::Env(env));
                     self.consume_env_marker("\\end");
                     vec![Block::Div(
-                        Attr {
+                        Box::new(Attr {
                             id: String::new(),
                             classes: vec![env.to_owned()],
                             attributes: Vec::new(),
-                        },
+                        }),
                         inner,
                     )]
                 }
@@ -754,11 +754,11 @@ impl Parser {
         }
         let content = self.read_verbatim_body(env);
         vec![Block::CodeBlock(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes,
                 attributes,
-            },
+            }),
             content,
         )]
     }
@@ -792,15 +792,15 @@ impl Parser {
         let (blocks, caption, id) = self.collect_float(env);
         self.in_figure = was_in_figure;
         Block::Figure(
-            Attr {
+            Box::new(Attr {
                 id: id.unwrap_or_default(),
                 classes: Vec::new(),
                 attributes: Vec::new(),
-            },
-            Caption {
+            }),
+            Box::new(Caption {
                 short: None,
                 long: caption,
-            },
+            }),
             blocks.into_iter().map(demote_image_para).collect(),
         )
     }
@@ -1248,7 +1248,7 @@ impl Parser {
                     classes: Vec::new(),
                     attributes: vec![("style".to_owned(), format!("{property}: {}", color.trim()))],
                 };
-                emit(out, buf, Inline::Span(attr, inner));
+                emit(out, buf, Inline::Span(Box::new(attr), inner));
             }
             "texttt" | "lstinline" => {
                 if name == "lstinline" {
@@ -1258,12 +1258,12 @@ impl Parser {
                 emit(
                     out,
                     buf,
-                    Inline::Code(Attr::default(), to_plain_text(&inner)),
+                    Inline::Code(Box::default(), to_plain_text(&inner)),
                 );
             }
             "verb" => {
                 if let Some(code) = self.read_verb() {
-                    emit(out, buf, Inline::Code(Attr::default(), code));
+                    emit(out, buf, Inline::Code(Box::default(), code));
                 }
             }
             "footnote" | "footnotetext" | "thanks" => {
@@ -1278,16 +1278,16 @@ impl Parser {
                         out,
                         buf,
                         Inline::Link(
-                            Attr {
+                            Box::new(Attr {
                                 id: String::new(),
                                 classes: vec!["uri".to_owned()],
                                 attributes: Vec::new(),
-                            },
+                            }),
                             vec![Inline::Str(url.clone())],
-                            Target {
+                            Box::new(Target {
                                 url,
                                 title: String::new(),
-                            },
+                            }),
                         ),
                     );
                 }
@@ -1302,12 +1302,12 @@ impl Parser {
                     out,
                     buf,
                     Inline::Link(
-                        Attr::default(),
+                        Box::default(),
                         text,
-                        Target {
+                        Box::new(Target {
                             url,
                             title: String::new(),
-                        },
+                        }),
                     ),
                 );
             }
@@ -1324,16 +1324,16 @@ impl Parser {
                     out,
                     buf,
                     Inline::Image(
-                        Attr {
+                        Box::new(Attr {
                             id: String::new(),
                             classes: Vec::new(),
                             attributes,
-                        },
+                        }),
                         alt,
-                        Target {
+                        Box::new(Target {
                             url: path,
                             title: String::new(),
-                        },
+                        }),
                     ),
                 );
             }
@@ -1343,11 +1343,11 @@ impl Parser {
                         out,
                         buf,
                         Inline::Span(
-                            Attr {
+                            Box::new(Attr {
                                 id: id.clone(),
                                 classes: Vec::new(),
                                 attributes: vec![("label".to_owned(), id)],
-                            },
+                            }),
                             Vec::new(),
                         ),
                     );
@@ -2070,11 +2070,11 @@ fn extract_spaces<F: FnOnce(Vec<Inline>) -> Inline>(
 /// Wraps inlines in a span carrying a single class.
 fn span_class(inlines: Vec<Inline>, class: &str) -> Inline {
     Inline::Span(
-        Attr {
+        Box::new(Attr {
             id: String::new(),
             classes: vec![class.to_owned()],
             attributes: Vec::new(),
-        },
+        }),
         inlines,
     )
 }
@@ -2087,19 +2087,19 @@ fn reference_link(name: &str, target: &str) -> Inline {
         other => other,
     };
     Inline::Link(
-        Attr {
+        Box::new(Attr {
             id: String::new(),
             classes: Vec::new(),
             attributes: vec![
                 ("reference-type".to_owned(), kind.to_owned()),
                 ("reference".to_owned(), target.to_owned()),
             ],
-        },
+        }),
         vec![Inline::Str(format!("[{target}]"))],
-        Target {
+        Box::new(Target {
             url: format!("#{target}"),
             title: String::new(),
-        },
+        }),
     )
 }
 
@@ -2118,7 +2118,7 @@ impl Switch {
             Switch::Strong => Inline::Strong(inner),
             Switch::Emph => Inline::Emph(inner),
             Switch::SmallCaps => Inline::SmallCaps(inner),
-            Switch::Code => Inline::Code(Attr::default(), to_plain_text(&inner)),
+            Switch::Code => Inline::Code(Box::default(), to_plain_text(&inner)),
         }
     }
 }
@@ -2146,7 +2146,7 @@ fn group_span(inner: Vec<Inline>) -> Option<Inline> {
         {
             inner.into_iter().next()
         }
-        _ => Some(Inline::Span(Attr::default(), inner)),
+        _ => Some(Inline::Span(Box::default(), inner)),
     }
 }
 
@@ -3005,15 +3005,15 @@ mod tests {
                 Inline::Space,
                 Inline::Str("Section\u{a0}".to_owned()),
                 Inline::Link(
-                    attr(vec![
+                    Box::new(attr(vec![
                         ("reference-type".to_owned(), "ref".to_owned()),
                         ("reference".to_owned(), "sec:intro".to_owned()),
-                    ]),
+                    ])),
                     vec![Inline::Str("[sec:intro]".to_owned())],
-                    Target {
+                    Box::new(Target {
                         url: "#sec:intro".to_owned(),
                         title: String::new(),
-                    },
+                    }),
                 ),
                 Inline::Str(".".to_owned()),
             ])],
@@ -3054,12 +3054,12 @@ mod tests {
                 Inline::Str("x".to_owned()),
                 Inline::Space,
                 Inline::Image(
-                    attr(vec![("width".to_owned(), "50%".to_owned())]),
+                    Box::new(attr(vec![("width".to_owned(), "50%".to_owned())])),
                     vec![Inline::Str("image".to_owned())],
-                    Target {
+                    Box::new(Target {
                         url: "diagram.png".to_owned(),
                         title: String::new(),
-                    },
+                    }),
                 ),
                 Inline::Space,
                 Inline::Str("y".to_owned()),

--- a/crates/carta-readers/src/man.rs
+++ b/crates/carta-readers/src/man.rs
@@ -137,7 +137,7 @@ impl Font {
 fn code_inline(inlines: &[Inline]) -> Inline {
     let mut text = String::new();
     collect_code_text(inlines, &mut text);
-    Inline::Code(Attr::default(), text)
+    Inline::Code(Box::default(), text)
 }
 
 fn collect_code_text(inlines: &[Inline], out: &mut String) {
@@ -391,10 +391,10 @@ impl Parser {
                     let id = self.headings.assign(&inlines);
                     blocks.push(Block::Header(
                         level,
-                        Attr {
+                        Box::new(Attr {
                             id,
                             ..Attr::default()
-                        },
+                        }),
                         inlines,
                     ));
                 }
@@ -659,7 +659,7 @@ impl Parser {
                 text_lines.push(flatten(&line, &self.strings));
             }
         }
-        Block::CodeBlock(Attr::default(), text_lines.join("\n"))
+        Block::CodeBlock(Box::default(), text_lines.join("\n"))
     }
 
     /// Parses a tbl table region (`.TS`/`.TE`) into a [`Block::Table`]. The region's structure is the
@@ -850,12 +850,12 @@ impl Parser {
         append_text(
             fill,
             vec![Inline::Link(
-                Attr::default(),
+                Box::default(),
                 label,
-                Target {
+                Box::new(Target {
                     url,
                     title: String::new(),
-                },
+                }),
             )],
         );
         if !trailing.is_empty() {
@@ -2291,10 +2291,10 @@ mod tests {
             doc.blocks.first(),
             Some(&Block::Header(
                 1,
-                Attr {
+                Box::new(Attr {
                     id: "name".into(),
                     ..Attr::default()
-                },
+                }),
                 vec![Inline::Str("NAME".into())]
             ))
         );
@@ -2655,7 +2655,7 @@ mod tests {
         assert_eq!(
             doc.blocks.first(),
             Some(&Block::CodeBlock(
-                Attr::default(),
+                Box::default(),
                 "line one\n  indented".into()
             ))
         );
@@ -2666,7 +2666,7 @@ mod tests {
         let doc = read(".TH T 1\n.EX\n\\fBcode\\fR \\- here\n.EE\n");
         assert_eq!(
             doc.blocks.first(),
-            Some(&Block::CodeBlock(Attr::default(), "code - here".into()))
+            Some(&Block::CodeBlock(Box::default(), "code - here".into()))
         );
     }
 
@@ -2676,16 +2676,16 @@ mod tests {
         assert_eq!(
             doc.blocks.first(),
             Some(&Block::Para(vec![Inline::Link(
-                Attr::default(),
+                Box::default(),
                 vec![
                     Inline::Str("the".into()),
                     Inline::Space,
                     Inline::Str("text".into()),
                 ],
-                Target {
+                Box::new(Target {
                     url: "https://example.com".into(),
                     title: String::new(),
-                },
+                }),
             )]))
         );
     }
@@ -2941,7 +2941,7 @@ mod tests {
             Some(&Block::Para(vec![
                 Inline::Str("plain".into()),
                 Inline::Space,
-                Inline::Code(Attr::default(), "mono".into()),
+                Inline::Code(Box::default(), "mono".into()),
                 Inline::Space,
                 Inline::Str("back".into()),
             ]))
@@ -2954,7 +2954,7 @@ mod tests {
         assert_eq!(
             doc.blocks.first(),
             Some(&Block::Para(vec![Inline::Strong(vec![Inline::Code(
-                Attr::default(),
+                Box::default(),
                 "mono".into()
             )])]))
         );

--- a/crates/carta-readers/src/mediawiki.rs
+++ b/crates/carta-readers/src/mediawiki.rs
@@ -220,7 +220,7 @@ impl Parser {
                         classes: Vec::new(),
                         attributes: Vec::new(),
                     };
-                    blocks.push(Block::Header(level, attr, inlines));
+                    blocks.push(Block::Header(level, Box::new(attr), inlines));
                     let (np, ls) = finish_inline_block(chars, closer_end);
                     pos = np;
                     line_start = ls;
@@ -506,7 +506,7 @@ impl Parser {
             }
             "pre" => {
                 let (inner, after) = enclosed(chars, after_open, "pre");
-                Some((Block::CodeBlock(Attr::default(), trim_code(&inner)), after))
+                Some((Block::CodeBlock(Box::default(), trim_code(&inner)), after))
             }
             "source" | "syntaxhighlight" => {
                 let (inner, after) = enclosed(chars, after_open, &name);
@@ -521,7 +521,7 @@ impl Parser {
                     classes,
                     attributes: Vec::new(),
                 };
-                Some((Block::CodeBlock(attr, trim_code(&inner)), after))
+                Some((Block::CodeBlock(Box::new(attr), trim_code(&inner)), after))
             }
             "ul" => Some(self.parse_html_list(chars, after_open, false, &raw_open, self_closing)),
             "ol" => Some(self.parse_html_list(chars, after_open, true, &raw_open, self_closing)),
@@ -1158,7 +1158,10 @@ impl Parser {
                     classes: vec![class.to_string()],
                     attributes: Vec::new(),
                 };
-                (vec![Inline::Span(attr, self.parse_inlines(&inner))], after)
+                (
+                    vec![Inline::Span(Box::new(attr), self.parse_inlines(&inner))],
+                    after,
+                )
             }
             None => (vec![raw_html(raw_open.to_string())], after_open),
         }
@@ -1187,12 +1190,12 @@ impl Parser {
         };
         Some((
             vec![Inline::Link(
-                Attr::default(),
+                Box::default(),
                 text,
-                Target {
+                Box::new(Target {
                     url: encode_url_target(&url),
                     title: String::new(),
-                },
+                }),
             )],
             close + 1,
         ))
@@ -1228,12 +1231,12 @@ impl Parser {
                     attributes: Vec::new(),
                 };
                 self.categories.push(Inline::Link(
-                    attr,
+                    Box::new(attr),
                     text,
-                    Target {
+                    Box::new(Target {
                         url: wikilink_url(&target),
                         title,
-                    },
+                    }),
                 ));
                 return Some((Vec::new(), close + 2));
             }
@@ -1274,7 +1277,11 @@ impl Parser {
         };
         let url = wikilink_url(&target);
         Some((
-            vec![Inline::Link(attr, label, Target { url, title })],
+            vec![Inline::Link(
+                Box::new(attr),
+                label,
+                Box::new(Target { url, title }),
+            )],
             after,
         ))
     }
@@ -1326,7 +1333,11 @@ impl Parser {
             classes: Vec::new(),
             attributes,
         };
-        Some(Inline::Image(attr, alt, Target { url, title }))
+        Some(Inline::Image(
+            Box::new(attr),
+            alt,
+            Box::new(Target { url, title }),
+        ))
     }
 
     fn make_id(&mut self, inlines: &[Inline]) -> String {
@@ -1976,14 +1987,14 @@ fn preformat_transform(inlines: Vec<Inline>) -> Vec<Inline> {
             Inline::Space | Inline::SoftBreak => run.push('\u{a0}'),
             other => {
                 if !run.is_empty() {
-                    out.push(Inline::Code(Attr::default(), std::mem::take(&mut run)));
+                    out.push(Inline::Code(Box::default(), std::mem::take(&mut run)));
                 }
                 out.push(preformat_descend(other));
             }
         }
     }
     if !run.is_empty() {
-        out.push(Inline::Code(Attr::default(), run));
+        out.push(Inline::Code(Box::default(), run));
     }
     out
 }
@@ -2445,12 +2456,12 @@ fn bare_url(chars: &[char], i: usize) -> Option<(Inline, usize)> {
     let target = encode_url_target(&display);
     Some((
         Inline::Link(
-            Attr::default(),
+            Box::default(),
             vec![Inline::Str(display)],
-            Target {
+            Box::new(Target {
                 url: target,
                 title: String::new(),
-            },
+            }),
         ),
         i + consumed,
     ))
@@ -2687,8 +2698,8 @@ fn lone_image_figure(inlines: &[Inline]) -> Option<Block> {
     };
     let image = Inline::Image(attr.clone(), Vec::new(), target.clone());
     Some(Block::Figure(
-        Attr::default(),
-        caption,
+        Box::default(),
+        Box::new(caption),
         vec![Block::Plain(vec![image])],
     ))
 }
@@ -3940,7 +3951,10 @@ fn verbatim_code(
                 classes: classes.iter().map(|s| (*s).to_string()).collect(),
                 attributes: Vec::new(),
             };
-            (vec![Inline::Code(attr, decode_entities(&inner))], after)
+            (
+                vec![Inline::Code(Box::new(attr), decode_entities(&inner))],
+                after,
+            )
         }
         None => (vec![raw_html(raw_open.to_string())], after_open),
     }
@@ -4539,11 +4553,11 @@ mod tests {
             parse("== Hello World =="),
             vec![Block::Header(
                 2,
-                Attr {
+                Box::new(Attr {
                     id: "hello_world".into(),
                     classes: vec![],
                     attributes: vec![],
-                },
+                }),
                 vec![
                     Inline::Str("Hello".into()),
                     Inline::Space,
@@ -4609,11 +4623,11 @@ mod tests {
             vec![
                 Block::Header(
                     2,
-                    Attr {
+                    Box::new(Attr {
                         id: "h".into(),
                         classes: vec![],
                         attributes: vec![],
-                    },
+                    }),
                     vec![Inline::Str("H".into())],
                 ),
                 Block::Para(vec![Inline::Str("=".into())]),
@@ -4652,16 +4666,16 @@ mod tests {
         assert_eq!(
             parse("[[Page]]s"),
             vec![Block::Para(vec![Inline::Link(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["wikilink".into()],
                     attributes: vec![],
-                },
+                }),
                 vec![Inline::Str("Pages".into())],
-                Target {
+                Box::new(Target {
                     url: "Page".into(),
                     title: "Page".into(),
-                },
+                }),
             )])]
         );
     }
@@ -4671,22 +4685,22 @@ mod tests {
         assert_eq!(
             parse("[[File:Foo.jpg|thumb|A caption]]"),
             vec![Block::Figure(
-                Attr::default(),
-                Caption {
+                Box::default(),
+                Box::new(Caption {
                     short: None,
                     long: vec![Block::Plain(vec![
                         Inline::Str("A".into()),
                         Inline::Space,
                         Inline::Str("caption".into()),
                     ])],
-                },
+                }),
                 vec![Block::Plain(vec![Inline::Image(
-                    Attr::default(),
+                    Box::default(),
                     vec![],
-                    Target {
+                    Box::new(Target {
                         url: "Foo.jpg".into(),
                         title: "A caption".into(),
-                    },
+                    }),
                 )])],
             )]
         );
@@ -4697,18 +4711,18 @@ mod tests {
         assert_eq!(
             parse("[[Image:My Photo.jpg]]"),
             vec![Block::Figure(
-                Attr::default(),
-                Caption {
+                Box::default(),
+                Box::new(Caption {
                     short: None,
                     long: vec![Block::Plain(vec![Inline::Str("My_Photo.jpg".into())])],
-                },
+                }),
                 vec![Block::Plain(vec![Inline::Image(
-                    Attr::default(),
+                    Box::default(),
                     vec![],
-                    Target {
+                    Box::new(Target {
                         url: "My_Photo.jpg".into(),
                         title: "My_Photo.jpg".into(),
-                    },
+                    }),
                 )])],
             )]
         );
@@ -4719,25 +4733,25 @@ mod tests {
         assert_eq!(
             parse("[[File:Foo.jpg|100x200px|cap]]"),
             vec![Block::Figure(
-                Attr::default(),
-                Caption {
+                Box::default(),
+                Box::new(Caption {
                     short: None,
                     long: vec![Block::Plain(vec![Inline::Str("cap".into())])],
-                },
+                }),
                 vec![Block::Plain(vec![Inline::Image(
-                    Attr {
+                    Box::new(Attr {
                         id: String::new(),
                         classes: vec![],
                         attributes: vec![
                             ("width".into(), "100".into()),
                             ("height".into(), "200".into()),
                         ],
-                    },
+                    }),
                     vec![],
-                    Target {
+                    Box::new(Target {
                         url: "Foo.jpg".into(),
                         title: "cap".into(),
-                    },
+                    }),
                 )])],
             )]
         );
@@ -4751,12 +4765,12 @@ mod tests {
                 Inline::Str("x".into()),
                 Inline::Space,
                 Inline::Image(
-                    Attr::default(),
+                    Box::default(),
                     vec![Inline::Str("cap".into())],
-                    Target {
+                    Box::new(Target {
                         url: "Foo.jpg".into(),
                         title: "cap".into(),
-                    },
+                    }),
                 ),
             ])]
         );
@@ -4767,16 +4781,16 @@ mod tests {
         assert_eq!(
             parse("[[File:]]"),
             vec![Block::Para(vec![Inline::Link(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["wikilink".into()],
                     attributes: vec![],
-                },
+                }),
                 vec![Inline::Str("File:".into())],
-                Target {
+                Box::new(Target {
                     url: "File:".into(),
                     title: "File:".into(),
-                },
+                }),
             )])]
         );
     }
@@ -4787,21 +4801,21 @@ mod tests {
             parse("[http://x.com lbl] [http://y.com]"),
             vec![Block::Para(vec![
                 Inline::Link(
-                    Attr::default(),
+                    Box::default(),
                     vec![Inline::Str("lbl".into())],
-                    Target {
+                    Box::new(Target {
                         url: "http://x.com".into(),
                         title: String::new(),
-                    },
+                    }),
                 ),
                 Inline::Space,
                 Inline::Link(
-                    Attr::default(),
+                    Box::default(),
                     vec![Inline::Str("1".into())],
-                    Target {
+                    Box::new(Target {
                         url: "http://y.com".into(),
                         title: String::new(),
-                    },
+                    }),
                 ),
             ])]
         );
@@ -4815,12 +4829,12 @@ mod tests {
                 Inline::Str("see".into()),
                 Inline::Space,
                 Inline::Link(
-                    Attr::default(),
+                    Box::default(),
                     vec![Inline::Str("http://x.com".into())],
-                    Target {
+                    Box::new(Target {
                         url: "http://x.com".into(),
                         title: String::new(),
-                    },
+                    }),
                 ),
                 Inline::Str(".".into()),
             ])]
@@ -4863,7 +4877,7 @@ mod tests {
         assert_eq!(
             parse("<code>a &amp; b</code>"),
             vec![Block::Para(vec![Inline::Code(
-                Attr::default(),
+                Box::default(),
                 "a & b".into()
             )])]
         );
@@ -4910,11 +4924,11 @@ mod tests {
         assert_eq!(
             parse("<syntaxhighlight lang=\"rust\">\nfn main(){}\n</syntaxhighlight>"),
             vec![Block::CodeBlock(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["rust".into()],
                     attributes: vec![],
-                },
+                }),
                 "fn main(){}".into(),
             )]
         );
@@ -4934,7 +4948,7 @@ mod tests {
         assert_eq!(
             parse(" indented  line"),
             vec![Block::Para(vec![Inline::Code(
-                Attr::default(),
+                Box::default(),
                 "indented\u{a0}\u{a0}line".into()
             )])]
         );
@@ -4945,9 +4959,9 @@ mod tests {
         assert_eq!(
             parse(" a '''b''' c"),
             vec![Block::Para(vec![
-                Inline::Code(Attr::default(), "a\u{a0}".into()),
-                Inline::Strong(vec![Inline::Code(Attr::default(), "b".into())]),
-                Inline::Code(Attr::default(), "\u{a0}c".into()),
+                Inline::Code(Box::default(), "a\u{a0}".into()),
+                Inline::Strong(vec![Inline::Code(Box::default(), "b".into())]),
+                Inline::Code(Box::default(), "\u{a0}c".into()),
             ])]
         );
     }

--- a/crates/carta-readers/src/native.rs
+++ b/crates/carta-readers/src/native.rs
@@ -624,7 +624,7 @@ impl Parser {
             "CodeBlock" => {
                 let attr = self.parse_attr()?;
                 let text = self.parse_string()?;
-                Ok(Block::CodeBlock(attr, text))
+                Ok(Block::CodeBlock(Box::new(attr), text))
             }
             "RawBlock" => {
                 let format = self.parse_format()?;
@@ -645,7 +645,7 @@ impl Parser {
                 let level = self.parse_i32()?;
                 let attr = self.parse_attr()?;
                 let inlines = self.parse_inline_list()?;
-                Ok(Block::Header(level, attr, inlines))
+                Ok(Block::Header(level, Box::new(attr), inlines))
             }
             "HorizontalRule" => Ok(Block::HorizontalRule),
             "Table" => Ok(Block::Table(Box::new(self.parse_table()?))),
@@ -653,12 +653,12 @@ impl Parser {
                 let attr = self.parse_attr()?;
                 let caption = self.parse_caption()?;
                 let blocks = self.parse_block_list()?;
-                Ok(Block::Figure(attr, caption, blocks))
+                Ok(Block::Figure(Box::new(attr), Box::new(caption), blocks))
             }
             "Div" => {
                 let attr = self.parse_attr()?;
                 let blocks = self.parse_block_list()?;
-                Ok(Block::Div(attr, blocks))
+                Ok(Block::Div(Box::new(attr), blocks))
             }
             other => Err(syntax_error(format!("unknown block '{other}'"))),
         }
@@ -688,7 +688,7 @@ impl Parser {
             "Code" => {
                 let attr = self.parse_attr()?;
                 let text = self.parse_string()?;
-                Ok(Inline::Code(attr, text))
+                Ok(Inline::Code(Box::new(attr), text))
             }
             "Space" => Ok(Inline::Space),
             "SoftBreak" => Ok(Inline::SoftBreak),
@@ -707,19 +707,19 @@ impl Parser {
                 let attr = self.parse_attr()?;
                 let inlines = self.parse_inline_list()?;
                 let target = self.parse_target()?;
-                Ok(Inline::Link(attr, inlines, target))
+                Ok(Inline::Link(Box::new(attr), inlines, Box::new(target)))
             }
             "Image" => {
                 let attr = self.parse_attr()?;
                 let inlines = self.parse_inline_list()?;
                 let target = self.parse_target()?;
-                Ok(Inline::Image(attr, inlines, target))
+                Ok(Inline::Image(Box::new(attr), inlines, Box::new(target)))
             }
             "Note" => Ok(Inline::Note(self.parse_block_list()?)),
             "Span" => {
                 let attr = self.parse_attr()?;
                 let inlines = self.parse_inline_list()?;
-                Ok(Inline::Span(attr, inlines))
+                Ok(Inline::Span(Box::new(attr), inlines))
             }
             other => Err(syntax_error(format!("unknown inline '{other}'"))),
         }
@@ -1128,11 +1128,11 @@ mod tests {
         assert_eq!(
             only_block(r#"CodeBlock ("i", ["rust", "numberLines"], [("k", "v")]) "let x = 1;""#),
             Block::CodeBlock(
-                Attr {
+                Box::new(Attr {
                     id: "i".to_string(),
                     classes: vec!["rust".to_string(), "numberLines".to_string()],
                     attributes: vec![("k".to_string(), "v".to_string())],
-                },
+                }),
                 "let x = 1;".to_string()
             )
         );
@@ -1186,11 +1186,11 @@ mod tests {
             only_block(r#"Header 2 ("h", [], []) [Str "Title"]"#),
             Block::Header(
                 2,
-                Attr {
+                Box::new(Attr {
                     id: "h".to_string(),
                     classes: vec![],
                     attributes: vec![],
-                },
+                }),
                 vec![str_inline("Title")]
             )
         );
@@ -1201,11 +1201,11 @@ mod tests {
         assert_eq!(
             only_block(r#"Div ("d", [], []) [BlockQuote [Para [Str "q"]]]"#),
             Block::Div(
-                Attr {
+                Box::new(Attr {
                     id: "d".to_string(),
                     classes: vec![],
                     attributes: vec![],
-                },
+                }),
                 vec![Block::BlockQuote(vec![Block::Para(vec![str_inline("q")])])]
             )
         );
@@ -1267,7 +1267,7 @@ mod tests {
             Block::Para(vec![
                 Inline::Quoted(QuoteType::DoubleQuote, vec![str_inline("q")]),
                 Inline::Math(MathType::InlineMath, "x^2".to_string()),
-                Inline::Code(Attr::default(), "f()".to_string()),
+                Inline::Code(Box::default(), "f()".to_string()),
             ])
         );
     }
@@ -1281,27 +1281,27 @@ mod tests {
             block,
             Block::Para(vec![
                 Inline::Link(
-                    Attr::default(),
+                    Box::default(),
                     vec![str_inline("t")],
-                    Target {
+                    Box::new(Target {
                         url: "/u".to_string(),
                         title: "ti".to_string()
-                    }
+                    })
                 ),
                 Inline::Image(
-                    Attr::default(),
+                    Box::default(),
                     vec![str_inline("alt")],
-                    Target {
+                    Box::new(Target {
                         url: "/i".to_string(),
                         title: String::new()
-                    }
+                    })
                 ),
                 Inline::Span(
-                    Attr {
+                    Box::new(Attr {
                         id: "sp".to_string(),
                         classes: vec![],
                         attributes: vec![],
-                    },
+                    }),
                     vec![str_inline("s")]
                 ),
                 Inline::Note(vec![Block::Para(vec![str_inline("n")])]),

--- a/crates/carta-readers/src/opml.rs
+++ b/crates/carta-readers/src/opml.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use carta_ast::{Attr, Block, Document, Inline, MetaValue, QuoteType, Target};
+use carta_ast::{Block, Document, Inline, MetaValue, QuoteType, Target};
 use carta_core::{Reader, ReaderOptions, Result, presets};
 
 use crate::commonmark::CommonmarkReader;
@@ -80,17 +80,17 @@ fn emit_outline(outline: &Element, level: i32, blocks: &mut Vec<Block>) -> Resul
     let heading = if is_link_outline(outline) {
         let url = outline.attributes.get("url").cloned().unwrap_or_default();
         vec![Inline::Link(
-            Attr::default(),
+            Box::default(),
             heading,
-            Target {
+            Box::new(Target {
                 url,
                 title: String::new(),
-            },
+            }),
         )]
     } else {
         heading
     };
-    blocks.push(Block::Header(level, Attr::default(), heading));
+    blocks.push(Block::Header(level, Box::default(), heading));
     if let Some(note) = outline.attributes.get("_note") {
         let parsed = CommonmarkReader.read(note, &note_options())?;
         blocks.extend(parsed.blocks);
@@ -1006,7 +1006,7 @@ mod tests {
             vec![
                 Inline::Str("a".to_owned()),
                 Inline::Space,
-                Inline::Code(Attr::default(), "c".to_owned()),
+                Inline::Code(Box::default(), "c".to_owned()),
                 Inline::Space,
                 Inline::Str("b".to_owned()),
                 Inline::Space,
@@ -1320,10 +1320,7 @@ mod tests {
         // A matched pair inside a code span renders as its left and right glyphs, not a Quoted node.
         assert_eq!(
             inlines,
-            vec![Inline::Code(
-                Attr::default(),
-                "\u{2018}q\u{2019}".to_owned()
-            )]
+            vec![Inline::Code(Box::default(), "\u{2018}q\u{2019}".to_owned())]
         );
     }
 
@@ -1333,7 +1330,7 @@ mod tests {
         assert_eq!(
             inlines,
             vec![Inline::Code(
-                Attr::default(),
+                Box::default(),
                 "it\u{2019}s \u{2014} x".to_owned()
             )]
         );

--- a/crates/carta-readers/src/org.rs
+++ b/crates/carta-readers/src/org.rs
@@ -237,7 +237,7 @@ fn parse_blocks(
         // Fixed-width (colon) block.
         if is_fixed_width(line) {
             let (text, consumed) = collect_fixed_width(lines, i);
-            out.push(Block::CodeBlock(Attr::default(), text));
+            out.push(Block::CodeBlock(Box::default(), text));
             i += consumed;
             pending = Affiliated::default();
             continue;
@@ -257,7 +257,7 @@ fn parse_blocks(
                 classes: vec![name, "drawer".to_owned()],
                 ..Attr::default()
             };
-            out.push(Block::Div(attr, body));
+            out.push(Block::Div(Box::new(attr), body));
             pending = Affiliated::default();
             continue;
         }
@@ -331,8 +331,8 @@ fn apply_affiliated(block: Block, pending: &mut Affiliated) -> Block {
             };
             let long = caption.map(|c| vec![Block::Plain(c)]).unwrap_or_default();
             Block::Figure(
-                attr,
-                Caption { short: None, long },
+                Box::new(attr),
+                Box::new(Caption { short: None, long }),
                 vec![Block::Plain(inlines)],
             )
         }
@@ -408,7 +408,7 @@ fn build_headline(
         ..Attr::default()
     };
     let level = i32::try_from(level).unwrap_or(6).clamp(1, 6);
-    Block::Header(level, attr, inlines)
+    Block::Header(level, Box::new(attr), inlines)
 }
 
 fn todo_span(keyword: &str) -> Inline {
@@ -417,7 +417,7 @@ fn todo_span(keyword: &str) -> Inline {
         classes: vec![state.to_owned(), keyword.to_owned()],
         ..Attr::default()
     };
-    Inline::Span(attr, vec![Inline::Str(keyword.to_owned())])
+    Inline::Span(Box::new(attr), vec![Inline::Str(keyword.to_owned())])
 }
 
 fn tag_span(tag: &str) -> Inline {
@@ -427,7 +427,7 @@ fn tag_span(tag: &str) -> Inline {
         ..Attr::default()
     };
     Inline::Span(
-        attr,
+        Box::new(attr),
         vec![Inline::SmallCaps(vec![Inline::Str(tag.to_owned())])],
     )
 }
@@ -571,9 +571,9 @@ fn parse_greater_block(
                 classes: if lang.is_empty() { vec![] } else { vec![lang] },
                 ..Attr::default()
             };
-            Some(Block::CodeBlock(attr, dedent_verbatim(&content)))
+            Some(Block::CodeBlock(Box::new(attr), dedent_verbatim(&content)))
         }
-        "example" => Some(Block::CodeBlock(Attr::default(), dedent_verbatim(&content))),
+        "example" => Some(Block::CodeBlock(Box::default(), dedent_verbatim(&content))),
         "export" => {
             let fmt = header_args
                 .split_whitespace()
@@ -598,7 +598,7 @@ fn parse_greater_block(
                 ..Attr::default()
             };
             Some(Block::Div(
-                attr,
+                Box::new(attr),
                 parse_blocks(&content, ext, notes, ids, meta),
             ))
         }
@@ -1723,7 +1723,7 @@ impl Inlines<'_> {
                 while matches!(self.at(end), Some(' ' | '\t')) {
                     end += 1;
                 }
-                return Some((Inline::Span(attr, Vec::new()), end));
+                return Some((Inline::Span(Box::new(attr), Vec::new()), end));
             }
             return None;
         }
@@ -1945,28 +1945,28 @@ fn verbatim_code(marker: char, inner: &[char]) -> Inline {
     } else {
         Attr::default()
     };
-    Inline::Code(attr, text)
+    Inline::Code(Box::new(attr), text)
 }
 
 fn link(target: &str, desc: Vec<Inline>) -> Inline {
     Inline::Link(
-        Attr::default(),
+        Box::default(),
         desc,
-        carta_ast::Target {
+        Box::new(carta_ast::Target {
             url: target.to_owned(),
             title: String::new(),
-        },
+        }),
     )
 }
 
 fn image(target: &str, alt: Vec<Inline>) -> Inline {
     Inline::Image(
-        Attr::default(),
+        Box::default(),
         alt,
-        carta_ast::Target {
+        Box::new(carta_ast::Target {
             url: target.to_owned(),
             title: String::new(),
-        },
+        }),
     )
 }
 

--- a/crates/carta-readers/src/rst.rs
+++ b/crates/carta-readers/src/rst.rs
@@ -1502,11 +1502,11 @@ impl Parser<'_> {
         }
         Block::Header(
             level,
-            Attr {
+            Box::new(Attr {
                 id,
                 classes: Vec::new(),
                 attributes: Vec::new(),
-            },
+            }),
             inlines,
         )
     }
@@ -1621,7 +1621,7 @@ impl Parser<'_> {
             text_lines.pop();
         }
         Some((
-            Block::CodeBlock(Attr::default(), text_lines.join("\n")),
+            Block::CodeBlock(Box::default(), text_lines.join("\n")),
             end + 1,
         ))
     }
@@ -1646,7 +1646,7 @@ impl Parser<'_> {
         if text_lines.is_empty() {
             return None;
         }
-        Some((Block::CodeBlock(Attr::default(), text_lines.join("\n")), i))
+        Some((Block::CodeBlock(Box::default(), text_lines.join("\n")), i))
     }
 
     fn line_block(&mut self, lines: &[String], start: usize, out: &mut Vec<Block>) -> usize {
@@ -1861,7 +1861,7 @@ impl Parser<'_> {
             };
             let end = explicit_extent(lines, i, 0);
             let body = explicit_body(lines, i, end, value_col);
-            let term_inline = vec![Inline::Code(Attr::default(), term)];
+            let term_inline = vec![Inline::Code(Box::default(), term)];
             items.push((term_inline, vec![self.blocks(&body)]));
             i = end;
         }
@@ -1915,7 +1915,7 @@ impl Parser<'_> {
                 while text.ends_with('\n') {
                     text.pop();
                 }
-                out.push(Block::CodeBlock(attr, text));
+                out.push(Block::CodeBlock(Box::new(attr), text));
             }
             "math" => {
                 let mut equations = Vec::new();
@@ -1934,11 +1934,11 @@ impl Parser<'_> {
                     math
                 } else {
                     vec![Inline::Span(
-                        Attr {
+                        Box::new(Attr {
                             id,
                             classes,
                             attributes,
-                        },
+                        }),
                         math,
                     )]
                 };
@@ -1951,12 +1951,12 @@ impl Parser<'_> {
                     alt = vec![Inline::Str("image".to_string())];
                 }
                 let image = Inline::Image(
-                    attr,
+                    Box::new(attr),
                     alt,
-                    Target {
+                    Box::new(Target {
                         url,
                         title: String::new(),
-                    },
+                    }),
                 );
                 out.push(Block::Para(vec![Self::wrap_target(image, &options)]));
             }
@@ -1965,11 +1965,11 @@ impl Parser<'_> {
             | "important" | "tip" => {
                 let title = capitalize(name);
                 let mut blocks = vec![Block::Div(
-                    Attr {
+                    Box::new(Attr {
                         id: String::new(),
                         classes: vec!["title".to_string()],
                         attributes: Vec::new(),
-                    },
+                    }),
                     vec![Block::Para(vec![Inline::Str(title)])],
                 )];
                 blocks.extend(self.blocks(&directive_content(&body)));
@@ -2100,12 +2100,12 @@ impl Parser<'_> {
     fn wrap_target(image: Inline, options: &[(String, String)]) -> Inline {
         if let Some((_, url)) = options.iter().find(|(k, _)| k == "target") {
             Inline::Link(
-                Attr::default(),
+                Box::default(),
                 vec![image],
-                Target {
+                Box::new(Target {
                     url: url.clone(),
                     title: String::new(),
-                },
+                }),
             )
         } else {
             image
@@ -2136,15 +2136,15 @@ impl Parser<'_> {
         // The image description defaults to the figure's caption when no explicit alt is given.
         let description = if alt.is_empty() { caption_inlines } else { alt };
         let image = Inline::Image(
-            img_attr,
+            Box::new(img_attr),
             description,
-            Target {
+            Box::new(Target {
                 url,
                 title: String::new(),
-            },
+            }),
         );
         let body = vec![Block::Plain(vec![image])];
-        Block::Figure(figure_attr(options), caption, body)
+        Block::Figure(Box::new(figure_attr(options)), Box::new(caption), body)
     }
 
     /// A `line-block` directive: each body line becomes one line of the block, with a blank body line
@@ -2200,22 +2200,22 @@ impl Parser<'_> {
             .iter()
             .map(|(label, body)| {
                 let term = vec![Inline::Span(
-                    Attr {
+                    Box::new(Attr {
                         id: label.clone(),
                         classes: vec!["citation-label".to_string()],
                         attributes: Vec::new(),
-                    },
+                    }),
                     vec![Inline::Str(label.clone())],
                 )];
                 (term, vec![self.blocks(body)])
             })
             .collect();
         Some(Block::Div(
-            Attr {
+            Box::new(Attr {
                 id: "citations".to_string(),
                 classes: Vec::new(),
                 attributes: Vec::new(),
-            },
+            }),
             vec![Block::DefinitionList(items)],
         ))
     }
@@ -2835,11 +2835,11 @@ impl Parser<'_> {
         let id = carta_ast::slug(&carta_ast::to_plain_text(&inner));
         Some((
             Inline::Span(
-                Attr {
+                Box::new(Attr {
                     id,
                     classes: Vec::new(),
                     attributes: Vec::new(),
-                },
+                }),
                 inner,
             ),
             end,
@@ -3004,7 +3004,7 @@ impl Parser<'_> {
             let (content, end) = find_close_literal(chars, pos + 2, "``")?;
             return Some((
                 vec![Inline::Code(
-                    Attr::default(),
+                    Box::default(),
                     normalize_inline_literal(&content),
                 )],
                 false,
@@ -3078,24 +3078,27 @@ impl Parser<'_> {
                 if let Some(language) = chain.language {
                     classes.push(language);
                 }
-                Inline::Code(class_attr(classes), content.to_string())
+                Inline::Code(Box::new(class_attr(classes)), content.to_string())
             }
             "title-reference" | "title" | "t" => {
                 let mut classes = chain.classes;
                 classes.push("title-ref".to_string());
-                Inline::Span(class_attr(classes), self.inlines_no_trim(content))
+                Inline::Span(Box::new(class_attr(classes)), self.inlines_no_trim(content))
             }
             // A chain that bottoms out in no base role (a plain custom role) wraps the content in a
             // span carrying its accumulated classes.
-            "" => Inline::Span(class_attr(chain.classes), self.inlines_no_trim(content)),
+            "" => Inline::Span(
+                Box::new(class_attr(chain.classes)),
+                self.inlines_no_trim(content),
+            ),
             // An unrecognized role keeps its content verbatim, tagged with the role name so the
             // information survives a round-trip.
             other => Inline::Code(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["interpreted-text".to_string()],
                     attributes: vec![("role".to_string(), other.to_string())],
-                },
+                }),
                 content.to_string(),
             ),
         }
@@ -3162,12 +3165,12 @@ impl Parser<'_> {
             push_text(&mut display, &format!("|{name}|"));
             return Some((
                 vec![Inline::Link(
-                    Attr::default(),
+                    Box::default(),
                     display,
-                    Target {
+                    Box::new(Target {
                         url: format!("##SUBST##|{name}|"),
                         title: String::new(),
-                    },
+                    }),
                 )],
                 false,
                 end,
@@ -3181,16 +3184,16 @@ impl Parser<'_> {
                 // A replacement that expands to several inlines is kept together as one unit.
                 match inlines.len() {
                     1 => inlines,
-                    _ => vec![Inline::Span(Attr::default(), inlines)],
+                    _ => vec![Inline::Span(Box::default(), inlines)],
                 }
             }
             Some(Substitution::Image(url, attr, alt)) => vec![Inline::Image(
-                attr,
+                Box::new(attr),
                 alt,
-                Target {
+                Box::new(Target {
                     url,
                     title: String::new(),
-                },
+                }),
             )],
             None => {
                 // An undefined substitution is preserved as a placeholder link whose visible text is
@@ -3199,12 +3202,12 @@ impl Parser<'_> {
                 push_text(&mut display, &format!("|{name}|"));
                 return Some((
                     vec![Inline::Link(
-                        Attr::default(),
+                        Box::default(),
                         display,
-                        Target {
+                        Box::new(Target {
                             url: format!("##SUBST##|{name}|"),
                             title: String::new(),
-                        },
+                        }),
                     )],
                     false,
                     end,
@@ -3213,12 +3216,12 @@ impl Parser<'_> {
         };
         let result = if referenced {
             vec![Inline::Link(
-                Attr::default(),
+                Box::default(),
                 expansion,
-                Target {
+                Box::new(Target {
                     url: defer_reference(&name),
                     title: String::new(),
-                },
+                }),
             )]
         } else {
             expansion
@@ -3246,16 +3249,16 @@ impl Parser<'_> {
         if is_citation_label(&label) {
             let url = format!("#{label}");
             let link = Inline::Link(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["citation".to_string()],
                     attributes: Vec::new(),
-                },
+                }),
                 vec![Inline::Str(format!("[{label}]"))],
-                Target {
+                Box::new(Target {
                     url,
                     title: String::new(),
-                },
+                }),
             );
             return Some((vec![link], false, end));
         }
@@ -3305,12 +3308,12 @@ impl Parser<'_> {
             self.deferred.insert(normalize_name(&label), target.clone());
         }
         Inline::Link(
-            Attr::default(),
+            Box::default(),
             self.inlines(&display),
-            Target {
+            Box::new(Target {
                 url: target,
                 title: String::new(),
-            },
+            }),
         )
     }
 
@@ -3347,12 +3350,12 @@ impl Parser<'_> {
             defer_reference(&name)
         };
         let link = Inline::Link(
-            Attr::default(),
+            Box::default(),
             vec![Inline::Str(name)],
-            Target {
+            Box::new(Target {
                 url,
                 title: String::new(),
-            },
+            }),
         );
         Some((link, after))
     }
@@ -3864,11 +3867,11 @@ fn scale_dimension(dimension: Dimension, scale: Option<(f64, bool)>) -> Dimensio
 
 fn class_div(classes: Vec<String>, blocks: Vec<Block>) -> Block {
     Block::Div(
-        Attr {
+        Box::new(Attr {
             id: String::new(),
             classes,
             attributes: Vec::new(),
-        },
+        }),
         blocks,
     )
 }
@@ -3915,11 +3918,11 @@ fn attach_targets(mut blocks: Vec<Block>, mut targets: Vec<String>) -> Vec<Block
         attr.id = last;
         for name in targets.into_iter().rev() {
             inlines.push(Inline::Span(
-                Attr {
+                Box::new(Attr {
                     id: name,
                     classes: Vec::new(),
                     attributes: Vec::new(),
-                },
+                }),
                 Vec::new(),
             ));
         }
@@ -3927,11 +3930,11 @@ fn attach_targets(mut blocks: Vec<Block>, mut targets: Vec<String>) -> Vec<Block
     }
     for name in targets.into_iter().rev() {
         blocks = vec![Block::Div(
-            Attr {
+            Box::new(Attr {
                 id: name,
                 classes: Vec::new(),
                 attributes: Vec::new(),
-            },
+            }),
             blocks,
         )];
     }
@@ -3961,11 +3964,11 @@ fn options_div(name: &str, options: &[(String, String)], blocks: Vec<Block>) -> 
     let mut classes = vec![name.to_string()];
     classes.extend(extra);
     Block::Div(
-        Attr {
+        Box::new(Attr {
             id,
             classes,
             attributes,
-        },
+        }),
         blocks,
     )
 }
@@ -4371,12 +4374,12 @@ fn try_uri_autolink(chars: &[char], pos: usize) -> Option<(Inline, usize)> {
     // The link text shows the URL as written; the destination is percent-encoded.
     Some((
         Inline::Link(
-            Attr::default(),
+            Box::default(),
             vec![Inline::Str(url.clone())],
-            Target {
+            Box::new(Target {
                 url: escape_uri(&url),
                 title: String::new(),
-            },
+            }),
         ),
         end,
     ))
@@ -4425,12 +4428,12 @@ fn try_email_autolink(chars: &[char], pos: usize) -> Option<(Inline, usize)> {
     let address: String = chars.get(pos..end)?.iter().collect();
     Some((
         Inline::Link(
-            Attr::default(),
+            Box::default(),
             vec![Inline::Str(address.clone())],
-            Target {
+            Box::new(Target {
                 url: format!("mailto:{address}"),
                 title: String::new(),
-            },
+            }),
         ),
         end,
     ))
@@ -5176,7 +5179,7 @@ mod tests {
                 Inline::Space,
                 Inline::Str("and".into()),
                 Inline::Space,
-                Inline::Code(Attr::default(), "lit".into()),
+                Inline::Code(Box::default(), "lit".into()),
                 Inline::Str(".".into()),
             ])]
         );
@@ -5189,11 +5192,11 @@ mod tests {
             blocks,
             vec![Block::Header(
                 1,
-                Attr {
+                Box::new(Attr {
                     id: "title".into(),
                     classes: Vec::new(),
                     attributes: Vec::new(),
-                },
+                }),
                 vec![Inline::Str("Title".into())],
             )]
         );
@@ -5249,7 +5252,7 @@ mod tests {
         let blocks = parse("::\n\n    code line\n");
         assert_eq!(
             blocks,
-            vec![Block::CodeBlock(Attr::default(), "code line".into())]
+            vec![Block::CodeBlock(Box::default(), "code line".into())]
         );
     }
 
@@ -5283,12 +5286,12 @@ mod tests {
                 assert_eq!(
                     link,
                     Some(&Inline::Link(
-                        Attr::default(),
+                        Box::default(),
                         vec![Inline::Str("website".into())],
-                        Target {
+                        Box::new(Target {
                             url: "https://example.org".into(),
                             title: String::new(),
-                        },
+                        }),
                     ))
                 );
             }
@@ -5429,7 +5432,7 @@ mod tests {
             };
             for inline in inlines {
                 if let Inline::Image(attr, _, _) = inline {
-                    return Some(attr.clone());
+                    return Some(*attr.clone());
                 }
             }
         }

--- a/crates/carta-writers/src/beamer.rs
+++ b/crates/carta-writers/src/beamer.rs
@@ -308,10 +308,10 @@ mod tests {
     fn header(level: i32, id: &str, title: &str) -> Block {
         Block::Header(
             level,
-            Attr {
+            Box::new(Attr {
                 id: id.to_owned(),
                 ..Attr::default()
-            },
+            }),
             vec![Inline::Str(title.to_owned())],
         )
     }
@@ -345,14 +345,14 @@ mod tests {
 
     #[test]
     fn code_block_marks_frame_fragile() {
-        let out = render(vec![Block::CodeBlock(Attr::default(), "x\n".to_owned())]);
+        let out = render(vec![Block::CodeBlock(Box::default(), "x\n".to_owned())]);
         assert!(out.starts_with("\\begin{frame}[fragile]"));
     }
 
     #[test]
     fn inline_code_marks_frame_fragile() {
         let out = render(vec![Block::Para(vec![Inline::Code(
-            Attr::default(),
+            Box::default(),
             "x".to_owned(),
         )])]);
         assert!(out.starts_with("\\begin{frame}[fragile]"));
@@ -378,7 +378,7 @@ mod tests {
         };
         attr.classes = vec!["allowframebreaks".to_owned(), "unknown".to_owned()];
         let out = render(vec![
-            Block::Header(6, attr, vec![Inline::Str("T".to_owned())]),
+            Block::Header(6, Box::new(attr), vec![Inline::Str("T".to_owned())]),
             para("y"),
         ]);
         assert!(out.starts_with("\\begin{frame}[allowframebreaks]{T}"));
@@ -391,10 +391,10 @@ mod tests {
 
     fn div(classes: &[&str], blocks: Vec<Block>) -> Block {
         Block::Div(
-            Attr {
+            Box::new(Attr {
                 classes: classes.iter().map(|class| (*class).to_owned()).collect(),
                 ..Attr::default()
-            },
+            }),
             blocks,
         )
     }

--- a/crates/carta-writers/src/commonmark.rs
+++ b/crates/carta-writers/src/commonmark.rs
@@ -1042,15 +1042,15 @@ mod tests {
     #[test]
     fn link_with_autolink_class_renders_angle_form() {
         let link = Inline::Link(
-            Attr {
+            Box::new(Attr {
                 classes: vec!["uri".into()],
                 ..Attr::default()
-            },
+            }),
             str_inlines("http://example.com"),
-            Target {
+            Box::new(Target {
                 url: "http://example.com".into(),
                 title: String::new(),
-            },
+            }),
         );
         assert_eq!(render(vec![para(vec![link])]), "<http://example.com>");
     }
@@ -1058,15 +1058,15 @@ mod tests {
     #[test]
     fn attributed_link_falls_back_to_html() {
         let link = Inline::Link(
-            Attr {
+            Box::new(Attr {
                 id: "l".into(),
                 ..Attr::default()
-            },
+            }),
             str_inlines("text"),
-            Target {
+            Box::new(Target {
                 url: "/p".into(),
                 title: "T".into(),
-            },
+            }),
         );
         let out = render(vec![para(vec![link])]);
         assert!(out.contains("<a href=\"/p\" id=\"l\" title=\"T\">text</a>"));
@@ -1075,12 +1075,12 @@ mod tests {
     #[test]
     fn plain_link_uses_inline_destination() {
         let link = Inline::Link(
-            Attr::default(),
+            Box::default(),
             str_inlines("text"),
-            Target {
+            Box::new(Target {
                 url: "/p".into(),
                 title: "T".into(),
-            },
+            }),
         );
         assert_eq!(render(vec![para(vec![link])]), "[text](/p \"T\")");
     }
@@ -1106,7 +1106,7 @@ mod tests {
     #[test]
     fn empty_header_keeps_marker() {
         assert_eq!(
-            render(vec![Block::Header(2, Attr::default(), vec![])]),
+            render(vec![Block::Header(2, Box::default(), vec![])]),
             "## "
         );
     }
@@ -1146,10 +1146,10 @@ mod tests {
     #[test]
     fn span_with_attrs_wraps_in_tag() {
         let span = Inline::Span(
-            Attr {
+            Box::new(Attr {
                 id: "s".into(),
                 ..Attr::default()
-            },
+            }),
             str_inlines("x"),
         );
         assert_eq!(render(vec![para(vec![span])]), "<span id=\"s\">x</span>");
@@ -1158,15 +1158,15 @@ mod tests {
     #[test]
     fn image_with_attrs_falls_back_to_html() {
         let image = Inline::Image(
-            Attr {
+            Box::new(Attr {
                 classes: vec!["c".into()],
                 ..Attr::default()
-            },
+            }),
             str_inlines("alt"),
-            Target {
+            Box::new(Target {
                 url: "i.png".into(),
                 title: "T".into(),
-            },
+            }),
         );
         let out = render(vec![para(vec![image])]);
         assert!(out.contains("<img src=\"i.png\" title=\"T\" class=\"c\" alt=\"alt\" />"));
@@ -1177,13 +1177,13 @@ mod tests {
         let a = "a".repeat(28);
         let b = "b".repeat(28);
         let div = Block::Div(
-            Attr {
+            Box::new(Attr {
                 attributes: vec![
                     ("data-one".into(), a.clone()),
                     ("data-two".into(), b.clone()),
                 ],
                 ..Attr::default()
-            },
+            }),
             vec![para(str_inlines("body"))],
         );
         assert_eq!(
@@ -1196,18 +1196,18 @@ mod tests {
     fn long_image_tag_wraps_at_fill_column() {
         let url = format!("{}.png", "x".repeat(46));
         let image = Inline::Image(
-            Attr {
+            Box::new(Attr {
                 attributes: vec![
                     ("width".into(), "320".into()),
                     ("height".into(), "240".into()),
                 ],
                 ..Attr::default()
-            },
+            }),
             vec![],
-            Target {
+            Box::new(Target {
                 url: url.clone(),
                 title: String::new(),
-            },
+            }),
         );
         assert_eq!(
             render(vec![para(vec![image])]),
@@ -1218,10 +1218,10 @@ mod tests {
     #[test]
     fn div_holding_only_a_dropped_raw_block_emits_no_surplus_blank_lines() {
         let div = Block::Div(
-            Attr {
+            Box::new(Attr {
                 id: "embed".into(),
                 ..Attr::default()
-            },
+            }),
             vec![Block::RawBlock(Format("latex".into()), "\\x".into())],
         );
         assert_eq!(render(vec![div]), "<div id=\"embed\">\n\n</div>");
@@ -1254,11 +1254,14 @@ mod tests {
             ..Attr::default()
         };
         assert_eq!(
-            render(vec![Block::CodeBlock(attr.clone(), "fn x(){}\n".into())]),
+            render(vec![Block::CodeBlock(
+                Box::new(attr.clone()),
+                "fn x(){}\n".into()
+            )]),
             "``` rust\nfn x(){}\n```"
         );
         assert_eq!(
-            render(vec![Block::CodeBlock(attr, String::new())]),
+            render(vec![Block::CodeBlock(Box::new(attr), String::new())]),
             "``` rust\n```"
         );
     }
@@ -1266,7 +1269,7 @@ mod tests {
     #[test]
     fn indented_code_block_without_attrs() {
         assert_eq!(
-            render(vec![Block::CodeBlock(Attr::default(), "a\n\nb\n".into())]),
+            render(vec![Block::CodeBlock(Box::default(), "a\n\nb\n".into())]),
             "    a\n\n    b"
         );
     }
@@ -1337,7 +1340,7 @@ mod tests {
     fn code_block_indented_then_list_separates() {
         assert!(needs_separator(
             &Block::BulletList(vec![plain_item("a")]),
-            &Block::CodeBlock(Attr::default(), "x".into())
+            &Block::CodeBlock(Box::default(), "x".into())
         ));
         assert!(!needs_separator(&Block::Para(vec![]), &Block::Para(vec![])));
     }
@@ -1471,14 +1474,18 @@ mod tests {
             long: vec![Block::Plain(str_inlines("a caption"))],
         };
         let image = Inline::Image(
-            Attr::default(),
+            Box::default(),
             str_inlines("a caption"),
-            Target {
+            Box::new(Target {
                 url: "pic.png".into(),
                 title: "fig title".into(),
-            },
+            }),
         );
-        let figure = Block::Figure(Attr::default(), caption, vec![Block::Plain(vec![image])]);
+        let figure = Block::Figure(
+            Box::default(),
+            Box::new(caption),
+            vec![Block::Plain(vec![image])],
+        );
         assert_eq!(
             render(vec![figure]),
             "<figure>\n<img src=\"pic.png\" title=\"fig title\" alt=\"a caption\" />\n\
@@ -1489,15 +1496,15 @@ mod tests {
     #[test]
     fn dimensioned_image_falls_back_to_html_img() {
         let image = Inline::Image(
-            Attr {
+            Box::new(Attr {
                 attributes: vec![("width".into(), "200".into())],
                 ..Attr::default()
-            },
+            }),
             str_inlines("alt"),
-            Target {
+            Box::new(Target {
                 url: "pic.png".into(),
                 title: String::new(),
-            },
+            }),
         );
         assert_eq!(
             render(vec![para(vec![image])]),
@@ -1508,27 +1515,27 @@ mod tests {
     #[test]
     fn attrless_image_stays_markdown() {
         let image = Inline::Image(
-            Attr::default(),
+            Box::default(),
             str_inlines("alt"),
-            Target {
+            Box::new(Target {
                 url: "pic.png".into(),
                 title: String::new(),
-            },
+            }),
         );
         assert_eq!(render(vec![para(vec![image])]), "![alt](pic.png)");
     }
 
     fn dimensioned_image(attributes: Vec<(String, String)>) -> Inline {
         Inline::Image(
-            Attr {
+            Box::new(Attr {
                 attributes,
                 ..Attr::default()
-            },
+            }),
             str_inlines("alt"),
-            Target {
+            Box::new(Target {
                 url: "pic.png".into(),
                 title: String::new(),
-            },
+            }),
         )
     }
 

--- a/crates/carta-writers/src/ipynb.rs
+++ b/crates/carta-writers/src/ipynb.rs
@@ -741,7 +741,7 @@ mod tests {
     #[test]
     fn loose_blocks_become_one_markdown_cell() {
         let notebook = write(vec![
-            Block::Header(1, Attr::default(), vec![Inline::Str("Title".to_owned())]),
+            Block::Header(1, Box::default(), vec![Inline::Str("Title".to_owned())]),
             para("Body."),
         ]);
         assert!(notebook.contains("\"cell_type\": \"markdown\""));
@@ -770,12 +770,12 @@ mod tests {
     #[test]
     fn cell_div_selects_kind_and_keeps_id() {
         let notebook = write(vec![Block::Div(
-            Attr {
+            Box::new(Attr {
                 id: "given".to_owned(),
                 classes: vec!["cell".to_owned(), "code".to_owned()],
                 attributes: vec![("execution_count".to_owned(), "7".to_owned())],
-            },
-            vec![Block::CodeBlock(Attr::default(), "print(1)".to_owned())],
+            }),
+            vec![Block::CodeBlock(Box::default(), "print(1)".to_owned())],
         )]);
         assert!(notebook.contains("\"cell_type\": \"code\""));
         assert!(notebook.contains("\"execution_count\": 7"));
@@ -787,11 +787,11 @@ mod tests {
     #[test]
     fn raw_cell_carries_mime_type() {
         let notebook = write(vec![Block::Div(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes: vec!["cell".to_owned(), "raw".to_owned()],
                 attributes: Vec::new(),
-            },
+            }),
             vec![Block::RawBlock(
                 Format("html".to_owned()),
                 "<b>x</b>".to_owned(),
@@ -805,11 +805,11 @@ mod tests {
     #[test]
     fn raw_cell_maps_asciidoc_mime() {
         let notebook = write(vec![Block::Div(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes: vec!["cell".to_owned(), "raw".to_owned()],
                 attributes: Vec::new(),
-            },
+            }),
             vec![Block::RawBlock(
                 Format("asciidoc".to_owned()),
                 "[NOTE]\n====\nbody\n====".to_owned(),
@@ -822,15 +822,15 @@ mod tests {
     #[test]
     fn stream_and_error_outputs_round_trip() {
         let notebook = write(vec![Block::Div(
-            Attr {
+            Box::new(Attr {
                 id: String::new(),
                 classes: vec!["cell".to_owned(), "code".to_owned()],
                 attributes: Vec::new(),
-            },
+            }),
             vec![
-                Block::CodeBlock(Attr::default(), "x".to_owned()),
+                Block::CodeBlock(Box::default(), "x".to_owned()),
                 Block::Div(
-                    Attr {
+                    Box::new(Attr {
                         id: String::new(),
                         classes: vec![
                             "output".to_owned(),
@@ -838,19 +838,19 @@ mod tests {
                             "stdout".to_owned(),
                         ],
                         attributes: Vec::new(),
-                    },
-                    vec![Block::CodeBlock(Attr::default(), "hi\n".to_owned())],
+                    }),
+                    vec![Block::CodeBlock(Box::default(), "hi\n".to_owned())],
                 ),
                 Block::Div(
-                    Attr {
+                    Box::new(Attr {
                         id: String::new(),
                         classes: vec!["output".to_owned(), "error".to_owned()],
                         attributes: vec![
                             ("ename".to_owned(), "ValueError".to_owned()),
                             ("evalue".to_owned(), "bad".to_owned()),
                         ],
-                    },
-                    vec![Block::CodeBlock(Attr::default(), "trace\n".to_owned())],
+                    }),
+                    vec![Block::CodeBlock(Box::default(), "trace\n".to_owned())],
                 ),
             ],
         )]);
@@ -865,26 +865,26 @@ mod tests {
     fn image_output_without_embedded_data_is_unrepresentable() {
         let document = Document {
             blocks: vec![Block::Div(
-                Attr {
+                Box::new(Attr {
                     id: String::new(),
                     classes: vec!["cell".to_owned(), "code".to_owned()],
                     attributes: Vec::new(),
-                },
+                }),
                 vec![
-                    Block::CodeBlock(Attr::default(), "plot()".to_owned()),
+                    Block::CodeBlock(Box::default(), "plot()".to_owned()),
                     Block::Div(
-                        Attr {
+                        Box::new(Attr {
                             id: String::new(),
                             classes: vec!["output".to_owned(), "display_data".to_owned()],
                             attributes: Vec::new(),
-                        },
+                        }),
                         vec![Block::Para(vec![Inline::Image(
-                            Attr::default(),
+                            Box::default(),
                             Vec::new(),
-                            carta_ast::Target {
+                            Box::new(carta_ast::Target {
                                 url: "plot.png".to_owned(),
                                 title: String::new(),
-                            },
+                            }),
                         )])],
                     ),
                 ],

--- a/crates/carta-writers/src/jira.rs
+++ b/crates/carta-writers/src/jira.rs
@@ -1321,7 +1321,7 @@ mod tests {
     /// Render a single inline-code token as the writer would, with no surrounding inlines.
     fn code(value: &str) -> String {
         render(vec![para(vec![Inline::Code(
-            Attr::default(),
+            Box::default(),
             value.to_owned(),
         )])])
     }

--- a/crates/carta-writers/src/latex.rs
+++ b/crates/carta-writers/src/latex.rs
@@ -2084,20 +2084,20 @@ mod tests {
     #[test]
     fn header_levels_and_anchors() {
         assert_eq!(
-            render(vec![Block::Header(1, Attr::default(), str_inlines("T"))]),
+            render(vec![Block::Header(1, Box::default(), str_inlines("T"))]),
             "\\section{T}"
         );
         assert_eq!(
-            render(vec![Block::Header(4, Attr::default(), str_inlines("T"))]),
+            render(vec![Block::Header(4, Box::default(), str_inlines("T"))]),
             "\\paragraph{T}"
         );
         assert_eq!(
-            render(vec![Block::Header(5, Attr::default(), str_inlines("T"))]),
+            render(vec![Block::Header(5, Box::default(), str_inlines("T"))]),
             "\\subparagraph{T}"
         );
         // A level beyond the mapped range degrades to plain text.
         assert_eq!(
-            render(vec![Block::Header(7, Attr::default(), str_inlines("T"))]),
+            render(vec![Block::Header(7, Box::default(), str_inlines("T"))]),
             "T"
         );
     }
@@ -2109,7 +2109,7 @@ mod tests {
             classes: vec!["unnumbered".into()],
             ..Attr::default()
         };
-        let out = render(vec![Block::Header(1, attr, str_inlines("Title"))]);
+        let out = render(vec![Block::Header(1, Box::new(attr), str_inlines("Title"))]);
         assert!(out.contains("\\section*{Title}\\label{sec}"));
         assert!(out.contains("\\addcontentsline{toc}{section}{Title}"));
     }
@@ -2117,7 +2117,7 @@ mod tests {
     #[test]
     fn header_with_markup_wraps_texorpdfstring() {
         let inlines = vec![Inline::Emph(str_inlines("x"))];
-        let out = render(vec![Block::Header(1, Attr::default(), inlines)]);
+        let out = render(vec![Block::Header(1, Box::default(), inlines)]);
         assert!(out.contains("\\texorpdfstring{\\emph{x}}{x}"));
     }
 
@@ -2195,8 +2195,8 @@ mod tests {
             ..Attr::default()
         };
         let out = render(vec![Block::Figure(
-            attr,
-            caption,
+            Box::new(attr),
+            Box::new(caption),
             vec![Block::Plain(str_inlines("body"))],
         )]);
         assert!(out.contains("\\caption{Cap}\\label{fig}"));
@@ -2209,8 +2209,8 @@ mod tests {
             ..Attr::default()
         };
         let out = render(vec![Block::Figure(
-            attr,
-            Caption::default(),
+            Box::new(attr),
+            Box::default(),
             vec![Block::Plain(str_inlines("body"))],
         )]);
         assert!(out.contains("\\caption{}\\label{fig}"));
@@ -2219,10 +2219,10 @@ mod tests {
     #[test]
     fn span_with_id_emits_phantom_label() {
         let span = Inline::Span(
-            Attr {
+            Box::new(Attr {
                 id: "s".into(),
                 ..Attr::default()
-            },
+            }),
             str_inlines("x"),
         );
         let out = render(vec![Block::Para(vec![span])]);
@@ -2239,12 +2239,12 @@ mod tests {
             ..Attr::default()
         };
         let image = Inline::Image(
-            attr,
+            Box::new(attr),
             str_inlines("alt"),
-            Target {
+            Box::new(Target {
                 url: "img.png".into(),
                 title: String::new(),
-            },
+            }),
         );
         let out = render(vec![Block::Para(vec![image])]);
         assert!(out.contains("width=0.5\\linewidth"));
@@ -2254,7 +2254,7 @@ mod tests {
 
     #[test]
     fn footnote_with_code_block_closes_on_own_line() {
-        let note = Inline::Note(vec![Block::CodeBlock(Attr::default(), "x\n".into())]);
+        let note = Inline::Note(vec![Block::CodeBlock(Box::default(), "x\n".into())]);
         let out = render(vec![Block::Para(vec![Inline::Str("a".into()), note])]);
         assert!(out.contains("\\begin{Verbatim}"));
         assert!(out.contains("\n}"));

--- a/crates/carta-writers/src/man.rs
+++ b/crates/carta-writers/src/man.rs
@@ -1007,7 +1007,7 @@ mod tests {
     fn paragraph_after_header_omits_pp() {
         assert_eq!(
             render(vec![
-                Block::Header(1, Attr::default(), vec![s("H")]),
+                Block::Header(1, Box::default(), vec![s("H")]),
                 para(vec![s("body")]),
             ]),
             ".SH H\nbody"
@@ -1018,8 +1018,8 @@ mod tests {
     fn header_levels() {
         assert_eq!(
             render(vec![
-                Block::Header(1, Attr::default(), vec![s("A")]),
-                Block::Header(3, Attr::default(), vec![s("B")]),
+                Block::Header(1, Box::default(), vec![s("A")]),
+                Block::Header(3, Box::default(), vec![s("B")]),
             ]),
             ".SH A\n.SS B"
         );
@@ -1039,7 +1039,7 @@ mod tests {
     #[test]
     fn code_uses_mono_font() {
         assert_eq!(
-            render(vec![para(vec![Inline::Code(Attr::default(), "x".into())])]),
+            render(vec![para(vec![Inline::Code(Box::default(), "x".into())])]),
             ".PP\n\\f[CR]x\\f[R]"
         );
     }
@@ -1103,7 +1103,7 @@ mod tests {
     #[test]
     fn code_block_example_group() {
         assert_eq!(
-            render(vec![Block::CodeBlock(Attr::default(), "a\nb\n".into())]),
+            render(vec![Block::CodeBlock(Box::default(), "a\nb\n".into())]),
             ".IP\n.EX\na\nb\n.EE"
         );
     }
@@ -1157,12 +1157,12 @@ mod tests {
     fn image_renders_placeholder() {
         assert_eq!(
             render(vec![para(vec![Inline::Image(
-                Attr::default(),
+                Box::default(),
                 vec![],
-                Target {
+                Box::new(Target {
                     url: "i.png".into(),
                     title: String::new(),
-                },
+                }),
             )])]),
             ".PP\n[IMAGE: image]"
         );
@@ -1421,7 +1421,7 @@ mod tests {
         assert_eq!(
             render(vec![Block::Header(
                 1,
-                Attr::default(),
+                Box::default(),
                 vec![s("T"), Inline::Space, display_math("a^2")],
             )]),
             ".SH T \n.RS\n\\f[I]a\\f[R]^2^\n.RE"

--- a/crates/carta-writers/src/markdown.rs
+++ b/crates/carta-writers/src/markdown.rs
@@ -867,8 +867,8 @@ impl State {
         if !self.config.has(Extension::ImplicitFigures) {
             return crate::html::render_fragment(
                 &[Block::Figure(
-                    attr.clone(),
-                    caption.clone(),
+                    Box::new(attr.clone()),
+                    Box::new(caption.clone()),
                     blocks.to_vec(),
                 )],
                 self.wrap,
@@ -879,8 +879,8 @@ impl State {
         }
         crate::html::render_fragment(
             &[Block::Figure(
-                attr.clone(),
-                caption.clone(),
+                Box::new(attr.clone()),
+                Box::new(caption.clone()),
                 blocks.to_vec(),
             )],
             self.wrap,

--- a/crates/carta-writers/src/math/inlines.rs
+++ b/crates/carta-writers/src/math/inlines.rs
@@ -593,7 +593,7 @@ fn wrap_text_run(name: &str, run: &str) -> Option<Vec<Inline>> {
         "textbf" => vec![Inline::Strong(vec![text])],
         "textit" => vec![Inline::Emph(vec![text])],
         // Typewriter text renders as a code span over the run.
-        "texttt" => vec![Inline::Code(carta_ast::Attr::default(), run.to_string())],
+        "texttt" => vec![Inline::Code(Box::default(), run.to_string())],
         _ => return None,
     };
     Some(wrapped)
@@ -646,7 +646,7 @@ fn render_char(c: char, style: Style) -> Option<(Vec<Inline>, Class, bool, bool)
     // or punctuation glyph keeps its spacing; the substituting styles already mapped a letter/digit
     // above and fall through here for a symbol, which keeps its plain glyph and class.
     let inlines = match style {
-        Style::Monospace => vec![Inline::Code(carta_ast::Attr::default(), text)],
+        Style::Monospace => vec![Inline::Code(Box::default(), text)],
         _ if c.is_alphabetic() && !style.is_upright() => vec![italic(text)],
         _ => vec![Inline::Str(text)],
     };
@@ -693,7 +693,7 @@ fn char_glyph(c: char) -> (String, Class, bool) {
 #[allow(clippy::unnecessary_wraps)]
 fn render_number(digits: &str, style: Style) -> Option<(Vec<Inline>, Class, bool, bool)> {
     let inlines = match style {
-        Style::Monospace => vec![Inline::Code(carta_ast::Attr::default(), digits.to_string())],
+        Style::Monospace => vec![Inline::Code(Box::default(), digits.to_string())],
         Style::Substitute(alphabet) => vec![Inline::Str(substitute_run(digits, alphabet))],
         Style::SubstituteBold(alphabet) => {
             vec![Inline::Strong(vec![Inline::Str(substitute_run(
@@ -716,10 +716,7 @@ fn style_glyph(c: char, style: Style) -> Option<Vec<Inline>> {
             substitute_char(c, alphabet),
         )])]),
         // Monospace renders the character as its own code span, whatever the character.
-        Style::Monospace => Some(vec![Inline::Code(
-            carta_ast::Attr::default(),
-            c.to_string(),
-        )]),
+        Style::Monospace => Some(vec![Inline::Code(Box::default(), c.to_string())]),
         _ => None,
     }
 }
@@ -793,7 +790,7 @@ fn style_single_glyph(text: &str, italic_default: bool, style: Style) -> Vec<Inl
 /// every other style keeps the run whole and upright.
 fn style_text_glyph(text: &str, style: Style) -> Vec<Inline> {
     match style {
-        Style::Monospace => vec![Inline::Code(carta_ast::Attr::default(), text.to_string())],
+        Style::Monospace => vec![Inline::Code(Box::default(), text.to_string())],
         Style::Substitute(alphabet) => vec![Inline::Str(substitute_run(text, alphabet))],
         Style::SubstituteBold(alphabet) => {
             vec![Inline::Strong(vec![Inline::Str(substitute_run(

--- a/crates/carta-writers/src/math/tests.rs
+++ b/crates/carta-writers/src/math/tests.rs
@@ -1,5 +1,5 @@
 use super::{to_inlines, to_typst, to_typst_display, to_typst_labeled};
-use carta_ast::{Attr, Inline};
+use carta_ast::Inline;
 
 /// The Typst body and formatted trailing label for an expression, for the equation-label tests.
 fn typst_labeled(tex: &str) -> Option<(String, Option<String>)> {
@@ -147,8 +147,8 @@ fn monospace_text_becomes_per_character_code() {
     assert_eq!(
         to_inlines("\\mathtt{ab}"),
         Some(vec![
-            Inline::Code(Attr::default(), "a".to_string()),
-            Inline::Code(Attr::default(), "b".to_string()),
+            Inline::Code(Box::default(), "a".to_string()),
+            Inline::Code(Box::default(), "b".to_string()),
         ])
     );
 }
@@ -1090,9 +1090,9 @@ fn monospace_keeps_a_digit_run_as_one_code_span() {
     assert_eq!(
         to_inlines("\\mathtt{1a23}"),
         Some(vec![
-            Inline::Code(Attr::default(), "1".to_string()),
-            Inline::Code(Attr::default(), "a".to_string()),
-            Inline::Code(Attr::default(), "23".to_string()),
+            Inline::Code(Box::default(), "1".to_string()),
+            Inline::Code(Box::default(), "a".to_string()),
+            Inline::Code(Box::default(), "23".to_string()),
         ])
     );
 }
@@ -2423,7 +2423,7 @@ fn text_escape_preserves_the_wrapper_formatting() {
     );
     assert_eq!(
         to_inlines("\\texttt{a\\%b}"),
-        Some(vec![Inline::Code(Attr::default(), "a%b".to_string())])
+        Some(vec![Inline::Code(Box::default(), "a%b".to_string())])
     );
 }
 
@@ -2810,19 +2810,19 @@ fn monospace_wraps_each_glyph_but_keeps_a_number_whole() {
     assert_eq!(
         to_inlines("\\mathtt{abc}"),
         Some(vec![
-            Inline::Code(Attr::default(), "a".to_string()),
-            Inline::Code(Attr::default(), "b".to_string()),
-            Inline::Code(Attr::default(), "c".to_string()),
+            Inline::Code(Box::default(), "a".to_string()),
+            Inline::Code(Box::default(), "b".to_string()),
+            Inline::Code(Box::default(), "c".to_string()),
         ])
     );
     assert_eq!(
         to_inlines("\\mathtt{12}"),
-        Some(vec![Inline::Code(Attr::default(), "12".to_string())])
+        Some(vec![Inline::Code(Box::default(), "12".to_string())])
     );
     // A monospaced operator is still code-wrapped, keeping its ordinary glyph.
     assert_eq!(
         to_inlines("\\mathtt{+}"),
-        Some(vec![Inline::Code(Attr::default(), "+".to_string())])
+        Some(vec![Inline::Code(Box::default(), "+".to_string())])
     );
 }
 

--- a/crates/carta-writers/src/native.rs
+++ b/crates/carta-writers/src/native.rs
@@ -792,10 +792,10 @@ mod tests {
     fn header_with_attr() {
         let header = Block::Header(
             1,
-            Attr {
+            Box::new(Attr {
                 id: "hi".into(),
                 ..Attr::default()
-            },
+            }),
             vec![Inline::Str("Hi".into())],
         );
         assert_eq!(

--- a/crates/carta-writers/src/revealjs.rs
+++ b/crates/carta-writers/src/revealjs.rs
@@ -263,10 +263,10 @@ mod tests {
     fn header(level: i32, id: &str, title: &str) -> Block {
         Block::Header(
             level,
-            Attr {
+            Box::new(Attr {
                 id: id.to_owned(),
                 ..Attr::default()
-            },
+            }),
             vec![Inline::Str(title.to_owned())],
         )
     }

--- a/crates/carta-writers/src/slides.rs
+++ b/crates/carta-writers/src/slides.rs
@@ -186,10 +186,10 @@ mod tests {
     fn header(level: i32, id: &str) -> Block {
         Block::Header(
             level,
-            Attr {
+            Box::new(Attr {
                 id: id.to_owned(),
                 ..Attr::default()
-            },
+            }),
             vec![Inline::Str(id.to_owned())],
         )
     }

--- a/crates/carta-writers/src/typst.rs
+++ b/crates/carta-writers/src/typst.rs
@@ -1257,10 +1257,10 @@ mod tests {
         assert_eq!(
             render(vec![Block::Header(
                 2,
-                Attr {
+                Box::new(Attr {
                     id: "intro".into(),
                     ..Attr::default()
-                },
+                }),
                 vec![str_inline("H")],
             )]),
             "== H\n<intro>"
@@ -1272,11 +1272,11 @@ mod tests {
         assert_eq!(
             render(vec![Block::Header(
                 1,
-                Attr {
+                Box::new(Attr {
                     id: "hidden".into(),
                     classes: vec!["unnumbered".into()],
                     ..Attr::default()
-                },
+                }),
                 vec![str_inline("Hidden")],
             )]),
             "#heading(level: 1, numbering: none)[Hidden]\n<hidden>"
@@ -1307,7 +1307,7 @@ mod tests {
     fn inline_code_uses_backticks() {
         assert_eq!(
             render(vec![para(vec![Inline::Code(
-                Attr::default(),
+                Box::default(),
                 "let x = 1;".into()
             )])]),
             "`let x = 1;`"
@@ -1317,10 +1317,7 @@ mod tests {
     #[test]
     fn inline_code_with_backtick_falls_back() {
         assert_eq!(
-            render(vec![para(vec![Inline::Code(
-                Attr::default(),
-                "a`b".into()
-            )])]),
+            render(vec![para(vec![Inline::Code(Box::default(), "a`b".into())])]),
             "#raw(\"a`b\")"
         );
     }
@@ -1385,10 +1382,10 @@ mod tests {
     fn span_label_at_start_anchors_with_zwsp() {
         assert_eq!(
             render(vec![para(vec![Inline::Span(
-                Attr {
+                Box::new(Attr {
                     id: "sid".into(),
                     ..Attr::default()
-                },
+                }),
                 vec![str_inline("a")],
             )])]),
             "\u{200b}a<sid>"
@@ -1402,10 +1399,10 @@ mod tests {
                 str_inline("a"),
                 Inline::Space,
                 Inline::Span(
-                    Attr {
+                    Box::new(Attr {
                         id: "s".into(),
                         ..Attr::default()
-                    },
+                    }),
                     vec![str_inline("styled")],
                 ),
                 Inline::Space,
@@ -1419,10 +1416,10 @@ mod tests {
     fn mark_span_highlights() {
         assert_eq!(
             render(vec![para(vec![Inline::Span(
-                Attr {
+                Box::new(Attr {
                     classes: vec!["mark".into()],
                     ..Attr::default()
-                },
+                }),
                 vec![str_inline("x")],
             )])]),
             "#highlight[x]"
@@ -1433,15 +1430,15 @@ mod tests {
     fn image_pixel_width_converts_to_inches() {
         assert_eq!(
             render(vec![para(vec![Inline::Image(
-                Attr {
+                Box::new(Attr {
                     attributes: vec![("width".into(), "200".into())],
                     ..Attr::default()
-                },
+                }),
                 vec![str_inline("alt")],
-                Target {
+                Box::new(Target {
                     url: "i.png".into(),
                     title: String::new(),
-                },
+                }),
             )])]),
             "#box(image(\"i.png\", width: 2.08333in, alt: \"alt\"))"
         );
@@ -1487,10 +1484,10 @@ mod tests {
     fn code_block_with_language() {
         assert_eq!(
             render(vec![Block::CodeBlock(
-                Attr {
+                Box::new(Attr {
                     classes: vec!["rust".into()],
                     ..Attr::default()
-                },
+                }),
                 "fn x() {}".into(),
             )]),
             "```rust\nfn x() {}\n```"

--- a/crates/carta/tests/native_roundtrip.rs
+++ b/crates/carta/tests/native_roundtrip.rs
@@ -85,29 +85,32 @@ fn document_corpus() -> Vec<Document> {
             Inline::Quoted(QuoteType::DoubleQuote, vec![str_inline("b")]),
         ])]),
         document(vec![Block::Para(vec![
-            Inline::Code(attr("i", &["lang"], &[("k", "v")]), "x = 1".to_owned()),
+            Inline::Code(
+                Box::new(attr("i", &["lang"], &[("k", "v")])),
+                "x = 1".to_owned(),
+            ),
             Inline::Math(MathType::InlineMath, "a^2".to_owned()),
             Inline::Math(MathType::DisplayMath, "b".to_owned()),
             Inline::RawInline(Format("html".to_owned()), "<b>".to_owned()),
         ])]),
         document(vec![Block::Para(vec![
             Inline::Link(
-                attr("l", &["c"], &[]),
+                Box::new(attr("l", &["c"], &[])),
                 vec![str_inline("t")],
-                Target {
+                Box::new(Target {
                     url: "http://x".to_owned(),
                     title: "ti".to_owned(),
-                },
+                }),
             ),
             Inline::Image(
-                Attr::default(),
+                Box::default(),
                 vec![str_inline("alt")],
-                Target {
+                Box::new(Target {
                     url: "p.png".to_owned(),
                     title: String::new(),
-                },
+                }),
             ),
-            Inline::Span(attr("s", &["c"], &[]), vec![str_inline("inner")]),
+            Inline::Span(Box::new(attr("s", &["c"], &[])), vec![str_inline("inner")]),
             Inline::Note(vec![Block::Para(vec![str_inline("n")])]),
         ])]),
         document(vec![Block::Para(vec![Inline::Cite(
@@ -141,7 +144,7 @@ fn document_corpus() -> Vec<Document> {
         )])]),
         document(vec![
             Block::LineBlock(vec![vec![str_inline("one")], vec![str_inline("two")]]),
-            Block::CodeBlock(attr("", &["rust"], &[]), "let x = 1;".to_owned()),
+            Block::CodeBlock(Box::new(attr("", &["rust"], &[])), "let x = 1;".to_owned()),
             Block::RawBlock(Format("html".to_owned()), "<div>".to_owned()),
             Block::BlockQuote(vec![Block::Para(vec![str_inline("q")])]),
             Block::HorizontalRule,
@@ -207,34 +210,38 @@ fn document_corpus() -> Vec<Document> {
             Block::DefinitionList(vec![(vec![str_inline("Term")], vec![vec![plain("def")]])]),
         ]),
         document(vec![
-            Block::Header(2, attr("id", &["c"], &[("k", "v")]), vec![str_inline("H")]),
+            Block::Header(
+                2,
+                Box::new(attr("id", &["c"], &[("k", "v")])),
+                vec![str_inline("H")],
+            ),
             Block::Div(
-                attr("d", &["note"], &[]),
+                Box::new(attr("d", &["note"], &[])),
                 vec![Block::Para(vec![str_inline("body")])],
             ),
         ]),
         document(vec![
             Block::Figure(
-                attr("f", &[], &[]),
-                Caption {
+                Box::new(attr("f", &[], &[])),
+                Box::new(Caption {
                     short: None,
                     long: vec![Block::Plain(vec![str_inline("cap")])],
-                },
+                }),
                 vec![Block::Plain(vec![Inline::Image(
-                    Attr::default(),
+                    Box::default(),
                     vec![str_inline("alt")],
-                    Target {
+                    Box::new(Target {
                         url: "p.png".to_owned(),
                         title: String::new(),
-                    },
+                    }),
                 )])],
             ),
             Block::Figure(
-                Attr::default(),
-                Caption {
+                Box::default(),
+                Box::new(Caption {
                     short: Some(vec![str_inline("short")]),
                     long: vec![Block::Plain(vec![str_inline("long")])],
-                },
+                }),
                 vec![Block::Para(vec![str_inline("x")])],
             ),
         ]),


### PR DESCRIPTION
## Summary

Every `Inline`/`Block` node paid for the largest variant's embedded `Attr`/`Target`/`Caption` payloads (~152 bytes per inline node). Boxing those rare fat payloads — extending the existing `Table` precedent — shrinks `Inline` to 56 and `Block` to 48 bytes, cutting peak RSS on a 1 MB commonmark→json conversion from ~96 MiB to ~52 MiB with an unchanged JSON wire format; a new size-assertion test guards against regression.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.