### PR TITLE
feat: byte-capable reader/writer seam (prep for container formats)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ carta --list-extensions=gfm      # extensions and defaults for a given format
 ### Library
 
 ```rust
-use carta::{convert, ReaderOptions, WriterOptions};
+use carta::{convert_text, ReaderOptions, WriterOptions};
 
-let html = convert(
+let html = convert_text(
     "commonmark",
     "html",
     "# Hello, *world*",
@@ -218,6 +218,8 @@ let html = convert(
     &WriterOptions::default(),
 )?;
 ```
+
+`convert_text` is the shortcut for text-to-text conversion. The general entry point is `convert`, which takes raw bytes and returns an `Output` that is text or bytes depending on the target format — use it when either side is a binary format.
 
 You can select formats at compile time via per-direction features to make binaries even more lightweight for your individual needs.
 

--- a/crates/carta-core/src/lib.rs
+++ b/crates/carta-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! output text. Readers and writers depend only on the AST contract and this crate, so input and
 //! output formats stay independent.
 
+use std::fmt;
 use std::io;
 
 use carta_ast::{Block, Document, Inline};
@@ -23,7 +24,9 @@ pub enum Error {
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
     #[error("input is not valid UTF-8: {0}")]
-    InvalidUtf8(#[from] std::string::FromUtf8Error),
+    InvalidUtf8(#[from] std::str::Utf8Error),
+    #[error("format '{0}' converts binary data; use the byte-level API (convert_bytes)")]
+    BinaryFormat(String),
     #[error("unsupported format: {0}")]
     UnsupportedFormat(String),
     #[error("format '{0}' is recognized but not enabled in this build")]
@@ -330,5 +333,150 @@ pub trait Writer {
     /// instead and leaves this `false`.
     fn numbers_sections_in_body(&self) -> bool {
         false
+    }
+}
+
+/// Parses input bytes in some source format into the document model. The byte-shaped counterpart of
+/// [`Reader`], for formats whose wire form is not text — zip containers and the like.
+pub trait BytesReader {
+    fn read(&self, input: &[u8], options: &ReaderOptions) -> Result<Document>;
+}
+
+/// Renders the document model into some target format's bytes. The byte-shaped counterpart of
+/// [`Writer`], for formats whose output is not text — zip containers and the like.
+///
+/// This trait carries no decoration hooks (templates, table of contents, metadata rendering): a
+/// container writer produces a complete document by construction. Hooks are added when a real format
+/// needs them.
+pub trait BytesWriter {
+    fn write(&self, document: &Document, options: &WriterOptions) -> Result<Vec<u8>>;
+}
+
+/// The output of a conversion: text from a text writer, bytes from a byte-shaped writer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Output {
+    Text(String),
+    Bytes(Vec<u8>),
+}
+
+/// A resolved reader, either text-shaped ([`Reader`]) or byte-shaped ([`BytesReader`]).
+pub enum AnyReader {
+    Text(Box<dyn Reader>),
+    Bytes(Box<dyn BytesReader>),
+}
+
+impl fmt::Debug for AnyReader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let variant = match self {
+            AnyReader::Text(_) => "Text",
+            AnyReader::Bytes(_) => "Bytes",
+        };
+        f.debug_tuple(variant).finish()
+    }
+}
+
+impl AnyReader {
+    /// Reads `input` into a document. A text reader decodes the bytes as UTF-8 first; a byte reader
+    /// takes the raw slice.
+    ///
+    /// # Errors
+    /// [`Error::InvalidUtf8`] if a text reader is handed input that is not valid UTF-8, plus any error
+    /// the underlying reader returns.
+    pub fn read(&self, input: &[u8], options: &ReaderOptions) -> Result<Document> {
+        match self {
+            AnyReader::Text(reader) => reader.read(std::str::from_utf8(input)?, options),
+            AnyReader::Bytes(reader) => reader.read(input, options),
+        }
+    }
+}
+
+/// A resolved writer, either text-shaped ([`Writer`]) or byte-shaped ([`BytesWriter`]).
+pub enum AnyWriter {
+    Text(Box<dyn Writer>),
+    Bytes(Box<dyn BytesWriter>),
+}
+
+impl fmt::Debug for AnyWriter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let variant = match self {
+            AnyWriter::Text(_) => "Text",
+            AnyWriter::Bytes(_) => "Bytes",
+        };
+        f.debug_tuple(variant).finish()
+    }
+}
+
+impl AnyWriter {
+    /// This format's own standalone template, or `None` when standalone output is identical to the
+    /// fragment. A byte-shaped writer never has one.
+    #[must_use]
+    pub fn default_template(&self) -> Option<&'static str> {
+        match self {
+            AnyWriter::Text(writer) => writer.default_template(),
+            AnyWriter::Bytes(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AnyReader, AnyWriter, BytesReader, BytesWriter, Error, Reader, ReaderOptions, Result,
+        WriterOptions,
+    };
+    use carta_ast::Document;
+
+    struct FixedBytesWriter;
+    impl BytesWriter for FixedBytesWriter {
+        fn write(&self, _document: &Document, _options: &WriterOptions) -> Result<Vec<u8>> {
+            Ok(vec![0x00, 0xff, 0x9f])
+        }
+    }
+
+    struct RawBytesReader;
+    impl BytesReader for RawBytesReader {
+        fn read(&self, input: &[u8], _options: &ReaderOptions) -> Result<Document> {
+            assert_eq!(input, &[0xff, 0xfe]);
+            Ok(Document::default())
+        }
+    }
+
+    struct EmptyTextReader;
+    impl Reader for EmptyTextReader {
+        fn read(&self, _input: &str, _options: &ReaderOptions) -> Result<Document> {
+            Ok(Document::default())
+        }
+    }
+
+    #[test]
+    fn bytes_writer_round_trips_bytes() {
+        let writer = AnyWriter::Bytes(Box::new(FixedBytesWriter));
+        assert!(writer.default_template().is_none());
+        let AnyWriter::Bytes(inner) = &writer else {
+            panic!("expected a byte writer");
+        };
+        let output = inner
+            .write(&Document::default(), &WriterOptions::default())
+            .unwrap();
+        assert_eq!(output, vec![0x00, 0xff, 0x9f]);
+    }
+
+    #[test]
+    fn text_reader_rejects_invalid_utf8() {
+        let reader = AnyReader::Text(Box::new(EmptyTextReader));
+        let error = reader
+            .read(&[0xff, 0xfe], &ReaderOptions::default())
+            .unwrap_err();
+        assert!(matches!(error, Error::InvalidUtf8(_)), "{error:?}");
+    }
+
+    #[test]
+    fn bytes_reader_accepts_invalid_utf8() {
+        let reader = AnyReader::Bytes(Box::new(RawBytesReader));
+        assert!(
+            reader
+                .read(&[0xff, 0xfe], &ReaderOptions::default())
+                .is_ok()
+        );
     }
 }

--- a/crates/carta-core/src/lib.rs
+++ b/crates/carta-core/src/lib.rs
@@ -25,7 +25,7 @@ pub enum Error {
     Io(#[from] io::Error),
     #[error("input is not valid UTF-8: {0}")]
     InvalidUtf8(#[from] std::str::Utf8Error),
-    #[error("format '{0}' converts binary data; use the byte-level API (convert_bytes)")]
+    #[error("format '{0}' converts binary data; use the byte-capable API (convert)")]
     BinaryFormat(String),
     #[error("unsupported format: {0}")]
     UnsupportedFormat(String),

--- a/crates/carta/benches/convert.rs
+++ b/crates/carta/benches/convert.rs
@@ -3,7 +3,7 @@
 
 use std::fs;
 
-use carta::{ReaderOptions, WriterOptions, convert, reader_for, writer_for};
+use carta::{ReaderOptions, WriterOptions, convert_text, reader_for, writer_for};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
 /// Small input size: large enough for stable per-iteration timing, small enough to stay fast.
@@ -143,7 +143,7 @@ fn convert_end_to_end(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(input.len() as u64));
         group.bench_function(*name, |b| {
             b.iter(|| {
-                convert(
+                convert_text(
                     "commonmark",
                     "html",
                     input,

--- a/crates/carta/src/lib.rs
+++ b/crates/carta/src/lib.rs
@@ -1,8 +1,8 @@
 //! carta — a document converter library.
 //!
-//! The public entry points: [`convert`] parses text `input` in a source format and renders it to
-//! text in a target format; [`convert_bytes`] is the general form, taking raw bytes and returning an
-//! [`Output`] that is text or bytes depending on the target format's wire shape. Formats are selected
+//! The public entry points: [`convert`] handles any format pair, taking raw bytes and returning an
+//! [`Output`] that is text or bytes depending on the target format's wire shape; [`convert_text`] is
+//! a shortcut for when both sides are text. Formats are selected
 //! at compile time via per-direction Cargo features (`read-*`/`write-*`);
 //! [`supported_input_formats`]/[`supported_output_formats`] report what this build contains. For
 //! lower-level use, the document model is re-exported as [`ast`], and [`reader_for`]/[`writer_for`]
@@ -27,25 +27,28 @@ pub use registry::{
     supported_input_formats, supported_output_formats, writer_for,
 };
 
-/// Converts `input` from format `from` to format `to`.
+/// Converts text `input` from format `from` to text in format `to`.
 ///
-/// Each format may carry `+ext`/`-ext` toggles (e.g. `commonmark+strikeout-raw_html`); the selected
-/// extensions are merged with any already present in the supplied options.
+/// A shortcut over [`convert`] for the common case where both formats are text-shaped. Each format
+/// may carry `+ext`/`-ext` toggles (e.g. `commonmark+strikeout-raw_html`); the selected extensions
+/// are merged with any already present in the supplied options.
 ///
 /// The returned string carries no trailing newline; callers that emit to a stream append their own
 /// (the CLI appends exactly one).
 ///
 /// # Errors
-/// Propagates format-resolution errors ([`Error::UnsupportedFormat`], [`Error::FormatNotEnabled`],
-/// [`Error::UnknownExtension`]) and any reader/writer error encountered during conversion.
-pub fn convert(
+/// [`Error::BinaryFormat`] if `to` names a byte-shaped format (its output cannot be represented as a
+/// `String` — use [`convert`]). Otherwise propagates format-resolution errors
+/// ([`Error::UnsupportedFormat`], [`Error::FormatNotEnabled`], [`Error::UnknownExtension`]) and any
+/// reader/writer error encountered during conversion.
+pub fn convert_text(
     from: &str,
     to: &str,
     input: &str,
     reader_options: &ReaderOptions,
     writer_options: &WriterOptions,
 ) -> Result<String> {
-    match convert_bytes(from, to, input.as_bytes(), reader_options, writer_options)? {
+    match convert(from, to, input.as_bytes(), reader_options, writer_options)? {
         Output::Text(text) => Ok(text),
         Output::Bytes(_) => {
             let (base, _) = parse_format_spec(to)?;
@@ -57,18 +60,19 @@ pub fn convert(
 /// Converts raw `input` bytes from format `from` to format `to`, returning text for a text target and
 /// bytes for a byte-shaped one.
 ///
-/// This is the general form of [`convert`]. A text reader decodes `input` as UTF-8 (yielding
-/// [`Error::InvalidUtf8`] on invalid bytes); a byte reader takes the raw slice. Like [`convert`], each
-/// format may carry `+ext`/`-ext` toggles, merged with the extensions already in the supplied options.
+/// This handles any format pair; [`convert_text`] is a shortcut for when both sides are text. A text
+/// reader decodes `input` as UTF-8 (yielding [`Error::InvalidUtf8`] on invalid bytes); a byte reader
+/// takes the raw slice. Each format may carry `+ext`/`-ext` toggles, merged with the extensions
+/// already in the supplied options.
 ///
 /// # Errors
 /// Propagates format-resolution errors ([`Error::UnsupportedFormat`], [`Error::FormatNotEnabled`],
 /// [`Error::UnknownExtension`]) and any reader/writer error encountered during conversion.
 ///
 /// ```
-/// use carta::{convert_bytes, Output, ReaderOptions, WriterOptions};
+/// use carta::{convert, Output, ReaderOptions, WriterOptions};
 ///
-/// let output = convert_bytes(
+/// let output = convert(
 ///     "commonmark",
 ///     "html",
 ///     b"# Hi\n",
@@ -78,7 +82,7 @@ pub fn convert(
 /// .unwrap();
 /// assert_eq!(output, Output::Text("<h1>Hi</h1>".to_owned()));
 /// ```
-pub fn convert_bytes(
+pub fn convert(
     from: &str,
     to: &str,
     input: &[u8],

--- a/crates/carta/src/lib.rs
+++ b/crates/carta/src/lib.rs
@@ -1,17 +1,19 @@
 //! carta — a document converter library.
 //!
-//! The single public entry point: [`convert`] parses `input` in a source format and renders it to a
-//! target format. Formats are selected at compile time via per-direction Cargo features
-//! (`read-*`/`write-*`); [`supported_input_formats`]/[`supported_output_formats`] report what this
-//! build contains. For lower-level use, the document model is re-exported as [`ast`], and
-//! [`reader_for`]/[`writer_for`] hand back the [`Reader`]/[`Writer`] trait objects so callers can
-//! inspect or transform the [`Document`] directly.
+//! The public entry points: [`convert`] parses text `input` in a source format and renders it to
+//! text in a target format; [`convert_bytes`] is the general form, taking raw bytes and returning an
+//! [`Output`] that is text or bytes depending on the target format's wire shape. Formats are selected
+//! at compile time via per-direction Cargo features (`read-*`/`write-*`);
+//! [`supported_input_formats`]/[`supported_output_formats`] report what this build contains. For
+//! lower-level use, the document model is re-exported as [`ast`], and [`reader_for`]/[`writer_for`]
+//! hand back the [`Reader`]/[`Writer`] trait objects so callers can inspect or transform the
+//! [`Document`] directly.
 
 pub use carta_ast as ast;
 pub use carta_ast::Document;
 pub use carta_core::{
-    Error, Extension, Extensions, MathMethod, Reader, ReaderOptions, Result, TocStyle, WrapMode,
-    Writer, WriterOptions, presets,
+    AnyReader, AnyWriter, BytesReader, BytesWriter, Error, Extension, Extensions, MathMethod,
+    Output, Reader, ReaderOptions, Result, TocStyle, WrapMode, Writer, WriterOptions, presets,
 };
 
 mod format_spec;
@@ -21,8 +23,8 @@ mod standalone;
 
 pub use format_spec::parse_format_spec;
 pub use registry::{
-    input_format_names, output_format_names, reader_for, supported_input_formats,
-    supported_output_formats, writer_for,
+    any_reader_for, any_writer_for, input_format_names, output_format_names, reader_for,
+    supported_input_formats, supported_output_formats, writer_for,
 };
 
 /// Converts `input` from format `from` to format `to`.
@@ -43,11 +45,51 @@ pub fn convert(
     reader_options: &ReaderOptions,
     writer_options: &WriterOptions,
 ) -> Result<String> {
+    match convert_bytes(from, to, input.as_bytes(), reader_options, writer_options)? {
+        Output::Text(text) => Ok(text),
+        Output::Bytes(_) => {
+            let (base, _) = parse_format_spec(to)?;
+            Err(Error::BinaryFormat(base))
+        }
+    }
+}
+
+/// Converts raw `input` bytes from format `from` to format `to`, returning text for a text target and
+/// bytes for a byte-shaped one.
+///
+/// This is the general form of [`convert`]. A text reader decodes `input` as UTF-8 (yielding
+/// [`Error::InvalidUtf8`] on invalid bytes); a byte reader takes the raw slice. Like [`convert`], each
+/// format may carry `+ext`/`-ext` toggles, merged with the extensions already in the supplied options.
+///
+/// # Errors
+/// Propagates format-resolution errors ([`Error::UnsupportedFormat`], [`Error::FormatNotEnabled`],
+/// [`Error::UnknownExtension`]) and any reader/writer error encountered during conversion.
+///
+/// ```
+/// use carta::{convert_bytes, Output, ReaderOptions, WriterOptions};
+///
+/// let output = convert_bytes(
+///     "commonmark",
+///     "html",
+///     b"# Hi\n",
+///     &ReaderOptions::default(),
+///     &WriterOptions::default(),
+/// )
+/// .unwrap();
+/// assert_eq!(output, Output::Text("<h1>Hi</h1>".to_owned()));
+/// ```
+pub fn convert_bytes(
+    from: &str,
+    to: &str,
+    input: &[u8],
+    reader_options: &ReaderOptions,
+    writer_options: &WriterOptions,
+) -> Result<Output> {
     let (from_base, from_ext) = format_spec::parse_reader_format_spec(from)?;
     let (to_base, to_ext) = parse_format_spec(to)?;
 
-    let reader = reader_for(&from_base)?;
-    let writer = writer_for(&to_base)?;
+    let reader = any_reader_for(&from_base)?;
+    let writer = any_writer_for(&to_base)?;
 
     let mut reader_options = reader_options.clone();
     reader_options.extensions = from_ext.union(reader_options.extensions);
@@ -67,6 +109,15 @@ pub fn convert(
     #[cfg(not(feature = "standalone"))]
     let document = reader.read(input, &reader_options)?;
 
+    // A byte-shaped writer owns its complete output: no template, standalone wrapping, or section
+    // splicing decorates it.
+    let writer = match writer {
+        AnyWriter::Text(writer) => writer,
+        AnyWriter::Bytes(writer) => {
+            return writer.write(&document, &writer_options).map(Output::Bytes);
+        }
+    };
+
     // A pristine copy of the document is kept only when the contents builder will later consume it:
     // numbering splices section numbers into the heading inlines the builder reads, so it must see
     // the unnumbered tree to avoid double-numbering its entries. When no standalone wrapper runs the
@@ -85,7 +136,7 @@ pub fn convert(
             writer.write(&numbered, &writer_options)?
         } else {
             carta_core::sections::number_sections(&mut document.blocks);
-            return writer.write(&document, &writer_options);
+            return writer.write(&document, &writer_options).map(Output::Text);
         }
     } else {
         writer.write(&document, &writer_options)?
@@ -96,10 +147,10 @@ pub fn convert(
         && let Some(wrapped) =
             standalone::render(writer.as_ref(), &document, &body, &writer_options, &to_base)?
     {
-        return Ok(wrapped);
+        return Ok(Output::Text(wrapped));
     }
 
-    Ok(body)
+    Ok(Output::Text(body))
 }
 
 /// Parses a metadata file into a metadata map, for use as `WriterOptions::metadata_defaults`.

--- a/crates/carta/src/main.rs
+++ b/crates/carta/src/main.rs
@@ -7,12 +7,14 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use carta::ast::MetaValue;
-use carta::{Error, MathMethod, ReaderOptions, Result, WrapMode, WriterOptions, convert};
+use carta::{
+    Error, MathMethod, Output, ReaderOptions, Result, WrapMode, WriterOptions, convert_bytes,
+};
 use clap::{ArgAction, Parser};
 
 const LIST_FLAGS: [&str; 4] = [
@@ -152,7 +154,6 @@ fn run(cli: &Cli) -> Result<()> {
 
 fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     let input = read_input(cli.input.as_deref())?;
-    let text = String::from_utf8(input)?;
 
     let mut writer_options = WriterOptions::default();
     writer_options.standalone = cli.standalone;
@@ -180,7 +181,7 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     // A template (default or `--template`) emits verbatim; a bare fragment gets one trailing newline.
     let verbatim = cli.standalone || cli.template.is_some();
 
-    let output = convert(from, to, &text, &ReaderOptions::default(), &writer_options)?;
+    let output = convert_bytes(from, to, &input, &ReaderOptions::default(), &writer_options)?;
     write_output(cli.output.as_deref(), &output, verbatim)
 }
 
@@ -300,7 +301,7 @@ fn read_metadata_files(paths: &[PathBuf]) -> Result<BTreeMap<String, MetaValue>>
 
 fn print_default_template(spec: &str) -> Result<()> {
     let (base, _) = carta::parse_format_spec(spec)?;
-    let writer = carta::writer_for(&base)?;
+    let writer = carta::any_writer_for(&base)?;
     match writer.default_template() {
         Some(template) => {
             io::stdout().lock().write_all(template.as_bytes())?;
@@ -339,17 +340,35 @@ fn read_input(path: Option<&Path>) -> Result<Vec<u8>> {
     }
 }
 
-fn write_output(path: Option<&Path>, output: &str, verbatim: bool) -> Result<()> {
+fn write_output(path: Option<&Path>, output: &Output, verbatim: bool) -> Result<()> {
+    if matches!(output, Output::Bytes(_)) && binary_to_terminal(path) {
+        return Err(Error::Io(io::Error::other(
+            "refusing to write binary output to a terminal (use -o FILE or redirect stdout)",
+        )));
+    }
+
     let mut writer: Box<dyn Write> = match path {
         Some(path) => Box::new(fs::File::create(path)?),
         None => Box::new(io::stdout().lock()),
     };
-    writer.write_all(output.as_bytes())?;
-    // A fragment gets exactly one trailing newline; a template's output is emitted byte-for-byte.
-    if !verbatim {
-        writer.write_all(b"\n")?;
+    match output {
+        Output::Text(text) => {
+            writer.write_all(text.as_bytes())?;
+            // A fragment gets exactly one trailing newline; a template's output is emitted byte-for-byte.
+            if !verbatim {
+                writer.write_all(b"\n")?;
+            }
+        }
+        // Binary output is emitted exactly, with no trailing newline.
+        Output::Bytes(bytes) => writer.write_all(bytes)?,
     }
     Ok(())
+}
+
+/// Whether writing would send binary output straight to a terminal — no `-o FILE` and stdout is a
+/// tty. Such output corrupts the terminal, so it is refused.
+fn binary_to_terminal(path: Option<&Path>) -> bool {
+    path.is_none() && io::stdout().is_terminal()
 }
 
 #[cfg(test)]

--- a/crates/carta/src/main.rs
+++ b/crates/carta/src/main.rs
@@ -12,9 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use carta::ast::MetaValue;
-use carta::{
-    Error, MathMethod, Output, ReaderOptions, Result, WrapMode, WriterOptions, convert_bytes,
-};
+use carta::{Error, MathMethod, Output, ReaderOptions, Result, WrapMode, WriterOptions, convert};
 use clap::{ArgAction, Parser};
 
 const LIST_FLAGS: [&str; 4] = [
@@ -181,7 +179,7 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     // A template (default or `--template`) emits verbatim; a bare fragment gets one trailing newline.
     let verbatim = cli.standalone || cli.template.is_some();
 
-    let output = convert_bytes(from, to, &input, &ReaderOptions::default(), &writer_options)?;
+    let output = convert(from, to, &input, &ReaderOptions::default(), &writer_options)?;
     write_output(cli.output.as_deref(), &output, verbatim)
 }
 

--- a/crates/carta/src/registry.rs
+++ b/crates/carta/src/registry.rs
@@ -11,21 +11,20 @@
 
 use carta_core::{AnyReader, AnyWriter, Error, Reader, Result, Writer};
 
-/// Wraps a constructor into the tagged dispatch enum according to its kind token, `text` for a
-/// text-shaped format and `bytes` for a byte-shaped one.
-macro_rules! dispatch_arm {
-    ($any:ident, text, $constructor:expr) => {
-        $any::Text(Box::new($constructor))
-    };
-    ($any:ident, bytes, $constructor:expr) => {
-        $any::Bytes(Box::new($constructor))
-    };
-}
-
 /// Expands one per-direction format table into its resolver and enumerators. Each entry reads
 /// `<feature> => <canonical> [| <alias>]* => <kind> <constructor>;`, where `<kind>` is `text` or
 /// `bytes`.
+///
+/// The `@wrap` internal rules box a constructor into the tagged dispatch enum by its kind token.
+/// Folding them in (rather than a standalone helper macro) keeps this macro invoked in every feature
+/// configuration, including the zero-format build where all resolver arms are `#[cfg]`-stripped.
 macro_rules! format_dispatch {
+    (@wrap $any:ident text $constructor:expr) => {
+        $any::Text(Box::new($constructor))
+    };
+    (@wrap $any:ident bytes $constructor:expr) => {
+        $any::Bytes(Box::new($constructor))
+    };
     (
         trait: $trait:ident;
         any: $any_enum:ident;
@@ -43,7 +42,7 @@ macro_rules! format_dispatch {
             match name {
                 $(
                     #[cfg(feature = $feature)]
-                    $canonical $(| $alias)* => Ok(dispatch_arm!($any_enum, $kind, $constructor)),
+                    $canonical $(| $alias)* => Ok(format_dispatch!(@wrap $any_enum $kind $constructor)),
                 )+
                 other if $recognizes(other) => Err(Error::FormatNotEnabled(other.to_owned())),
                 other => Err(Error::UnsupportedFormat(other.to_owned())),

--- a/crates/carta/src/registry.rs
+++ b/crates/carta/src/registry.rs
@@ -9,28 +9,41 @@
 //! the build resolve. A recognized name whose feature is off yields [`Error::FormatNotEnabled`]; an
 //! unrecognized name yields [`Error::UnsupportedFormat`].
 
-use carta_core::{Error, Reader, Result, Writer};
+use carta_core::{AnyReader, AnyWriter, Error, Reader, Result, Writer};
+
+/// Wraps a constructor into the tagged dispatch enum according to its kind token, `text` for a
+/// text-shaped format and `bytes` for a byte-shaped one.
+macro_rules! dispatch_arm {
+    ($any:ident, text, $constructor:expr) => {
+        $any::Text(Box::new($constructor))
+    };
+    ($any:ident, bytes, $constructor:expr) => {
+        $any::Bytes(Box::new($constructor))
+    };
+}
 
 /// Expands one per-direction format table into its resolver and enumerators. Each entry reads
-/// `<feature> => <canonical> [| <alias>]* => <constructor>;`.
+/// `<feature> => <canonical> [| <alias>]* => <kind> <constructor>;`, where `<kind>` is `text` or
+/// `bytes`.
 macro_rules! format_dispatch {
     (
         trait: $trait:ident;
+        any: $any_enum:ident;
         resolve: $resolve:ident;
         recognizes: $recognizes:ident;
         supported: $supported:ident;
         names: $names:ident;
-        $( $feature:literal => $canonical:literal $(| $alias:literal)* => $constructor:expr ; )+
+        $( $feature:literal => $canonical:literal $(| $alias:literal)* => $kind:ident $constructor:expr ; )+
     ) => {
-        #[doc = concat!("Resolves a format name to its boxed [`", stringify!($trait), "`].")]
+        #[doc = concat!("Resolves a format name to its [`", stringify!($any_enum), "`].")]
         #[doc = ""]
         #[doc = "[`Error::FormatNotEnabled`] if the format is recognized but its feature is off;"]
         #[doc = "[`Error::UnsupportedFormat`] if the name is unknown."]
-        pub fn $resolve(name: &str) -> Result<Box<dyn $trait>> {
+        pub fn $resolve(name: &str) -> Result<$any_enum> {
             match name {
                 $(
                     #[cfg(feature = $feature)]
-                    $canonical $(| $alias)* => Ok(Box::new($constructor)),
+                    $canonical $(| $alias)* => Ok(dispatch_arm!($any_enum, $kind, $constructor)),
                 )+
                 other if $recognizes(other) => Err(Error::FormatNotEnabled(other.to_owned())),
                 other => Err(Error::UnsupportedFormat(other.to_owned())),
@@ -70,57 +83,83 @@ macro_rules! format_dispatch {
 
 format_dispatch! {
     trait: Reader;
-    resolve: reader_for;
+    any: AnyReader;
+    resolve: any_reader_for;
     recognizes: reader_recognizes;
     supported: supported_input_formats;
     names: input_format_names;
-    "read-commonmark" => "commonmark" | "commonmark_x" | "markdown" | "gfm" | "markdown_strict" | "markdown_mmd" | "markdown_phpextra" | "markdown_github" => carta_readers::CommonmarkReader;
-    "read-json" => "json" => carta_readers::JsonReader;
-    "read-native" => "native" => carta_readers::NativeReader;
-    "read-html" => "html" => carta_readers::HtmlReader;
-    "read-csv" => "csv" => carta_readers::CsvReader;
-    "read-tsv" => "tsv" => carta_readers::TsvReader;
-    "read-opml" => "opml" => carta_readers::OpmlReader;
-    "read-rst" => "rst" => carta_readers::RstReader;
-    "read-ipynb" => "ipynb" => carta_readers::IpynbReader;
-    "read-mediawiki" => "mediawiki" => carta_readers::MediawikiReader;
-    "read-dokuwiki" => "dokuwiki" => carta_readers::DokuwikiReader;
-    "read-jira" => "jira" => carta_readers::JiraReader;
-    "read-man" => "man" => carta_readers::ManReader;
-    "read-latex" => "latex" => carta_readers::LatexReader;
-    "read-org" => "org" => carta_readers::OrgReader;
+    "read-commonmark" => "commonmark" | "commonmark_x" | "markdown" | "gfm" | "markdown_strict" | "markdown_mmd" | "markdown_phpextra" | "markdown_github" => text carta_readers::CommonmarkReader;
+    "read-json" => "json" => text carta_readers::JsonReader;
+    "read-native" => "native" => text carta_readers::NativeReader;
+    "read-html" => "html" => text carta_readers::HtmlReader;
+    "read-csv" => "csv" => text carta_readers::CsvReader;
+    "read-tsv" => "tsv" => text carta_readers::TsvReader;
+    "read-opml" => "opml" => text carta_readers::OpmlReader;
+    "read-rst" => "rst" => text carta_readers::RstReader;
+    "read-ipynb" => "ipynb" => text carta_readers::IpynbReader;
+    "read-mediawiki" => "mediawiki" => text carta_readers::MediawikiReader;
+    "read-dokuwiki" => "dokuwiki" => text carta_readers::DokuwikiReader;
+    "read-jira" => "jira" => text carta_readers::JiraReader;
+    "read-man" => "man" => text carta_readers::ManReader;
+    "read-latex" => "latex" => text carta_readers::LatexReader;
+    "read-org" => "org" => text carta_readers::OrgReader;
 }
 
 format_dispatch! {
     trait: Writer;
-    resolve: writer_for;
+    any: AnyWriter;
+    resolve: any_writer_for;
     recognizes: writer_recognizes;
     supported: supported_output_formats;
     names: output_format_names;
-    "write-html" => "html" | "html5" => carta_writers::HtmlWriter;
-    "write-html4" => "html4" => carta_writers::Html4Writer;
-    "write-json" => "json" => carta_writers::JsonWriter;
-    "write-plain" => "plain" => carta_writers::PlainWriter;
-    "write-native" => "native" => carta_writers::NativeWriter;
-    "write-latex" => "latex" => carta_writers::LatexWriter;
-    "write-commonmark" => "commonmark" => carta_writers::CommonmarkWriter;
-    "write-markdown" => "markdown" => carta_writers::MarkdownWriter;
-    "write-markdown" => "commonmark_x" => carta_writers::CommonmarkXWriter;
-    "write-markdown" => "markdown_github" => carta_writers::MarkdownGithubWriter;
-    "write-markdown" => "markdown_phpextra" => carta_writers::MarkdownPhpextraWriter;
-    "write-markdown" => "markdown_mmd" => carta_writers::MarkdownMmdWriter;
-    "write-markdown" => "markdown_strict" => carta_writers::MarkdownStrictWriter;
-    "write-gfm" => "gfm" => carta_writers::GfmWriter;
-    "write-rst" => "rst" => carta_writers::RstWriter;
-    "write-mediawiki" => "mediawiki" => carta_writers::MediawikiWriter;
-    "write-typst" => "typst" => carta_writers::TypstWriter;
-    "write-dokuwiki" => "dokuwiki" => carta_writers::DokuwikiWriter;
-    "write-jira" => "jira" => carta_writers::JiraWriter;
-    "write-asciidoc" => "asciidoc" => carta_writers::AsciidocWriter;
-    "write-man" => "man" => carta_writers::ManWriter;
-    "write-opml" => "opml" => carta_writers::OpmlWriter;
-    "write-org" => "org" => carta_writers::OrgWriter;
-    "write-beamer" => "beamer" => carta_writers::BeamerWriter;
-    "write-revealjs" => "revealjs" => carta_writers::RevealjsWriter;
-    "write-ipynb" => "ipynb" => carta_writers::IpynbWriter;
+    "write-html" => "html" | "html5" => text carta_writers::HtmlWriter;
+    "write-html4" => "html4" => text carta_writers::Html4Writer;
+    "write-json" => "json" => text carta_writers::JsonWriter;
+    "write-plain" => "plain" => text carta_writers::PlainWriter;
+    "write-native" => "native" => text carta_writers::NativeWriter;
+    "write-latex" => "latex" => text carta_writers::LatexWriter;
+    "write-commonmark" => "commonmark" => text carta_writers::CommonmarkWriter;
+    "write-markdown" => "markdown" => text carta_writers::MarkdownWriter;
+    "write-markdown" => "commonmark_x" => text carta_writers::CommonmarkXWriter;
+    "write-markdown" => "markdown_github" => text carta_writers::MarkdownGithubWriter;
+    "write-markdown" => "markdown_phpextra" => text carta_writers::MarkdownPhpextraWriter;
+    "write-markdown" => "markdown_mmd" => text carta_writers::MarkdownMmdWriter;
+    "write-markdown" => "markdown_strict" => text carta_writers::MarkdownStrictWriter;
+    "write-gfm" => "gfm" => text carta_writers::GfmWriter;
+    "write-rst" => "rst" => text carta_writers::RstWriter;
+    "write-mediawiki" => "mediawiki" => text carta_writers::MediawikiWriter;
+    "write-typst" => "typst" => text carta_writers::TypstWriter;
+    "write-dokuwiki" => "dokuwiki" => text carta_writers::DokuwikiWriter;
+    "write-jira" => "jira" => text carta_writers::JiraWriter;
+    "write-asciidoc" => "asciidoc" => text carta_writers::AsciidocWriter;
+    "write-man" => "man" => text carta_writers::ManWriter;
+    "write-opml" => "opml" => text carta_writers::OpmlWriter;
+    "write-org" => "org" => text carta_writers::OrgWriter;
+    "write-beamer" => "beamer" => text carta_writers::BeamerWriter;
+    "write-revealjs" => "revealjs" => text carta_writers::RevealjsWriter;
+    "write-ipynb" => "ipynb" => text carta_writers::IpynbWriter;
+}
+
+/// Resolves a format name to its boxed [`Reader`], the text-only view of [`any_reader_for`].
+///
+/// [`Error::FormatNotEnabled`] if the format is recognized but its feature is off;
+/// [`Error::UnsupportedFormat`] if the name is unknown; [`Error::BinaryFormat`] if the format is
+/// byte-shaped, so it has no text reader.
+pub fn reader_for(name: &str) -> Result<Box<dyn Reader>> {
+    match any_reader_for(name)? {
+        AnyReader::Text(reader) => Ok(reader),
+        AnyReader::Bytes(_) => Err(Error::BinaryFormat(name.to_owned())),
+    }
+}
+
+/// Resolves a format name to its boxed [`Writer`], the text-only view of [`any_writer_for`].
+///
+/// [`Error::FormatNotEnabled`] if the format is recognized but its feature is off;
+/// [`Error::UnsupportedFormat`] if the name is unknown; [`Error::BinaryFormat`] if the format is
+/// byte-shaped, so it has no text writer.
+pub fn writer_for(name: &str) -> Result<Box<dyn Writer>> {
+    match any_writer_for(name)? {
+        AnyWriter::Text(writer) => Ok(writer),
+        AnyWriter::Bytes(_) => Err(Error::BinaryFormat(name.to_owned())),
+    }
 }

--- a/crates/carta/tests/cli.rs
+++ b/crates/carta/tests/cli.rs
@@ -19,6 +19,10 @@ struct Output {
 }
 
 fn run(args: &[&str], stdin: &str) -> Output {
+    run_bytes(args, stdin.as_bytes())
+}
+
+fn run_bytes(args: &[&str], stdin: &[u8]) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_carta"))
         .args(args)
         .stdin(Stdio::piped())
@@ -26,11 +30,7 @@ fn run(args: &[&str], stdin: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn carta");
-    let write_result = child
-        .stdin
-        .take()
-        .expect("child stdin")
-        .write_all(stdin.as_bytes());
+    let write_result = child.stdin.take().expect("child stdin").write_all(stdin);
     // A rejected invocation (e.g. an unsupported format) can exit before reading stdin, closing the
     // pipe; a broken-pipe write is then expected and must not fail the test.
     if let Err(error) = write_result {
@@ -141,6 +141,17 @@ fn missing_to_flag_fails() {
     assert!(!result.success);
     assert!(
         result.stderr.contains("--to") && result.stderr.contains("required"),
+        "stderr: {}",
+        result.stderr
+    );
+}
+
+#[test]
+fn invalid_utf8_input_fails() {
+    let result = run_bytes(&["-f", "commonmark", "-t", "html"], &[0xff, 0xfe]);
+    assert!(!result.success);
+    assert!(
+        result.stderr.contains("input is not valid UTF-8"),
         "stderr: {}",
         result.stderr
     );

--- a/crates/carta/tests/convert.rs
+++ b/crates/carta/tests/convert.rs
@@ -1,4 +1,4 @@
-//! Facade integration tests: the high-level `convert` entry point and format-name resolution. These
+//! Facade integration tests: the high-level `convert_text` and `convert` entry points and format-name resolution. These
 //! run fully offline — outputs are the writers' own deterministic text. The error-classification cases
 //! are feature-gated so they assert the right branch under both `--all-features` and a minimal
 //! `--no-default-features --features read-commonmark,write-html` build.
@@ -6,13 +6,13 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use carta::{
-    Error, Output, ReaderOptions, WriterOptions, convert, convert_bytes, reader_for, writer_for,
+    Error, Output, ReaderOptions, WriterOptions, convert, convert_text, reader_for, writer_for,
 };
 
 #[cfg(all(feature = "read-commonmark", feature = "write-html"))]
 #[test]
-fn convert_bytes_text_target_matches_convert() {
-    let bytes = convert_bytes(
+fn convert_on_text_target_matches_convert_text() {
+    let bytes = convert(
         "commonmark",
         "html",
         b"# Hi\n",
@@ -20,7 +20,7 @@ fn convert_bytes_text_target_matches_convert() {
         &WriterOptions::default(),
     )
     .unwrap();
-    let text = convert(
+    let text = convert_text(
         "commonmark",
         "html",
         "# Hi\n",
@@ -33,8 +33,8 @@ fn convert_bytes_text_target_matches_convert() {
 
 #[cfg(all(feature = "read-commonmark", feature = "write-html"))]
 #[test]
-fn convert_bytes_rejects_invalid_utf8_for_a_text_reader() {
-    let error = convert_bytes(
+fn convert_rejects_invalid_utf8_for_a_text_reader() {
+    let error = convert(
         "commonmark",
         "html",
         &[0xff, 0xfe],
@@ -48,7 +48,7 @@ fn convert_bytes_rejects_invalid_utf8_for_a_text_reader() {
 #[cfg(all(feature = "read-commonmark", feature = "write-html"))]
 #[test]
 fn commonmark_to_html() {
-    let output = convert(
+    let output = convert_text(
         "commonmark",
         "html",
         "# Hi\n",
@@ -56,7 +56,7 @@ fn commonmark_to_html() {
         &WriterOptions::default(),
     )
     .unwrap();
-    // `convert` returns no trailing newline.
+    // `convert_text` returns no trailing newline.
     assert_eq!(output, "<h1>Hi</h1>");
 }
 
@@ -65,7 +65,7 @@ fn commonmark_to_html() {
 fn number_sections_without_standalone_numbers_the_body_in_place() {
     let mut writer_options = WriterOptions::default();
     writer_options.number_sections = true;
-    let output = convert(
+    let output = convert_text(
         "commonmark",
         "html",
         "# First\n\n## Nested\n",
@@ -95,7 +95,7 @@ fn number_sections_with_standalone_toc_numbers_body_and_toc_exactly_once() {
     writer_options.number_sections = true;
     writer_options.standalone = true;
     writer_options.toc = true;
-    let output = convert(
+    let output = convert_text(
         "commonmark",
         "html",
         "# First\n\n## Nested\n",
@@ -128,7 +128,7 @@ fn number_sections_with_standalone_toc_numbers_body_and_toc_exactly_once() {
 #[test]
 fn json_round_trips() {
     let input = r#"{"pandoc-api-version":[1,23,1,2],"meta":{},"blocks":[{"t":"Para","c":[{"t":"Str","c":"hi"}]}]}"#;
-    let output = convert(
+    let output = convert_text(
         "json",
         "json",
         input,

--- a/crates/carta/tests/convert.rs
+++ b/crates/carta/tests/convert.rs
@@ -5,7 +5,45 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use carta::{Error, ReaderOptions, WriterOptions, convert, reader_for, writer_for};
+use carta::{
+    Error, Output, ReaderOptions, WriterOptions, convert, convert_bytes, reader_for, writer_for,
+};
+
+#[cfg(all(feature = "read-commonmark", feature = "write-html"))]
+#[test]
+fn convert_bytes_text_target_matches_convert() {
+    let bytes = convert_bytes(
+        "commonmark",
+        "html",
+        b"# Hi\n",
+        &ReaderOptions::default(),
+        &WriterOptions::default(),
+    )
+    .unwrap();
+    let text = convert(
+        "commonmark",
+        "html",
+        "# Hi\n",
+        &ReaderOptions::default(),
+        &WriterOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(bytes, Output::Text(text));
+}
+
+#[cfg(all(feature = "read-commonmark", feature = "write-html"))]
+#[test]
+fn convert_bytes_rejects_invalid_utf8_for_a_text_reader() {
+    let error = convert_bytes(
+        "commonmark",
+        "html",
+        &[0xff, 0xfe],
+        &ReaderOptions::default(),
+        &WriterOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(error, Error::InvalidUtf8(_)), "{error:?}");
+}
 
 #[cfg(all(feature = "read-commonmark", feature = "write-html"))]
 #[test]

--- a/crates/carta/tests/golden_reader.rs
+++ b/crates/carta/tests/golden_reader.rs
@@ -22,7 +22,7 @@ fn reader_ast_snapshots() {
         if !readers.contains(&case.group.as_str()) {
             continue;
         }
-        let json = carta::convert(
+        let json = carta::convert_text(
             &case.group,
             "json",
             &case.input,
@@ -46,7 +46,7 @@ fn reader_ext_ast_snapshots() {
         if carta::reader_for(&base).is_err() {
             continue;
         }
-        let json = carta::convert(
+        let json = carta::convert_text(
             &case.group,
             "json",
             &case.input,

--- a/crates/carta/tests/golden_wrap.rs
+++ b/crates/carta/tests/golden_wrap.rs
@@ -57,7 +57,7 @@ fn wrap_mode_output_snapshots() {
             for (mode, mode_name) in [(WrapMode::None, "none"), (WrapMode::Preserve, "preserve")] {
                 let mut options = WriterOptions::default();
                 options.wrap = mode;
-                let output = carta::convert(
+                let output = carta::convert_text(
                     "json",
                     target,
                     &case.input,

--- a/crates/carta/tests/golden_writer.rs
+++ b/crates/carta/tests/golden_writer.rs
@@ -56,7 +56,7 @@ fn writer_output_snapshots() {
             {
                 continue;
             }
-            let output = carta::convert(
+            let output = carta::convert_text(
                 "json",
                 target,
                 &case.input,
@@ -87,7 +87,7 @@ fn writer_ext_output_snapshots() {
         if !writers.contains(&base) {
             continue;
         }
-        let output = carta::convert(
+        let output = carta::convert_text(
             "json",
             &case.group,
             &case.input,

--- a/crates/carta/tests/standalone.rs
+++ b/crates/carta/tests/standalone.rs
@@ -1,5 +1,5 @@
 //! Standalone-output integration tests: the context builder, metadata precedence, and target-aware
-//! interpolation, driven through the public `convert` entry point. A single inline template is
+//! interpolation, driven through the public `convert_text` entry point. A single inline template is
 //! rendered to two formats so the same metadata produces format-specific markup. Fully offline.
 
 #![cfg(all(feature = "standalone", feature = "read-commonmark"))]
@@ -8,7 +8,7 @@
 use std::collections::BTreeMap;
 
 use carta::ast::MetaValue;
-use carta::{ReaderOptions, WriterOptions, convert};
+use carta::{ReaderOptions, WriterOptions, convert_text};
 
 /// Document with a mix of metadata kinds: an inline title (markup), a boolean, a list, and two keys
 /// that also appear in higher precedence layers.
@@ -65,7 +65,7 @@ fn options() -> WriterOptions {
 #[cfg(feature = "write-html")]
 #[test]
 fn standalone_html_context_and_precedence() {
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "html",
         INPUT,
@@ -83,7 +83,7 @@ O=from-V & raw|M=from-M|VM=from-V-vm|D=default-val|B=<p>Body text.</p>"
 #[cfg(feature = "write-latex")]
 #[test]
 fn standalone_latex_context_and_precedence() {
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "latex",
         INPUT,
@@ -128,7 +128,7 @@ fn identity_options() -> WriterOptions {
 #[cfg(feature = "write-html")]
 #[test]
 fn web_identity_variables_expose_pagetitle_date_and_author_list() {
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "html",
         IDENTITY_INPUT,
@@ -148,7 +148,7 @@ AML=[<Ada Lovelace>,<Alan Turing>]"
 #[cfg(feature = "write-latex")]
 #[test]
 fn pdf_identity_variables_expose_title_meta_and_joined_authors() {
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "latex",
         IDENTITY_INPUT,
@@ -170,7 +170,7 @@ AML=[<Ada Lovelace; Alan Turing>]"
 fn plain_title_block_shows_author_and_date_without_a_title() {
     let mut options = WriterOptions::default();
     options.standalone = true;
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "plain",
         "---\nauthor: Ada Lovelace\ndate: 2026-06-20\n---\n\nBody text.\n",
@@ -198,7 +198,7 @@ fn web_pagetitle_strips_markup_but_keeps_quote_glyphs() {
     let mut options = WriterOptions::default();
     options.standalone = true;
     options.template = Some("[$pagetitle$]".to_owned());
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "html",
         QUOTED_TITLE_INPUT,
@@ -217,7 +217,7 @@ fn pdf_title_meta_strips_markup_but_keeps_quote_glyphs() {
     let mut options = WriterOptions::default();
     options.standalone = true;
     options.template = Some("[$title-meta$]".to_owned());
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "latex",
         QUOTED_TITLE_INPUT,
@@ -239,7 +239,7 @@ fn pdf_identity_variables_are_defined_even_without_metadata() {
 TML=[$for(title-meta)$<$title-meta$>$endfor$]"
             .to_owned(),
     );
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "latex",
         "Body only.\n",
@@ -282,7 +282,7 @@ fn web_pagetitle_flattens_a_lone_paragraph_title() {
     let mut options = WriterOptions::default();
     options.standalone = true;
     options.template = Some("[$pagetitle$]".to_owned());
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "html",
         BLOCK_SCALAR_TITLE,
@@ -300,7 +300,7 @@ fn pdf_title_meta_flattens_a_lone_paragraph_title() {
     let mut options = WriterOptions::default();
     options.standalone = true;
     options.template = Some("[$title-meta$]".to_owned());
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "latex",
         BLOCK_SCALAR_TITLE,
@@ -317,7 +317,7 @@ fn pdf_title_meta_is_empty_for_a_multi_paragraph_title() {
     let mut options = WriterOptions::default();
     options.standalone = true;
     options.template = Some("[$title-meta$]".to_owned());
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "latex",
         TWO_PARAGRAPH_TITLE,
@@ -336,7 +336,7 @@ fn man_flattens_block_metadata_into_a_header_field() {
     options.standalone = true;
     options.template = Some("[$title$]".to_owned());
 
-    let single = convert(
+    let single = convert_text(
         "markdown",
         "man",
         BLOCK_SCALAR_TITLE,
@@ -347,7 +347,7 @@ fn man_flattens_block_metadata_into_a_header_field() {
     // The lone paragraph flattens to inline roff — no paragraph macro leaks into the header field.
     assert_eq!(single, "[Multi\\-line Title Block]");
 
-    let multi = convert(
+    let multi = convert_text(
         "markdown",
         "man",
         TWO_PARAGRAPH_TITLE,
@@ -364,7 +364,7 @@ fn rst_builds_a_title_block_from_a_block_scalar_title() {
     let mut options = WriterOptions::default();
     options.standalone = true;
     options.template = Some("[$titleblock$]".to_owned());
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "rst",
         BLOCK_SCALAR_TITLE,
@@ -384,7 +384,7 @@ fn rst_builds_a_title_block_from_a_block_scalar_title() {
 fn typst_default_template_renders_a_structured_author_name() {
     let mut options = WriterOptions::default();
     options.standalone = true;
-    let output = convert(
+    let output = convert_text(
         "markdown",
         "typst",
         "---\nauthor:\n  - name: Grace Hopper\ntitle: Hi\n---\n\nBody.\n",

--- a/crates/carta/tests/standalone_snapshots.rs
+++ b/crates/carta/tests/standalone_snapshots.rs
@@ -6,7 +6,7 @@
 #![cfg(all(feature = "standalone", feature = "read-commonmark"))]
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use carta::{ReaderOptions, WriterOptions, convert};
+use carta::{ReaderOptions, WriterOptions, convert_text};
 
 /// A document touching every title-block and metadata slot a default template can interpolate: an
 /// inline title carrying both markup and a quotation (so the plain-text identity variables keep the
@@ -59,7 +59,7 @@ fn default_template_snapshots() {
         }
         let mut options = WriterOptions::default();
         options.standalone = true;
-        let output = convert(
+        let output = convert_text(
             "markdown",
             target,
             INPUT,


### PR DESCRIPTION
## Summary

Adds byte-level `BytesReader`/`BytesWriter` traits, tagged `AnyReader`/`AnyWriter`/`Output` dispatch, a general byte-capable `convert` entry point (with `convert_text` as the text-to-text shortcut), and byte-aware CLI I/O (refusing binary output to a terminal) — with zero behavior change for existing formats. Upcoming container formats (docx, epub, odt, …) are zip archives whose wire form isn't UTF-8, so the pipeline needs a byte-shaped seam before the first one can land.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.