### PR TITLE
perf(ast): store textual payloads in a small-string type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
 name = "carta-ast"
 version = "0.0.2"
 dependencies = [
+ "compact_str",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -163,6 +164,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -252,6 +262,21 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
 
 [[package]]
 name = "console"
@@ -589,6 +614,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +694,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4", features = ["derive"] }
 unicode-general-category = "1"
 unicode-normalization = "0.1"
 caseless = "0.2"
+compact_str = { version = "0.9", features = ["serde"] }
 insta = "1"
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 

--- a/crates/carta-ast/Cargo.toml
+++ b/crates/carta-ast/Cargo.toml
@@ -20,3 +20,4 @@ workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 unicode-general-category = { workspace = true }
+compact_str = { workspace = true }

--- a/crates/carta-ast/src/ast.rs
+++ b/crates/carta-ast/src/ast.rs
@@ -37,9 +37,10 @@ macro_rules! node_enum {
     };
 }
 
-/// Every textual payload in the tree. Owned today; aliased so it can be swapped for a
-/// compact-string type later without touching call sites.
-pub type Text = String;
+/// Every textual payload in the tree. A small-string type that stores payloads up to 24 bytes
+/// inline, avoiding a heap allocation for the short words that dominate prose, while keeping the
+/// same 24-byte footprint and string serialization as an owned `String`.
+pub type Text = compact_str::CompactString;
 
 /// The AST schema version carried by an interchange document, as an integer component list
 /// (e.g. `[1, 23, 1, 2]`). Stored verbatim so a parsed document re-serializes losslessly; freshly
@@ -420,7 +421,7 @@ fn push_plain_inlines(inlines: &[Inline], out: &mut Vec<Inline>) {
                 out.push(Inline::Str(text.clone()));
             }
             Inline::Space | Inline::SoftBreak | Inline::LineBreak => {
-                out.push(Inline::Str(" ".to_owned()));
+                out.push(Inline::Str(Text::from(" ")));
             }
             Inline::Quoted(quote, xs) => {
                 out.push(Inline::Quoted(quote.clone(), to_plain_inlines(xs)));
@@ -452,18 +453,27 @@ mod tests {
     }
 
     #[test]
+    fn text_stays_word_sized() {
+        assert_eq!(
+            std::mem::size_of::<Text>(),
+            std::mem::size_of::<String>(),
+            "Text must keep String's footprint so swapping the type never fattens every node"
+        );
+    }
+
+    #[test]
     fn plain_inlines_unwraps_markup_keeps_quotation_and_drops_passthrough() {
         let inlines = vec![
-            Inline::Emph(vec![Inline::Str("emph".to_owned())]),
+            Inline::Emph(vec![Inline::Str("emph".into())]),
             Inline::Space,
             Inline::Quoted(
                 QuoteType::DoubleQuote,
-                vec![Inline::Strong(vec![Inline::Str("loud".to_owned())])],
+                vec![Inline::Strong(vec![Inline::Str("loud".into())])],
             ),
-            Inline::Code(Box::default(), "code".to_owned()),
-            Inline::Math(MathType::InlineMath, "x".to_owned()),
-            Inline::RawInline(Format("html".to_owned()), "<br>".to_owned()),
-            Inline::Note(vec![Block::Para(vec![Inline::Str("note".to_owned())])]),
+            Inline::Code(Box::default(), "code".into()),
+            Inline::Math(MathType::InlineMath, "x".into()),
+            Inline::RawInline(Format("html".into()), "<br>".into()),
+            Inline::Note(vec![Block::Para(vec![Inline::Str("note".into())])]),
         ];
         let plain = to_plain_inlines(&inlines);
         // The emphasis wrapper is gone, the space collapses to a `Str`, the quotation survives with
@@ -472,11 +482,11 @@ mod tests {
         assert_eq!(
             plain,
             vec![
-                Inline::Str("emph".to_owned()),
-                Inline::Str(" ".to_owned()),
-                Inline::Quoted(QuoteType::DoubleQuote, vec![Inline::Str("loud".to_owned())]),
-                Inline::Str("code".to_owned()),
-                Inline::Str("x".to_owned()),
+                Inline::Str("emph".into()),
+                Inline::Str(" ".into()),
+                Inline::Quoted(QuoteType::DoubleQuote, vec![Inline::Str("loud".into())]),
+                Inline::Str("code".into()),
+                Inline::Str("x".into()),
             ]
         );
     }
@@ -484,29 +494,29 @@ mod tests {
     #[test]
     fn single_block_inlines_takes_a_lone_paragraph_and_nothing_else() {
         let para = vec![Block::Para(vec![
-            Inline::Str("Multi".to_owned()),
+            Inline::Str("Multi".into()),
             Inline::SoftBreak,
-            Inline::Str("line".to_owned()),
+            Inline::Str("line".into()),
         ])];
         assert_eq!(
             single_block_inlines(&para),
             &[
-                Inline::Str("Multi".to_owned()),
+                Inline::Str("Multi".into()),
                 Inline::SoftBreak,
-                Inline::Str("line".to_owned()),
+                Inline::Str("line".into()),
             ]
         );
 
         // A lone plain block is also unwrapped.
-        let plain = vec![Block::Plain(vec![Inline::Str("p".to_owned())])];
-        assert_eq!(single_block_inlines(&plain), &[Inline::Str("p".to_owned())]);
+        let plain = vec![Block::Plain(vec![Inline::Str("p".into())])];
+        assert_eq!(single_block_inlines(&plain), &[Inline::Str("p".into())]);
 
         // No inline form: empty, several blocks, or a single non-paragraph block.
         assert!(single_block_inlines(&[]).is_empty());
         assert!(
             single_block_inlines(&[
-                Block::Para(vec![Inline::Str("a".to_owned())]),
-                Block::Para(vec![Inline::Str("b".to_owned())]),
+                Block::Para(vec![Inline::Str("a".into())]),
+                Block::Para(vec![Inline::Str("b".into())]),
             ])
             .is_empty()
         );

--- a/crates/carta-ast/src/lib.rs
+++ b/crates/carta-ast/src/lib.rs
@@ -12,6 +12,11 @@ mod serde_impls;
 pub use ast::*;
 pub use codec::{from_json, to_json, to_json_writer};
 
+/// Formats a value (a `char`, an integer, …) directly into a [`Text`], keeping short results in
+/// inline storage. Re-exported here so downstream crates build `Text` values without naming the
+/// backing crate.
+pub use compact_str::ToCompactString;
+
 /// The JSON object key carrying the AST schema version.
 ///
 /// This is an opaque external protocol identifier, deliberately confined to this one constant; do

--- a/crates/carta-core/src/sections.rs
+++ b/crates/carta-core/src/sections.rs
@@ -7,7 +7,7 @@
 //! level, the result joined from the document's shallowest heading level — so a heading and its
 //! contents entry always carry the same number.
 
-use carta_ast::{Attr, Block, Inline, Target};
+use carta_ast::{Attr, Block, Inline, Target, Text};
 
 /// Headings range over levels 1 through 6.
 const MAX_LEVEL: usize = 6;
@@ -40,7 +40,7 @@ impl Counters {
     /// level 2 still numbers from `1`; a skipped level reads as a zero (`1` then a level-3 heading is
     /// `1.0.1`); and a heading deeper than the base level appearing before any heading reaches that
     /// base reads with leading zeros (a level-2 heading before the first level-1 heading is `0.1`).
-    fn advance(&mut self, level: i32, classes: &[String]) -> Option<String> {
+    fn advance(&mut self, level: i32, classes: &[Text]) -> Option<Text> {
         if classes.iter().any(|class| class == UNNUMBERED) {
             return None;
         }
@@ -60,7 +60,7 @@ impl Counters {
             .map(u32::to_string)
             .collect::<Vec<_>>()
             .join(".");
-        Some(number)
+        Some(number.into())
     }
 }
 
@@ -98,7 +98,7 @@ fn number_in(blocks: &mut [Block], counters: &mut Counters) {
         match block {
             Block::Header(level, attr, inlines) => {
                 if let Some(number) = counters.advance(*level, &attr.classes) {
-                    attr.attributes.push(("number".to_owned(), number.clone()));
+                    attr.attributes.push((Text::from("number"), number.clone()));
                     let span = Inline::Span(
                         Box::new(section_number_attr("header-section-number")),
                         vec![Inline::Str(number)],
@@ -209,7 +209,7 @@ fn toc_entry(
     if let Some(number) = number.filter(|_| numbered) {
         content.push(Inline::Span(
             Box::new(section_number_attr("toc-section-number")),
-            vec![Inline::Str(number.to_owned())],
+            vec![Inline::Str(number.into())],
         ));
         content.push(Inline::Space);
     }
@@ -219,9 +219,9 @@ fn toc_entry(
     }
     let link_attr = Attr {
         id: if anchors {
-            format!("toc-{}", attr.id)
+            format!("toc-{}", attr.id).into()
         } else {
-            String::new()
+            Text::default()
         },
         classes: Vec::new(),
         attributes: Vec::new(),
@@ -230,8 +230,8 @@ fn toc_entry(
         Box::new(link_attr),
         content,
         Box::new(Target {
-            url: format!("#{}", attr.id),
-            title: String::new(),
+            url: format!("#{}", attr.id).into(),
+            title: Text::default(),
         }),
     )]
 }
@@ -268,8 +268,8 @@ fn clean_toc_inlines(inlines: &[Inline]) -> Vec<Inline> {
 
 fn section_number_attr(class: &str) -> Attr {
     Attr {
-        id: String::new(),
-        classes: vec![class.to_owned()],
+        id: Text::default(),
+        classes: vec![class.into()],
         attributes: Vec::new(),
     }
 }
@@ -283,11 +283,11 @@ mod tests {
         Block::Header(
             level,
             Box::new(Attr {
-                id: text.to_lowercase().replace(' ', "-"),
-                classes: classes.iter().map(|class| (*class).to_owned()).collect(),
+                id: text.to_lowercase().replace(' ', "-").into(),
+                classes: classes.iter().map(|class| (*class).into()).collect(),
                 attributes: Vec::new(),
             }),
-            vec![Inline::Str(text.to_owned())],
+            vec![Inline::Str(text.into())],
         )
     }
 
@@ -296,7 +296,7 @@ mod tests {
             attr.attributes
                 .iter()
                 .find(|(key, _)| key == "number")
-                .map(|(_, value)| value.clone())
+                .map(|(_, value)| value.to_string())
         } else {
             None
         }
@@ -417,7 +417,7 @@ mod tests {
     fn empty_document_has_no_toc() {
         assert!(
             build_toc(
-                &[Block::Para(vec![Inline::Str("hi".to_owned())])],
+                &[Block::Para(vec![Inline::Str("hi".into())])],
                 3,
                 false,
                 true
@@ -451,19 +451,19 @@ mod tests {
         let heading = Block::Header(
             1,
             Box::new(Attr {
-                id: "h".to_owned(),
+                id: "h".into(),
                 ..Attr::default()
             }),
             vec![
                 Inline::Link(
                     Box::default(),
-                    vec![Inline::Str("text".to_owned())],
+                    vec![Inline::Str("text".into())],
                     Box::new(Target {
-                        url: "x".to_owned(),
-                        title: String::new(),
+                        url: "x".into(),
+                        title: Text::default(),
                     }),
                 ),
-                Inline::Note(vec![Block::Para(vec![Inline::Str("note".to_owned())])]),
+                Inline::Note(vec![Block::Para(vec![Inline::Str("note".into())])]),
             ],
         );
         let Some(Block::BulletList(items)) = build_toc(&[heading], 3, false, true) else {
@@ -475,7 +475,7 @@ mod tests {
         let Some(Inline::Link(_, content, _)) = inlines.first() else {
             panic!("expected a link");
         };
-        assert_eq!(content, &vec![Inline::Str("text".to_owned())]);
+        assert_eq!(content, &vec![Inline::Str("text".into())]);
     }
 
     #[test]
@@ -496,13 +496,13 @@ mod tests {
 
     #[test]
     fn toc_entry_without_an_id_is_plain_text() {
-        let heading = Block::Header(1, Box::default(), vec![Inline::Str("Untitled".to_owned())]);
+        let heading = Block::Header(1, Box::default(), vec![Inline::Str("Untitled".into())]);
         let Some(Block::BulletList(items)) = build_toc(&[heading], 3, false, true) else {
             panic!("expected a contents list");
         };
         let Some(Block::Plain(inlines)) = items.first().and_then(|item| item.first()) else {
             panic!("expected a plain item");
         };
-        assert_eq!(inlines, &vec![Inline::Str("Untitled".to_owned())]);
+        assert_eq!(inlines, &vec![Inline::Str("Untitled".into())]);
     }
 }

--- a/crates/carta-readers/src/commonmark/attr.rs
+++ b/crates/carta-readers/src/commonmark/attr.rs
@@ -69,7 +69,7 @@ fn parse_attributes_chars_with(
                     return None;
                 }
                 if matches!(policy, IdPolicy::Last) || attr.id.is_empty() {
-                    attr.id = id;
+                    attr.id = id.into();
                 }
             }
             Some('.') => {
@@ -78,7 +78,7 @@ fn parse_attributes_chars_with(
                 if class.is_empty() {
                     return None;
                 }
-                attr.classes.push(class);
+                attr.classes.push(class.into());
             }
             Some(_) => {
                 let key = read_key(chars, &mut index);
@@ -87,7 +87,7 @@ fn parse_attributes_chars_with(
                 }
                 index += 1;
                 let value = read_value(chars, &mut index);
-                attr.attributes.push((key, value));
+                attr.attributes.push((key.into(), value.into()));
             }
         }
     }
@@ -182,8 +182,8 @@ mod tests {
         assert_eq!(
             a.attributes,
             [
-                ("key".to_owned(), "val".to_owned()),
-                ("k2".to_owned(), "two words".to_owned())
+                ("key".into(), "val".into()),
+                ("k2".into(), "two words".into())
             ]
         );
         assert_eq!(consumed, r#"{#sec .a .b key=val k2="two words"}"#.len());
@@ -213,21 +213,18 @@ mod tests {
 
     #[test]
     fn empty_value_after_equals() {
-        assert_eq!(
-            attr("{key=}").0.attributes,
-            [("key".to_owned(), String::new())]
-        );
+        assert_eq!(attr("{key=}").0.attributes, [("key".into(), "".into())]);
     }
 
     #[test]
     fn single_quoted_and_escaped_double_quote() {
         assert_eq!(
             attr("{title='hi there'}").0.attributes,
-            [("title".to_owned(), "hi there".to_owned())]
+            [("title".into(), "hi there".into())]
         );
         assert_eq!(
             attr(r#"{title="a \"q\" b"}"#).0.attributes,
-            [("title".to_owned(), r#"a "q" b"#.to_owned())]
+            [("title".into(), r#"a "q" b"#.into())]
         );
     }
 

--- a/crates/carta-readers/src/commonmark/autolink.rs
+++ b/crates/carta-readers/src/commonmark/autolink.rs
@@ -103,7 +103,7 @@ fn split_text(text: &str, markdown: bool, out: &mut Vec<Inline>) {
                 let attr = if markdown {
                     Attr {
                         id: carta_ast::Text::default(),
-                        classes: vec![m.kind.class().to_owned().into()],
+                        classes: vec![m.kind.class().into()],
                         attributes: Vec::new(),
                     }
                 } else {

--- a/crates/carta-readers/src/commonmark/autolink.rs
+++ b/crates/carta-readers/src/commonmark/autolink.rs
@@ -102,8 +102,8 @@ fn split_text(text: &str, markdown: bool, out: &mut Vec<Inline>) {
                 let label: String = span.iter().collect();
                 let attr = if markdown {
                     Attr {
-                        id: String::new(),
-                        classes: vec![m.kind.class().to_owned()],
+                        id: carta_ast::Text::default(),
+                        classes: vec![m.kind.class().to_owned().into()],
                         attributes: Vec::new(),
                     }
                 } else {
@@ -118,10 +118,10 @@ fn split_text(text: &str, markdown: bool, out: &mut Vec<Inline>) {
                 };
                 out.push(Inline::Link(
                     Box::new(attr),
-                    vec![Inline::Str(label)],
+                    vec![Inline::Str(label.into())],
                     Box::new(Target {
-                        url,
-                        title: String::new(),
+                        url: url.into(),
+                        title: carta_ast::Text::default(),
                     }),
                 ));
             }
@@ -341,7 +341,7 @@ mod tests {
 
     /// Autolink a single text token, reporting each link as `(label, href, classes)`.
     fn classed_links(text: &str, markdown: bool) -> Vec<(String, String, Vec<String>)> {
-        let mut inlines = vec![Inline::Str(text.to_owned())];
+        let mut inlines = vec![Inline::Str(text.to_owned().into())];
         autolink_inlines(&mut inlines, markdown);
         inlines
             .iter()
@@ -354,7 +354,11 @@ mod tests {
                             _ => "",
                         })
                         .collect();
-                    Some((text, target.url.clone(), attr.classes.clone()))
+                    Some((
+                        text,
+                        target.url.to_string(),
+                        attr.classes.iter().map(ToString::to_string).collect(),
+                    ))
                 }
                 _ => None,
             })
@@ -363,7 +367,7 @@ mod tests {
 
     /// Autolink a single text token, returning the resulting inlines.
     fn autolinked(text: &str, markdown: bool) -> Vec<Inline> {
-        let mut inlines = vec![Inline::Str(text.to_owned())];
+        let mut inlines = vec![Inline::Str(text.to_owned().into())];
         autolink_inlines(&mut inlines, markdown);
         inlines
     }
@@ -459,10 +463,10 @@ mod tests {
         // A link is never nested inside another link: a pre-formed Link is passed through verbatim.
         let inner = Inline::Link(
             Box::default(),
-            vec![Inline::Str("http://example.com".to_owned())],
+            vec![Inline::Str("http://example.com".to_owned().into())],
             Box::new(Target {
-                url: "http://example.com".to_owned(),
-                title: String::new(),
+                url: "http://example.com".to_owned().into(),
+                title: carta_ast::Text::default(),
             }),
         );
         let mut inlines = vec![inner.clone()];
@@ -472,7 +476,7 @@ mod tests {
 
     #[test]
     fn code_is_left_untouched() {
-        let code = Inline::Code(Box::default(), "http://example.com".to_owned());
+        let code = Inline::Code(Box::default(), "http://example.com".to_owned().into());
         let mut inlines = vec![code.clone()];
         autolink_inlines(&mut inlines, false);
         assert_eq!(inlines, vec![code]);
@@ -540,7 +544,7 @@ mod tests {
         // bare `www.` hosts, so the token must survive as a single unchanged `Str`.
         assert_eq!(
             autolinked("www.example.com", true),
-            vec![Inline::Str("www.example.com".to_owned())]
+            vec![Inline::Str("www.example.com".to_owned().into())]
         );
     }
 
@@ -548,7 +552,7 @@ mod tests {
     fn trigger_gate_passes_plain_token_through_unchanged() {
         assert_eq!(
             autolinked("nothing-here", false),
-            vec![Inline::Str("nothing-here".to_owned())]
+            vec![Inline::Str("nothing-here".to_owned().into())]
         );
     }
 
@@ -557,7 +561,7 @@ mod tests {
         // Contains `://` and `@` triggers so the gate does not skip it, yet nothing matches.
         assert_eq!(
             autolinked("not:a//url @ alone", false),
-            vec![Inline::Str("not:a//url @ alone".to_owned())]
+            vec![Inline::Str("not:a//url @ alone".to_owned().into())]
         );
     }
 
@@ -574,7 +578,7 @@ mod tests {
                             _ => "",
                         })
                         .collect();
-                    Some((text, target.url.clone()))
+                    Some((text, target.url.to_string()))
                 }
                 _ => None,
             })

--- a/crates/carta-readers/src/commonmark/block.rs
+++ b/crates/carta-readers/src/commonmark/block.rs
@@ -2435,7 +2435,7 @@ impl Parser {
                 if self.extensions.contains(Extension::RawAttribute)
                     && let Some(format) = raw_block_format(&fence.info)
                 {
-                    IrBlock::RawBlock(Format(format), text)
+                    IrBlock::RawBlock(Format(format.into()), text)
                 } else {
                     IrBlock::CodeBlock(fence_attr(&fence.info, self.extensions), text)
                 }
@@ -2454,7 +2454,7 @@ impl Parser {
                     }
                     IrBlock::Para(trimmed.to_owned())
                 } else {
-                    IrBlock::RawBlock(Format("tex".to_owned()), node.text.clone())
+                    IrBlock::RawBlock(Format("tex".to_owned().into()), node.text.clone())
                 }
             }
             Kind::BlockQuote => {
@@ -2528,8 +2528,8 @@ impl Parser {
 
         let title = IrBlock::Div(
             Attr {
-                id: String::new(),
-                classes: vec!["title".to_owned()],
+                id: carta_ast::Text::default(),
+                classes: vec!["title".to_owned().into()],
                 attributes: Vec::new(),
             },
             vec![IrBlock::Para(alert_type.title.to_owned())],
@@ -2551,8 +2551,8 @@ impl Parser {
 
         Some(IrBlock::Div(
             Attr {
-                id: String::new(),
-                classes: vec![alert_type.class.to_owned()],
+                id: carta_ast::Text::default(),
+                classes: vec![alert_type.class.to_owned().into()],
                 attributes: Vec::new(),
             },
             content,
@@ -3012,8 +3012,8 @@ fn fence_attr(info: &str, extensions: Extensions) -> Attr {
     }
     let language = info.split_whitespace().next().unwrap_or("");
     Attr {
-        id: String::new(),
-        classes: vec![language.to_owned()],
+        id: carta_ast::Text::default(),
+        classes: vec![language.to_owned().into()],
         attributes: Vec::new(),
     }
 }
@@ -3119,8 +3119,8 @@ fn div_open_attr(spec: &str) -> Option<Attr> {
         return None;
     }
     Some(Attr {
-        id: String::new(),
-        classes: vec![spec.to_owned()],
+        id: carta_ast::Text::default(),
+        classes: vec![spec.to_owned().into()],
         attributes: Vec::new(),
     })
 }
@@ -3439,13 +3439,13 @@ mod html_element {
             end = next;
         }
         match name.as_str() {
-            "id" => attr.id = value,
+            "id" => attr.id = value.into(),
             "class" => {
                 if attr.classes.is_empty() {
-                    attr.classes = value.split_whitespace().map(str::to_owned).collect();
+                    attr.classes = value.split_whitespace().map(Into::into).collect();
                 }
             }
-            _ => attr.attributes.push((name, value)),
+            _ => attr.attributes.push((name.into(), value.into())),
         }
         Some(end)
     }
@@ -3959,7 +3959,7 @@ mod tests {
     #[test]
     fn caption_keyvals_attach_to_the_table() {
         let (attr, _) = table_attr_and_caption("| a |\n|---|\n| 1 |\n\n: c {key=val}\n");
-        assert_eq!(attr.attributes, [("key".to_owned(), "val".to_owned())]);
+        assert_eq!(attr.attributes, [("key".into(), "val".into())]);
     }
 
     #[test]
@@ -4025,10 +4025,7 @@ mod html_element_tests {
         assert_eq!(attr.classes, vec!["a".to_owned(), "b".to_owned()]);
         assert_eq!(
             attr.attributes,
-            vec![
-                ("data-z".to_owned(), "1".to_owned()),
-                ("data-a".to_owned(), "2".to_owned()),
-            ]
+            vec![("data-z".into(), "1".into()), ("data-a".into(), "2".into()),]
         );
     }
 
@@ -4207,10 +4204,7 @@ mod html_element_tests {
         assert_eq!(tag.tag, "div");
         assert_eq!(tag.attr.id, "x");
         assert_eq!(tag.attr.classes, vec!["a".to_owned(), "b".to_owned()]);
-        assert_eq!(
-            tag.attr.attributes,
-            vec![("data-k".to_owned(), "v".to_owned())]
-        );
+        assert_eq!(tag.attr.attributes, vec![("data-k".into(), "v".into())]);
         // The extent stops just past the `>`, leaving any same-line remainder.
         assert_eq!(tag.len, "<div id=\"x\" class=\"a b\" data-k=v>".len());
     }
@@ -4233,10 +4227,7 @@ mod html_element_tests {
     fn parse_open_tag_records_a_valueless_attribute_as_an_empty_value() {
         let tag = html_element::parse_open_tag("<div hidden class=\"a\">").expect("a div");
         assert_eq!(tag.attr.classes, vec!["a".to_owned()]);
-        assert_eq!(
-            tag.attr.attributes,
-            vec![("hidden".to_owned(), String::new())]
-        );
+        assert_eq!(tag.attr.attributes, vec![("hidden".into(), "".into())]);
     }
 
     #[test]

--- a/crates/carta-readers/src/commonmark/block.rs
+++ b/crates/carta-readers/src/commonmark/block.rs
@@ -2454,7 +2454,7 @@ impl Parser {
                     }
                     IrBlock::Para(trimmed.to_owned())
                 } else {
-                    IrBlock::RawBlock(Format("tex".to_owned().into()), node.text.clone())
+                    IrBlock::RawBlock(Format("tex".into()), node.text.clone())
                 }
             }
             Kind::BlockQuote => {
@@ -2529,7 +2529,7 @@ impl Parser {
         let title = IrBlock::Div(
             Attr {
                 id: carta_ast::Text::default(),
-                classes: vec!["title".to_owned().into()],
+                classes: vec!["title".into()],
                 attributes: Vec::new(),
             },
             vec![IrBlock::Para(alert_type.title.to_owned())],
@@ -2552,7 +2552,7 @@ impl Parser {
         Some(IrBlock::Div(
             Attr {
                 id: carta_ast::Text::default(),
-                classes: vec![alert_type.class.to_owned().into()],
+                classes: vec![alert_type.class.into()],
                 attributes: Vec::new(),
             },
             content,
@@ -3013,7 +3013,7 @@ fn fence_attr(info: &str, extensions: Extensions) -> Attr {
     let language = info.split_whitespace().next().unwrap_or("");
     Attr {
         id: carta_ast::Text::default(),
-        classes: vec![language.to_owned().into()],
+        classes: vec![language.into()],
         attributes: Vec::new(),
     }
 }
@@ -3120,7 +3120,7 @@ fn div_open_attr(spec: &str) -> Option<Attr> {
     }
     Some(Attr {
         id: carta_ast::Text::default(),
-        classes: vec![spec.to_owned().into()],
+        classes: vec![spec.into()],
         attributes: Vec::new(),
     })
 }

--- a/crates/carta-readers/src/commonmark/frontmatter.rs
+++ b/crates/carta-readers/src/commonmark/frontmatter.rs
@@ -146,7 +146,7 @@ pub(crate) fn parse_metadata_json(
 /// numbers parse as inline Markdown, booleans stay boolean, and arrays/objects recurse.
 fn json_to_meta(value: serde_json::Value, options: &ReaderOptions) -> MetaValue {
     match value {
-        serde_json::Value::Null => MetaValue::MetaString(String::new()),
+        serde_json::Value::Null => MetaValue::MetaString(carta_ast::Text::default()),
         serde_json::Value::Bool(b) => MetaValue::MetaBool(b),
         serde_json::Value::Number(n) => MetaValue::MetaInlines(parse_meta_inlines(
             &n.to_string(),
@@ -166,7 +166,7 @@ fn json_to_meta(value: serde_json::Value, options: &ReaderOptions) -> MetaValue 
         ),
         serde_json::Value::Object(map) => MetaValue::MetaMap(
             map.into_iter()
-                .map(|(key, item)| (key, json_to_meta(item, options)))
+                .map(|(key, item)| (key.into(), json_to_meta(item, options)))
                 .collect(),
         ),
     }
@@ -178,7 +178,7 @@ fn yaml_to_meta(value: Yaml, options: &ReaderOptions) -> MetaValue {
         Yaml::Mapping(entries) => MetaValue::MetaMap(
             entries
                 .into_iter()
-                .map(|(key, value)| (key, yaml_to_meta(value, options)))
+                .map(|(key, value)| (key.into(), yaml_to_meta(value, options)))
                 .collect(),
         ),
         Yaml::Sequence(items) => MetaValue::MetaList(
@@ -208,7 +208,7 @@ fn scalar_to_meta(scalar: Scalar, options: &ReaderOptions) -> MetaValue {
 
 fn plain_scalar_to_meta(text: &str, options: &ReaderOptions) -> MetaValue {
     if text.is_empty() || is_null(text) {
-        return MetaValue::MetaString(String::new());
+        return MetaValue::MetaString(carta_ast::Text::default());
     }
     if let Some(value) = as_bool(text) {
         return MetaValue::MetaBool(value);
@@ -371,7 +371,7 @@ fn insert_meta_field(meta: &mut BTreeMap<String, MetaValue>, key: &str, field: &
             if word_index > 0 {
                 inlines.push(Inline::Space);
             }
-            inlines.push(Inline::Str(word.to_owned()));
+            inlines.push(Inline::Str(word.to_owned().into()));
         }
     }
     meta.insert(key.to_owned(), MetaValue::MetaInlines(inlines));
@@ -447,7 +447,7 @@ mod tests {
         assert_eq!(
             document.meta.get("title"),
             Some(&MetaValue::MetaInlines(vec![carta_ast::Inline::Str(
-                "T".to_owned()
+                "T".to_owned().into()
             )]))
         );
         assert!(matches!(document.blocks.as_slice(), [Block::Para(_)]));
@@ -483,7 +483,7 @@ mod tests {
             if index > 0 {
                 out.push(Inline::Space);
             }
-            out.push(Inline::Str((*word).to_owned()));
+            out.push(Inline::Str((*word).to_owned().into()));
         }
         MetaValue::MetaInlines(out)
     }
@@ -514,9 +514,9 @@ mod tests {
         assert_eq!(
             document.meta.get("author"),
             Some(&MetaValue::MetaInlines(vec![
-                Inline::Str("Jane".to_owned()),
+                Inline::Str("Jane".to_owned().into()),
                 Inline::SoftBreak,
-                Inline::Str("John".to_owned()),
+                Inline::Str("John".to_owned().into()),
             ]))
         );
     }

--- a/crates/carta-readers/src/commonmark/frontmatter.rs
+++ b/crates/carta-readers/src/commonmark/frontmatter.rs
@@ -371,7 +371,7 @@ fn insert_meta_field(meta: &mut BTreeMap<String, MetaValue>, key: &str, field: &
             if word_index > 0 {
                 inlines.push(Inline::Space);
             }
-            inlines.push(Inline::Str(word.to_owned().into()));
+            inlines.push(Inline::Str(word.into()));
         }
     }
     meta.insert(key.to_owned(), MetaValue::MetaInlines(inlines));

--- a/crates/carta-readers/src/commonmark/identifiers.rs
+++ b/crates/carta-readers/src/commonmark/identifiers.rs
@@ -70,7 +70,7 @@ fn walk(blocks: &mut [Block], numbering: &mut HeaderNumbering) {
     for block in blocks {
         match block {
             Block::Header(_, attr, inlines) => {
-                attr.id = numbering.id_for(&attr.id, inlines);
+                attr.id = numbering.id_for(&attr.id, inlines).into();
             }
             Block::BlockQuote(children)
             | Block::Div(_, children)

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -206,7 +206,7 @@ fn resolve_block(
                 out.push(Block::Para(parse_inlines(text, refs, notes, ext)));
             } else {
                 out.push(Block::RawBlock(
-                    carta_ast::Format("html".to_owned().into()),
+                    carta_ast::Format("html".into()),
                     text.clone().into(),
                 ));
             }
@@ -1047,13 +1047,13 @@ impl InlineParser<'_> {
         };
         let attr = Attr {
             id: carta_ast::Text::default(),
-            classes: vec!["emoji".to_owned().into()],
-            attributes: vec![("data-emoji".to_owned().into(), name.into())],
+            classes: vec!["emoji".into()],
+            attributes: vec![("data-emoji".into(), name.into())],
         };
         self.pos = index + 1;
         self.nodes.push(Node::Inline(Inline::Span(
             Box::new(attr),
-            vec![Inline::Str(codepoints.to_owned().into())],
+            vec![Inline::Str(codepoints.into())],
         )));
         true
     }
@@ -1280,7 +1280,7 @@ impl InlineParser<'_> {
         };
         self.pos = i;
         self.nodes.push(Node::Inline(Inline::RawInline(
-            carta_ast::Format("tex".to_owned().into()),
+            carta_ast::Format("tex".into()),
             source.into(),
         )));
         true
@@ -1311,7 +1311,7 @@ impl InlineParser<'_> {
         };
         self.pos = end;
         self.nodes.push(Node::Inline(Inline::RawInline(
-            carta_ast::Format("tex".to_owned().into()),
+            carta_ast::Format("tex".into()),
             source.into(),
         )));
         true
@@ -1495,7 +1495,7 @@ impl InlineParser<'_> {
                 self.push_str(&html);
             } else {
                 self.nodes.push(Node::Inline(Inline::RawInline(
-                    carta_ast::Format("html".to_owned().into()),
+                    carta_ast::Format("html".into()),
                     html.into(),
                 )));
             }
@@ -2610,7 +2610,7 @@ fn resolve_mark(nodes: &mut Vec<Node>, ext: Extensions, markdown: bool) {
         let span = Inline::Span(
             Box::new(Attr {
                 id: carta_ast::Text::default(),
-                classes: vec!["mark".to_string().into()],
+                classes: vec!["mark".into()],
                 attributes: Vec::new(),
             }),
             content,
@@ -2852,7 +2852,7 @@ fn classify_angle_autolink(inline: Inline) -> Inline {
     };
     let is_email = matches!(text.first(), Some(Inline::Str(shown)) if *shown != target.url);
     attr.classes
-        .push(if is_email { "email" } else { "uri" }.to_owned().into());
+        .push(if is_email { "email" } else { "uri" }.into());
     Inline::Link(attr, text, target)
 }
 
@@ -3053,7 +3053,7 @@ fn pair_spans_level(
                         // No matching close at this level: the opener reverts to raw, and its
                         // gathered inner content rejoins the stream.
                         out.push(Inline::RawInline(
-                            carta_ast::Format("html".to_owned().into()),
+                            carta_ast::Format("html".into()),
                             open_tag_raw(&attr).into(),
                         ));
                         out.extend(inner);

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use carta_ast::{
     Alignment, Attr, Block, Caption, Cell as TableCell, Citation, CitationMode, ColSpec, ColWidth,
-    Inline, MathType, QuoteType, Row, Table, TableBody, TableFoot, TableHead, Target,
+    Inline, MathType, QuoteType, Row, Table, TableBody, TableFoot, TableHead, Target, Text,
 };
 use carta_core::{Extension, Extensions};
 
@@ -193,7 +193,10 @@ fn resolve_block(
             ));
         }
         IrBlock::CodeBlock(attr, text) => {
-            out.push(Block::CodeBlock(Box::new(attr.clone()), text.clone()));
+            out.push(Block::CodeBlock(
+                Box::new(attr.clone()),
+                text.clone().into(),
+            ));
         }
         IrBlock::RawHtml(text) => {
             // In the Markdown dialect with `raw_html` off an HTML block degrades to an ordinary
@@ -203,13 +206,13 @@ fn resolve_block(
                 out.push(Block::Para(parse_inlines(text, refs, notes, ext)));
             } else {
                 out.push(Block::RawBlock(
-                    carta_ast::Format("html".to_owned()),
-                    text.clone(),
+                    carta_ast::Format("html".to_owned().into()),
+                    text.clone().into(),
                 ));
             }
         }
         IrBlock::RawBlock(format, text) => {
-            out.push(Block::RawBlock(format.clone(), text.clone()));
+            out.push(Block::RawBlock(format.clone(), text.clone().into()));
         }
         IrBlock::ThematicBreak => out.push(Block::HorizontalRule),
         IrBlock::Div(attr, children) => {
@@ -630,7 +633,7 @@ fn split_header_attr(text: &str, ext: Extensions) -> (&str, Attr) {
         return (
             content,
             Attr {
-                id,
+                id: id.into(),
                 ..Attr::default()
             },
         );
@@ -996,7 +999,7 @@ impl InlineParser<'_> {
         let note_num = self.bump_cite_count();
         self.pos = next;
         let citation = Citation {
-            id: id.clone(),
+            id: id.clone().into(),
             prefix: Vec::new(),
             suffix: Vec::new(),
             mode: CitationMode::AuthorInText,
@@ -1005,7 +1008,7 @@ impl InlineParser<'_> {
         };
         self.nodes.push(Node::Inline(Inline::Cite(
             vec![citation],
-            vec![Inline::Str(format!("@{id}"))],
+            vec![Inline::Str(format!("@{id}").into())],
         )));
         true
     }
@@ -1043,14 +1046,14 @@ impl InlineParser<'_> {
             return false;
         };
         let attr = Attr {
-            id: String::new(),
-            classes: vec!["emoji".to_owned()],
-            attributes: vec![("data-emoji".to_owned(), name)],
+            id: carta_ast::Text::default(),
+            classes: vec!["emoji".to_owned().into()],
+            attributes: vec![("data-emoji".to_owned().into(), name.into())],
         };
         self.pos = index + 1;
         self.nodes.push(Node::Inline(Inline::Span(
             Box::new(attr),
-            vec![Inline::Str(codepoints.to_owned())],
+            vec![Inline::Str(codepoints.to_owned().into())],
         )));
         true
     }
@@ -1101,7 +1104,7 @@ impl InlineParser<'_> {
             Some(slice) if !slice.is_empty() => slice.iter().collect(),
             _ => return false,
         };
-        let inner = vec![Inline::Str(content)];
+        let inner = vec![Inline::Str(content.into())];
         let node = if delimiter == '^' {
             Inline::Superscript(inner)
         } else {
@@ -1188,7 +1191,7 @@ impl InlineParser<'_> {
             Some((math_type, content, next)) => {
                 self.pos = next;
                 self.nodes
-                    .push(Node::Inline(Inline::Math(math_type, content)));
+                    .push(Node::Inline(Inline::Math(math_type, content.into())));
                 true
             }
             None => false,
@@ -1277,8 +1280,8 @@ impl InlineParser<'_> {
         };
         self.pos = i;
         self.nodes.push(Node::Inline(Inline::RawInline(
-            carta_ast::Format("tex".to_owned()),
-            source,
+            carta_ast::Format("tex".to_owned().into()),
+            source.into(),
         )));
         true
     }
@@ -1308,8 +1311,8 @@ impl InlineParser<'_> {
         };
         self.pos = end;
         self.nodes.push(Node::Inline(Inline::RawInline(
-            carta_ast::Format("tex".to_owned()),
-            source,
+            carta_ast::Format("tex".to_owned().into()),
+            source.into(),
         )));
         true
     }
@@ -1409,15 +1412,15 @@ impl InlineParser<'_> {
                     if let Some((format, next)) = self.scan_raw_format() {
                         self.pos = next;
                         self.nodes.push(Node::Inline(Inline::RawInline(
-                            carta_ast::Format(format),
-                            normalize_code(&content, self.notes.markdown),
+                            carta_ast::Format(format.into()),
+                            normalize_code(&content, self.notes.markdown).into(),
                         )));
                         return;
                     }
                     let attr = self.take_code_attr();
                     self.nodes.push(Node::Inline(Inline::Code(
                         Box::new(attr),
-                        normalize_code(&content, self.notes.markdown),
+                        normalize_code(&content, self.notes.markdown).into(),
                     )));
                     return;
                 }
@@ -1448,16 +1451,20 @@ impl InlineParser<'_> {
                 crate::inline_scan::scan_display_math(self.chars, self.pos)
             {
                 self.pos = next;
-                self.nodes
-                    .push(Node::Inline(Inline::Math(MathType::DisplayMath, content)));
+                self.nodes.push(Node::Inline(Inline::Math(
+                    MathType::DisplayMath,
+                    content.into(),
+                )));
                 return;
             }
         } else if let Some((content, next)) =
             crate::inline_scan::scan_inline_math(self.chars, self.pos)
         {
             self.pos = next;
-            self.nodes
-                .push(Node::Inline(Inline::Math(MathType::InlineMath, content)));
+            self.nodes.push(Node::Inline(Inline::Math(
+                MathType::InlineMath,
+                content.into(),
+            )));
             return;
         }
         self.pos += 1;
@@ -1488,8 +1495,8 @@ impl InlineParser<'_> {
                 self.push_str(&html);
             } else {
                 self.nodes.push(Node::Inline(Inline::RawInline(
-                    carta_ast::Format("html".to_owned()),
-                    html,
+                    carta_ast::Format("html".to_owned().into()),
+                    html.into(),
                 )));
             }
             return;
@@ -1753,7 +1760,7 @@ impl InlineParser<'_> {
         // before its number (`p.\u{a0}5`). That join, gated on a fixed set of abbreviations, is not
         // applied here: the suffix is tokenized as ordinary inlines, so `p. 5` stays three tokens.
         Some(Citation {
-            id: key.id,
+            id: key.id.into(),
             prefix: parse_inlines(prefix_src.trim(), self.refs, self.notes, self.ext),
             suffix: parse_inlines(suffix_src.trim_end(), self.refs, self.notes, self.ext),
             mode,
@@ -1976,7 +1983,7 @@ impl InlineParser<'_> {
             self.push_text('!');
         }
         let note = if self.notes.in_definition {
-            Inline::Str(String::new())
+            Inline::Str(carta_ast::Text::default())
         } else {
             Inline::Note(self.notes.by_id.get(&key).cloned().unwrap_or_default())
         };
@@ -2030,7 +2037,7 @@ impl InlineParser<'_> {
         // The markdown dialect percent-encodes a destination's unsafe characters; the strict
         // CommonMark and GitHub dialects keep it verbatim.
         if self.notes.markdown {
-            target.url = escape_uri(&target.url);
+            target.url = escape_uri(&target.url).into();
         }
         let inner: Vec<Node> = self.nodes.split_off(opener_index + 1);
         self.nodes.pop(); // remove the opener delimiter
@@ -2063,7 +2070,7 @@ fn citation_fallback_inlines(raw: &str) -> Vec<Inline> {
     let mut had_newline = false;
     let flush_word = |out: &mut Vec<Inline>, word: &mut String| {
         if !word.is_empty() {
-            out.push(Inline::Str(std::mem::take(word)));
+            out.push(Inline::Str(std::mem::take(word).into()));
         }
     };
     for ch in raw.chars() {
@@ -2259,8 +2266,8 @@ fn find_citation_key(chars: &[char], range: std::ops::Range<usize>) -> Option<Ci
 
 fn def_target(def: &LinkDef) -> Target {
     Target {
-        url: def.url.clone(),
-        title: def.title.clone(),
+        url: def.url.clone().into(),
+        title: def.title.clone().into(),
     }
 }
 
@@ -2602,8 +2609,8 @@ fn resolve_mark(nodes: &mut Vec<Node>, ext: Extensions, markdown: bool) {
         let content = collapse(inner);
         let span = Inline::Span(
             Box::new(Attr {
-                id: String::new(),
-                classes: vec!["mark".to_string()],
+                id: carta_ast::Text::default(),
+                classes: vec!["mark".to_string().into()],
                 attributes: Vec::new(),
             }),
             content,
@@ -2789,8 +2796,8 @@ fn scan_markdown_inline_target(chars: &[char], pos: usize) -> Option<(Target, us
     }
     Some((
         Target {
-            url: unescape_string(&url),
-            title: unescape_string(&title),
+            url: unescape_string(&url).into(),
+            title: unescape_string(&title).into(),
         },
         index,
     ))
@@ -2845,7 +2852,7 @@ fn classify_angle_autolink(inline: Inline) -> Inline {
     };
     let is_email = matches!(text.first(), Some(Inline::Str(shown)) if *shown != target.url);
     attr.classes
-        .push(if is_email { "email" } else { "uri" }.to_owned());
+        .push(if is_email { "email" } else { "uri" }.to_owned().into());
     Inline::Link(attr, text, target)
 }
 
@@ -2854,7 +2861,7 @@ fn escape_link_destination(inline: Inline) -> Inline {
     let Inline::Link(attr, text, mut target) = inline else {
         return inline;
     };
-    target.url = escape_uri(&target.url);
+    target.url = escape_uri(&target.url).into();
     Inline::Link(attr, text, target)
 }
 
@@ -3046,8 +3053,8 @@ fn pair_spans_level(
                         // No matching close at this level: the opener reverts to raw, and its
                         // gathered inner content rejoins the stream.
                         out.push(Inline::RawInline(
-                            carta_ast::Format("html".to_owned()),
-                            open_tag_raw(&attr),
+                            carta_ast::Format("html".to_owned().into()),
+                            open_tag_raw(&attr).into(),
                         ));
                         out.extend(inner);
                     }
@@ -3207,16 +3214,16 @@ fn parse_span_attributes(chars: &[char], start: usize) -> Option<Attr> {
         match name.as_str() {
             "id" => {
                 if attr.id.is_empty() {
-                    attr.id = value;
+                    attr.id = value.into();
                 }
             }
             "class" => {
                 if !seen_class {
                     seen_class = true;
-                    attr.classes = value.split_whitespace().map(str::to_owned).collect();
+                    attr.classes = value.split_whitespace().map(Into::into).collect();
                 }
             }
-            _ => attr.attributes.push((name, value)),
+            _ => attr.attributes.push((name.into(), value.into())),
         }
     }
 }
@@ -3343,7 +3350,8 @@ fn collapse(nodes: Vec<Node>) -> Vec<Inline> {
 /// spaces to a single `Space`.
 fn push_text_inlines(out: &mut Vec<Inline>, text: &str) {
     let mut chars = text.chars().peekable();
-    let mut word = String::new();
+    // Built directly as `Text` so a word short enough for inline storage never touches the heap.
+    let mut word = Text::default();
     while let Some(ch) = chars.next() {
         if ch == ' ' {
             if !word.is_empty() {
@@ -3528,11 +3536,11 @@ mod tests {
     fn emoji_span(name: &str, text: &str) -> Inline {
         Inline::Span(
             Box::new(Attr {
-                id: String::new(),
-                classes: vec!["emoji".to_owned()],
-                attributes: vec![("data-emoji".to_owned(), name.to_owned())],
+                id: carta_ast::Text::default(),
+                classes: vec!["emoji".to_owned().into()],
+                attributes: vec![("data-emoji".to_owned().into(), name.to_owned().into())],
             }),
-            vec![Inline::Str(text.to_owned())],
+            vec![Inline::Str(text.to_owned().into())],
         )
     }
 
@@ -3574,12 +3582,12 @@ mod tests {
         // An unrecognized name leaves the colons and text verbatim.
         assert_eq!(
             parse_meta_inlines(":unknown_xyz:", on, false),
-            vec![Inline::Str(":unknown_xyz:".to_owned())]
+            vec![Inline::Str(":unknown_xyz:".to_owned().into())]
         );
         // An empty `::` is not a shortcode.
         assert_eq!(
             parse_meta_inlines("::", on, false),
-            vec![Inline::Str("::".to_owned())]
+            vec![Inline::Str("::".to_owned().into())]
         );
     }
 
@@ -3588,15 +3596,15 @@ mod tests {
         let off = Extensions::empty();
         assert_eq!(
             parse_meta_inlines(":smile:", off, false),
-            vec![Inline::Str(":smile:".to_owned())]
+            vec![Inline::Str(":smile:".to_owned().into())]
         );
     }
 
     fn mark_span(content: Vec<Inline>) -> Inline {
         Inline::Span(
             Box::new(Attr {
-                id: String::new(),
-                classes: vec!["mark".to_owned()],
+                id: carta_ast::Text::default(),
+                classes: vec!["mark".to_owned().into()],
                 attributes: Vec::new(),
             }),
             content,
@@ -3611,10 +3619,10 @@ mod tests {
             parse_meta_inlines("[==hi==](u)", on, false),
             vec![Inline::Link(
                 Box::default(),
-                vec![mark_span(vec![Inline::Str("hi".to_owned())])],
+                vec![mark_span(vec![Inline::Str("hi".to_owned().into())])],
                 Box::new(Target {
-                    url: "u".to_owned(),
-                    title: String::new(),
+                    url: "u".to_owned().into(),
+                    title: carta_ast::Text::default(),
                 }),
             )]
         );
@@ -3625,8 +3633,8 @@ mod tests {
         let on = exts(&[Extension::Mark, Extension::BracketedSpans]);
         // A `==…==` run nested in a bracketed span's body resolves there too.
         let span_attr = Attr {
-            id: String::new(),
-            classes: vec!["x".to_owned()],
+            id: carta_ast::Text::default(),
+            classes: vec!["x".to_owned().into()],
             attributes: Vec::new(),
         };
         assert_eq!(
@@ -3634,11 +3642,11 @@ mod tests {
             vec![Inline::Span(
                 Box::new(span_attr),
                 vec![
-                    Inline::Str("a".to_owned()),
+                    Inline::Str("a".to_owned().into()),
                     Inline::Space,
-                    mark_span(vec![Inline::Str("b".to_owned())]),
+                    mark_span(vec![Inline::Str("b".to_owned().into())]),
                     Inline::Space,
-                    Inline::Str("c".to_owned()),
+                    Inline::Str("c".to_owned().into()),
                 ],
             )]
         );
@@ -3652,10 +3660,10 @@ mod tests {
             parse_meta_inlines("[==hi==](u)", off, false),
             vec![Inline::Link(
                 Box::default(),
-                vec![Inline::Str("==hi==".to_owned())],
+                vec![Inline::Str("==hi==".to_owned().into())],
                 Box::new(Target {
-                    url: "u".to_owned(),
-                    title: String::new(),
+                    url: "u".to_owned().into(),
+                    title: carta_ast::Text::default(),
                 }),
             )]
         );
@@ -3909,7 +3917,7 @@ mod inline_tests {
     }
 
     fn str(s: &str) -> Inline {
-        Inline::Str(s.to_owned())
+        Inline::Str(s.to_owned().into())
     }
 
     fn link(content: Vec<Inline>, url: &str) -> Inline {
@@ -3917,8 +3925,8 @@ mod inline_tests {
             Box::default(),
             content,
             Box::new(Target {
-                url: url.to_owned(),
-                title: String::new(),
+                url: url.to_owned().into(),
+                title: carta_ast::Text::default(),
             }),
         )
     }
@@ -3928,8 +3936,8 @@ mod inline_tests {
             Box::default(),
             alt,
             Box::new(Target {
-                url: url.to_owned(),
-                title: String::new(),
+                url: url.to_owned().into(),
+                title: carta_ast::Text::default(),
             }),
         )
     }
@@ -4370,11 +4378,11 @@ mod inline_tests {
     // --- TeX math ---
 
     fn math_inline(content: &str) -> Inline {
-        Inline::Math(carta_ast::MathType::InlineMath, content.to_owned())
+        Inline::Math(carta_ast::MathType::InlineMath, content.to_owned().into())
     }
 
     fn math_display(content: &str) -> Inline {
-        Inline::Math(carta_ast::MathType::DisplayMath, content.to_owned())
+        Inline::Math(carta_ast::MathType::DisplayMath, content.to_owned().into())
     }
 
     fn math() -> Extensions {
@@ -4433,12 +4441,9 @@ mod inline_tests {
 
     fn attr(id: &str, classes: &[&str], kv: &[(&str, &str)]) -> Attr {
         Attr {
-            id: id.to_owned(),
-            classes: classes.iter().map(|c| (*c).to_owned()).collect(),
-            attributes: kv
-                .iter()
-                .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
-                .collect(),
+            id: id.to_owned().into(),
+            classes: classes.iter().map(|c| (*c).into()).collect(),
+            attributes: kv.iter().map(|(k, v)| ((*k).into(), (*v).into())).collect(),
         }
     }
 
@@ -4493,14 +4498,14 @@ mod inline_tests {
             pe("`code`{.rust #x}", attrs()),
             vec![Inline::Code(
                 Box::new(attr("x", &["rust"], &[])),
-                "code".to_owned()
+                "code".to_owned().into()
             )]
         );
         // A space before the block leaves it unattached (no wrapper artifact is produced).
         assert_eq!(
             pe("`code` x", attrs()),
             vec![
-                Inline::Code(Box::default(), "code".to_owned()),
+                Inline::Code(Box::default(), "code".to_owned().into()),
                 Inline::Space,
                 str("x")
             ]
@@ -4513,8 +4518,8 @@ mod inline_tests {
             Box::new(attr("home", &["external"], &[])),
             vec![str("t")],
             Box::new(Target {
-                url: "u".to_owned(),
-                title: String::new(),
+                url: "u".to_owned().into(),
+                title: carta_ast::Text::default(),
             }),
         );
         assert_eq!(pe("[t](u){.external #home}", attrs()), vec![link_with_attr]);
@@ -4522,8 +4527,8 @@ mod inline_tests {
             Box::new(attr("", &[], &[("width", "200")])),
             vec![str("a")],
             Box::new(Target {
-                url: "i".to_owned(),
-                title: String::new(),
+                url: "i".to_owned().into(),
+                title: carta_ast::Text::default(),
             }),
         );
         assert_eq!(pe("![a](i){width=200}", attrs()), vec![image_with_attr]);
@@ -4558,11 +4563,14 @@ mod inline_tests {
     // --- Inline raw attribute (`{=FORMAT}` on a code span) ---
 
     fn raw(format: &str, text: &str) -> Inline {
-        Inline::RawInline(carta_ast::Format(format.to_owned()), text.to_owned())
+        Inline::RawInline(
+            carta_ast::Format(format.to_owned().into()),
+            text.to_owned().into(),
+        )
     }
 
     fn code(text: &str) -> Inline {
-        Inline::Code(Box::default(), text.to_owned())
+        Inline::Code(Box::default(), text.to_owned().into())
     }
 
     #[test]
@@ -4617,10 +4625,10 @@ mod inline_tests {
             pe("`x`{.c}", ext),
             vec![Inline::Code(
                 Box::new(Attr {
-                    classes: vec!["c".to_owned()],
+                    classes: vec!["c".to_owned().into()],
                     ..Attr::default()
                 }),
-                "x".to_owned()
+                "x".to_owned().into()
             )]
         );
     }
@@ -4633,7 +4641,10 @@ mod inline_tests {
     // --- Inline raw TeX and backslash math ---
 
     fn tex(source: &str) -> Inline {
-        Inline::RawInline(carta_ast::Format("tex".to_owned()), source.to_owned())
+        Inline::RawInline(
+            carta_ast::Format("tex".to_owned().into()),
+            source.to_owned().into(),
+        )
     }
 
     fn raw_tex() -> Extensions {
@@ -5082,7 +5093,7 @@ mod inline_tests {
         note_num: i32,
     ) -> Citation {
         Citation {
-            id: id.to_owned(),
+            id: id.to_owned().into(),
             prefix,
             suffix,
             mode,

--- a/crates/carta-readers/src/commonmark/mod.rs
+++ b/crates/carta-readers/src/commonmark/mod.rs
@@ -51,7 +51,7 @@ impl Reader for CommonmarkReader {
             options.greedy_paragraphs,
         );
         Ok(Document {
-            meta,
+            meta: meta.into_iter().map(|(k, v)| (k.into(), v)).collect(),
             blocks,
             ..Document::default()
         })
@@ -531,7 +531,7 @@ mod tests {
         };
         assert_eq!(attr.id, "a");
         assert_eq!(attr.classes, ["b", "c"]);
-        assert_eq!(attr.attributes, [("k".to_owned(), "v".to_owned())]);
+        assert_eq!(attr.attributes, [("k".into(), "v".into())]);
     }
 
     #[test]
@@ -686,7 +686,7 @@ mod tests {
         blocks
             .iter()
             .filter_map(|b| match b {
-                Block::Header(_, attr, _) => Some(attr.id.clone()),
+                Block::Header(_, attr, _) => Some(attr.id.to_string()),
                 _ => None,
             })
             .collect()
@@ -741,7 +741,7 @@ mod tests {
             for inline in inlines {
                 match inline {
                     Inline::Link(_, _, target) | Inline::Image(_, _, target) => {
-                        out.push(target.url.clone());
+                        out.push(target.url.to_string());
                     }
                     _ => {}
                 }
@@ -1698,12 +1698,14 @@ mod tests {
         assert_eq!(doc.meta.get("flag"), Some(&MetaValue::MetaBool(true)));
         assert_eq!(
             doc.meta.get("empty"),
-            Some(&MetaValue::MetaString(String::new()))
+            Some(&MetaValue::MetaString(carta_ast::Text::default()))
         );
         // An unquoted numeric scalar is canonicalized before it is parsed as inline markdown.
         assert_eq!(
             doc.meta.get("revision"),
-            Some(&MetaValue::MetaInlines(vec![Inline::Str("7".to_owned())]))
+            Some(&MetaValue::MetaInlines(vec![Inline::Str(
+                "7".to_owned().into()
+            )]))
         );
         assert!(matches!(doc.blocks.as_slice(), [Block::Para(_)]));
     }
@@ -1775,7 +1777,7 @@ mod tests {
         );
         assert!(matches!(doc.blocks.as_slice(), [Block::Table(_)]));
         let inlines = caption_inlines(&doc.blocks).expect("captioned table");
-        assert_eq!(inlines.first(), Some(&Inline::Str("A".to_owned())));
+        assert_eq!(inlines.first(), Some(&Inline::Str("A".to_owned().into())));
     }
 
     #[test]

--- a/crates/carta-readers/src/commonmark/scan.rs
+++ b/crates/carta-readers/src/commonmark/scan.rs
@@ -99,22 +99,30 @@ pub(crate) fn scan_autolink(chars: &[char], start: usize) -> Option<(Inline, usi
     let after = end + 1;
     if is_uri_autolink(&content) {
         let target = Target {
-            url: content.clone(),
-            title: String::new(),
+            url: content.clone().into(),
+            title: carta_ast::Text::default(),
         };
         return Some((
-            Inline::Link(Box::default(), vec![Inline::Str(content)], Box::new(target)),
+            Inline::Link(
+                Box::default(),
+                vec![Inline::Str(content.into())],
+                Box::new(target),
+            ),
             after,
         ));
     }
     if is_email_autolink(&content) {
         let url = format!("mailto:{content}");
         let target = Target {
-            url,
-            title: String::new(),
+            url: url.into(),
+            title: carta_ast::Text::default(),
         };
         return Some((
-            Inline::Link(Box::default(), vec![Inline::Str(content)], Box::new(target)),
+            Inline::Link(
+                Box::default(),
+                vec![Inline::Str(content.into())],
+                Box::new(target),
+            ),
             after,
         ));
     }
@@ -378,8 +386,8 @@ pub(crate) fn scan_inline_target(chars: &[char], pos: usize) -> Option<(Target, 
     }
     Some((
         Target {
-            url: unescape_string(&url),
-            title: unescape_string(&title),
+            url: unescape_string(&url).into(),
+            title: unescape_string(&title).into(),
         },
         index + 1,
     ))

--- a/crates/carta-readers/src/csv.rs
+++ b/crates/carta-readers/src/csv.rs
@@ -219,7 +219,7 @@ fn field_inlines(field: &str) -> Vec<Inline> {
                 word.push(w);
                 chars.next();
             }
-            inlines.push(Inline::Str(word));
+            inlines.push(Inline::Str(word.into()));
         }
     }
 

--- a/crates/carta-readers/src/dokuwiki.rs
+++ b/crates/carta-readers/src/dokuwiki.rs
@@ -468,13 +468,16 @@ fn parse_raw_region(chars: &[char], start: usize) -> Option<(Block, usize)> {
         RawKind::Code => {
             let class = code_language(&attr_text);
             let attr = Attr {
-                classes: class.into_iter().collect(),
+                classes: class.into_iter().map(Into::into).collect(),
                 ..Default::default()
             };
-            Block::CodeBlock(Box::new(attr), content)
+            Block::CodeBlock(Box::new(attr), content.into())
         }
-        RawKind::Html => Block::RawBlock(Format("html".to_string()), content),
-        RawKind::Php => Block::RawBlock(Format("html".to_string()), format!("<?php {content} ?>")),
+        RawKind::Html => Block::RawBlock(Format("html".to_string().into()), content.into()),
+        RawKind::Php => Block::RawBlock(
+            Format("html".to_string().into()),
+            format!("<?php {content} ?>").into(),
+        ),
     };
     Some((block, end))
 }
@@ -517,7 +520,7 @@ fn parse_indented_code(lines: &[&str], index: &mut usize) -> Block {
         out.push('\n');
         *index += 1;
     }
-    Block::CodeBlock(Box::default(), out)
+    Block::CodeBlock(Box::default(), out.into())
 }
 
 /// Parse a thematically grouped run of list lines into one bullet or ordered list.
@@ -682,7 +685,7 @@ fn assign_heading_ids(
             Block::Header(_, attr, inlines) => {
                 let text = to_plain_text(inlines);
                 let text = if ascii { asciify(&text) } else { text };
-                attr.id = registry.assign(scheme, &text);
+                attr.id = registry.assign(scheme, &text).into();
             }
             Block::BlockQuote(children)
             | Block::Div(_, children)
@@ -892,7 +895,7 @@ fn scan_slice(chars: &[char], ctx: Ctx, depth: usize) -> Vec<Inline> {
 /// Push the buffered text as a `Str` and clear the buffer.
 fn flush(pending: &mut String, out: &mut Vec<Inline>) {
     if !pending.is_empty() {
-        out.push(Inline::Str(std::mem::take(pending)));
+        out.push(Inline::Str(std::mem::take(pending).into()));
     }
 }
 
@@ -1389,7 +1392,10 @@ fn parse_mono(
         if !closed {
             return None;
         }
-        return Some((Inline::Code(Box::default(), flatten_mono(&inner)), pos));
+        return Some((
+            Inline::Code(Box::default(), flatten_mono(&inner).into()),
+            pos,
+        ));
     }
     let close = find_subsequence(chars, begin + 2, "''")?;
     if close <= begin + 2 || is_ws_opt(chars.get(close - 1).copied()) {
@@ -1398,7 +1404,7 @@ fn parse_mono(
     let content = chars.get(begin + 2..close).unwrap_or(&[]);
     let inner = scan_slice(content, ctx, depth + 1);
     Some((
-        Inline::Code(Box::default(), to_plain_text(&inner)),
+        Inline::Code(Box::default(), to_plain_text(&inner).into()),
         close + 2,
     ))
 }
@@ -1470,7 +1476,10 @@ fn parse_display_math(chars: &[char], begin: usize) -> Option<(Inline, usize)> {
         return None;
     }
     let content: String = chars.get(begin + 2..close).unwrap_or(&[]).iter().collect();
-    Some((Inline::Math(MathType::DisplayMath, content), close + 2))
+    Some((
+        Inline::Math(MathType::DisplayMath, content.into()),
+        close + 2,
+    ))
 }
 
 /// A `$…$` inline-math span: the opener must be followed by a non-space, the closer preceded by a
@@ -1487,7 +1496,7 @@ fn parse_inline_math(chars: &[char], begin: usize) -> Option<(Inline, usize)> {
             && !chars.get(j + 1).is_some_and(char::is_ascii_digit)
         {
             let content: String = chars.get(begin + 1..j).unwrap_or(&[]).iter().collect();
-            return Some((Inline::Math(MathType::InlineMath, content), j + 1));
+            return Some((Inline::Math(MathType::InlineMath, content.into()), j + 1));
         }
         j += 1;
     }
@@ -1620,10 +1629,10 @@ fn try_autolink(chars: &[char], pos: usize) -> Option<(Inline, usize)> {
     Some((
         Inline::Link(
             Box::default(),
-            vec![Inline::Str(url.clone())],
+            vec![Inline::Str(url.clone().into())],
             Box::new(Target {
-                url,
-                title: String::new(),
+                url: url.into(),
+                title: carta_ast::Text::default(),
             }),
         ),
         end,
@@ -1716,7 +1725,7 @@ fn tokenize_text(text: &str) -> Vec<Inline> {
     for c in text.chars() {
         if c.is_whitespace() {
             if !word.is_empty() {
-                out.push(Inline::Str(std::mem::take(&mut word)));
+                out.push(Inline::Str(std::mem::take(&mut word).into()));
             }
             let token = if c == '\n' {
                 Inline::SoftBreak
@@ -1731,7 +1740,7 @@ fn tokenize_text(text: &str) -> Vec<Inline> {
         }
     }
     if !word.is_empty() {
-        out.push(Inline::Str(word));
+        out.push(Inline::Str(word.into()));
     }
     out
 }
@@ -1756,15 +1765,15 @@ fn parse_link(chars: &[char], start: usize) -> Option<(Inline, usize)> {
     // An explicit but empty label falls back to the target's auto-display text.
     let label_inlines = match label {
         Some(text) if !text.trim().is_empty() => tokenize_text(text.trim()),
-        _ => vec![Inline::Str(display)],
+        _ => vec![Inline::Str(display.into())],
     };
     Some((
         Inline::Link(
             Box::default(),
             label_inlines,
             Box::new(Target {
-                url,
-                title: String::new(),
+                url: url.into(),
+                title: carta_ast::Text::default(),
             }),
         ),
         close + 2,
@@ -1801,7 +1810,7 @@ fn parse_media(chars: &[char], start: usize) -> Option<(Inline, usize)> {
     let trailing_space = spec.ends_with(char::is_whitespace);
     let mut classes = Vec::new();
     if let Some(class) = media_align(leading_space, trailing_space) {
-        classes.push(class.to_string());
+        classes.push(class.to_string().into());
     }
 
     let spec = spec.trim();
@@ -1817,12 +1826,12 @@ fn parse_media(chars: &[char], start: usize) -> Option<(Inline, usize)> {
     // An explicit but empty caption falls back to the source's auto-display text.
     let alt = match caption {
         Some(text) if !text.trim().is_empty() => tokenize_text(text.trim()),
-        _ if is_external(id) => vec![Inline::Str(id.to_string())],
-        _ => vec![Inline::Str(display_id(id))],
+        _ if is_external(id) => vec![Inline::Str(id.to_string().into())],
+        _ => vec![Inline::Str(display_id(id).into())],
     };
     let target = Target {
-        url,
-        title: String::new(),
+        url: url.into(),
+        title: carta_ast::Text::default(),
     };
 
     let node = match query {
@@ -1847,7 +1856,10 @@ fn parse_media(chars: &[char], start: usize) -> Option<(Inline, usize)> {
             Inline::Image(
                 Box::new(Attr {
                     classes,
-                    attributes,
+                    attributes: attributes
+                        .into_iter()
+                        .map(|(k, v)| (k.into(), v.into()))
+                        .collect(),
                     ..Default::default()
                 }),
                 alt,
@@ -2046,7 +2058,10 @@ fn parse_angle(
     if let Some((inner, end)) = tag_region(chars, begin, "<html>", "</html>") {
         let text: String = inner.iter().collect();
         return Some((
-            vec![Inline::RawInline(Format("html".to_string()), text)],
+            vec![Inline::RawInline(
+                Format("html".to_string().into()),
+                text.into(),
+            )],
             end,
         ));
     }
@@ -2054,8 +2069,8 @@ fn parse_angle(
         let text: String = inner.iter().collect();
         return Some((
             vec![Inline::RawInline(
-                Format("html".to_string()),
-                format!("<?php {text} ?>"),
+                Format("html".to_string().into()),
+                format!("<?php {text} ?>").into(),
             )],
             end,
         ));
@@ -2102,10 +2117,10 @@ fn angle_email(chars: &[char], start: usize) -> Option<(Inline, usize)> {
     Some((
         Inline::Link(
             Box::default(),
-            vec![Inline::Str(inner)],
+            vec![Inline::Str(inner.into())],
             Box::new(Target {
-                url,
-                title: String::new(),
+                url: url.into(),
+                title: carta_ast::Text::default(),
             }),
         ),
         j + 1,

--- a/crates/carta-readers/src/dokuwiki.rs
+++ b/crates/carta-readers/src/dokuwiki.rs
@@ -473,11 +473,10 @@ fn parse_raw_region(chars: &[char], start: usize) -> Option<(Block, usize)> {
             };
             Block::CodeBlock(Box::new(attr), content.into())
         }
-        RawKind::Html => Block::RawBlock(Format("html".to_string().into()), content.into()),
-        RawKind::Php => Block::RawBlock(
-            Format("html".to_string().into()),
-            format!("<?php {content} ?>").into(),
-        ),
+        RawKind::Html => Block::RawBlock(Format("html".into()), content.into()),
+        RawKind::Php => {
+            Block::RawBlock(Format("html".into()), format!("<?php {content} ?>").into())
+        }
     };
     Some((block, end))
 }
@@ -1810,7 +1809,7 @@ fn parse_media(chars: &[char], start: usize) -> Option<(Inline, usize)> {
     let trailing_space = spec.ends_with(char::is_whitespace);
     let mut classes = Vec::new();
     if let Some(class) = media_align(leading_space, trailing_space) {
-        classes.push(class.to_string().into());
+        classes.push(class.into());
     }
 
     let spec = spec.trim();
@@ -1826,7 +1825,7 @@ fn parse_media(chars: &[char], start: usize) -> Option<(Inline, usize)> {
     // An explicit but empty caption falls back to the source's auto-display text.
     let alt = match caption {
         Some(text) if !text.trim().is_empty() => tokenize_text(text.trim()),
-        _ if is_external(id) => vec![Inline::Str(id.to_string().into())],
+        _ if is_external(id) => vec![Inline::Str(id.into())],
         _ => vec![Inline::Str(display_id(id).into())],
     };
     let target = Target {
@@ -2058,10 +2057,7 @@ fn parse_angle(
     if let Some((inner, end)) = tag_region(chars, begin, "<html>", "</html>") {
         let text: String = inner.iter().collect();
         return Some((
-            vec![Inline::RawInline(
-                Format("html".to_string().into()),
-                text.into(),
-            )],
+            vec![Inline::RawInline(Format("html".into()), text.into())],
             end,
         ));
     }
@@ -2069,7 +2065,7 @@ fn parse_angle(
         let text: String = inner.iter().collect();
         return Some((
             vec![Inline::RawInline(
-                Format("html".to_string().into()),
+                Format("html".into()),
                 format!("<?php {text} ?>").into(),
             )],
             end,

--- a/crates/carta-readers/src/html/convert.rs
+++ b/crates/carta-readers/src/html/convert.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use carta_ast::{
     Alignment, Attr, Block, Caption, Cell, ColSpec, ColWidth, Format, Inline, ListAttributes,
     ListNumberDelim, ListNumberStyle, MathType, MetaValue, QuoteType, Row, Table, TableBody,
-    TableFoot, TableHead, Target, slug, slug_gfm, to_plain_text,
+    TableFoot, TableHead, Target, ToCompactString, slug, slug_gfm, to_plain_text,
 };
 use carta_core::{Extension, Extensions};
 
@@ -312,7 +312,7 @@ impl Converter {
             let mut code_attr = extract_attr(code, &[]);
             for class in &mut code_attr.classes {
                 if let Some(rest) = class.strip_prefix("language-") {
-                    *class = rest.to_string().into();
+                    *class = rest.into();
                 }
             }
             merge_attr(&mut attr, code_attr);
@@ -605,7 +605,7 @@ impl Converter {
                     let attr = Attr {
                         id: carta_ast::Text::default(),
                         classes: Vec::new(),
-                        attributes: vec![("dir".to_string().into(), dir.into())],
+                        attributes: vec![("dir".into(), dir.into())],
                     };
                     out.push(Inline::Span(Box::new(attr), inner));
                 } else {
@@ -622,7 +622,7 @@ impl Converter {
             InlineKind::Image => out.push(image(e)),
             InlineKind::Style => {
                 out.push(Inline::RawInline(
-                    Format("html".to_string().into()),
+                    Format("html".into()),
                     serialize_element(e).into(),
                 ));
             }
@@ -638,13 +638,13 @@ impl Converter {
                     } else {
                         '\u{2610}'
                     };
-                    out.push(Inline::Str(symbol.to_string().into()));
+                    out.push(Inline::Str(symbol.to_compact_string()));
                     out.push(Inline::Space);
                 }
             }
             InlineKind::Transparent => {
                 if self.preserve_unknown_tags && block_kind(&e.name).is_none() {
-                    let format = Format("html".to_string().into());
+                    let format = Format("html".into());
                     if e.end_only {
                         out.push(Inline::RawInline(format, close_tag(&e.name).into()));
                     } else {
@@ -670,7 +670,7 @@ impl Converter {
     fn code_inline(&self, out: &mut Vec<Inline>, e: &Element, forced_class: Option<&str>) {
         let mut attr = extract_attr(e, &[]);
         if let Some(class) = forced_class {
-            attr.classes = vec![class.to_string().into()];
+            attr.classes = vec![class.into()];
         }
         let has_elements = e
             .children
@@ -1332,7 +1332,7 @@ fn push_str(out: &mut Vec<Inline>, word: &str) {
     if let Some(Inline::Str(existing)) = out.last_mut() {
         existing.push_str(word);
     } else {
-        out.push(Inline::Str(word.to_string().into()));
+        out.push(Inline::Str(word.into()));
     }
 }
 

--- a/crates/carta-readers/src/html/convert.rs
+++ b/crates/carta-readers/src/html/convert.rs
@@ -312,7 +312,7 @@ impl Converter {
             let mut code_attr = extract_attr(code, &[]);
             for class in &mut code_attr.classes {
                 if let Some(rest) = class.strip_prefix("language-") {
-                    *class = rest.to_string();
+                    *class = rest.to_string().into();
                 }
             }
             merge_attr(&mut attr, code_attr);
@@ -324,7 +324,7 @@ impl Converter {
         if text.ends_with('\n') {
             text.pop();
         }
-        Block::CodeBlock(Box::new(attr), text)
+        Block::CodeBlock(Box::new(attr), text.into())
     }
 
     fn table(&mut self, e: &Element) -> Block {
@@ -438,7 +438,7 @@ impl Converter {
     fn header_attr(&mut self, e: &Element, inlines: &[Inline]) -> Attr {
         let mut attr = extract_attr(e, &[]);
         if !attr.id.is_empty() {
-            self.used_ids.insert(attr.id.clone());
+            self.used_ids.insert(attr.id.to_string());
         } else if self.ext.contains(Extension::AutoIdentifiers) {
             let plain = to_plain_text(inlines);
             let base = if self.ext.contains(Extension::GfmAutoIdentifiers) {
@@ -451,7 +451,7 @@ impl Converter {
             } else {
                 base
             };
-            attr.id = self.unique_id(base);
+            attr.id = self.unique_id(base).into();
         }
         // `auto_identifiers` off: a heading without an explicit id keeps an empty one.
         attr
@@ -603,9 +603,9 @@ impl Converter {
                 let inner = self.build_inlines(&e.children);
                 if let Some(dir) = attr_value(e, "dir") {
                     let attr = Attr {
-                        id: String::new(),
+                        id: carta_ast::Text::default(),
                         classes: Vec::new(),
-                        attributes: vec![("dir".to_string(), dir)],
+                        attributes: vec![("dir".to_string().into(), dir.into())],
                     };
                     out.push(Inline::Span(Box::new(attr), inner));
                 } else {
@@ -614,7 +614,7 @@ impl Converter {
             }
             InlineKind::SpanClass => {
                 let mut attr = Box::new(extract_attr(e, &[]));
-                attr.classes.insert(0, e.name.clone());
+                attr.classes.insert(0, e.name.clone().into());
                 out.push(Inline::Span(attr, self.build_inlines(&e.children)));
             }
             InlineKind::Code(class) => self.code_inline(out, e, class),
@@ -622,13 +622,13 @@ impl Converter {
             InlineKind::Image => out.push(image(e)),
             InlineKind::Style => {
                 out.push(Inline::RawInline(
-                    Format("html".to_string()),
-                    serialize_element(e),
+                    Format("html".to_string().into()),
+                    serialize_element(e).into(),
                 ));
             }
             InlineKind::Script => {
                 if let Some(math_type) = math_script_type(e) {
-                    out.push(Inline::Math(math_type, collect_text(e)));
+                    out.push(Inline::Math(math_type, collect_text(e).into()));
                 }
             }
             InlineKind::Input => {
@@ -638,23 +638,23 @@ impl Converter {
                     } else {
                         '\u{2610}'
                     };
-                    out.push(Inline::Str(symbol.to_string()));
+                    out.push(Inline::Str(symbol.to_string().into()));
                     out.push(Inline::Space);
                 }
             }
             InlineKind::Transparent => {
                 if self.preserve_unknown_tags && block_kind(&e.name).is_none() {
-                    let format = Format("html".to_string());
+                    let format = Format("html".to_string().into());
                     if e.end_only {
-                        out.push(Inline::RawInline(format, close_tag(&e.name)));
+                        out.push(Inline::RawInline(format, close_tag(&e.name).into()));
                     } else {
-                        out.push(Inline::RawInline(format.clone(), open_tag(e)));
+                        out.push(Inline::RawInline(format.clone(), open_tag(e).into()));
                         if !e.void {
                             for child in &e.children {
                                 self.append_inline(out, child);
                             }
                             if e.closed {
-                                out.push(Inline::RawInline(format, close_tag(&e.name)));
+                                out.push(Inline::RawInline(format, close_tag(&e.name).into()));
                             }
                         }
                     }
@@ -670,7 +670,7 @@ impl Converter {
     fn code_inline(&self, out: &mut Vec<Inline>, e: &Element, forced_class: Option<&str>) {
         let mut attr = extract_attr(e, &[]);
         if let Some(class) = forced_class {
-            attr.classes = vec![class.to_string()];
+            attr.classes = vec![class.to_string().into()];
         }
         let has_elements = e
             .children
@@ -682,7 +682,7 @@ impl Converter {
             self.in_code.set(previous);
             codify(out, inner, &attr);
         } else {
-            out.push(Inline::Code(Box::new(attr), collect_text(e)));
+            out.push(Inline::Code(Box::new(attr), collect_text(e).into()));
         }
     }
 
@@ -698,7 +698,7 @@ impl Converter {
         if attr.id.is_empty()
             && let Some(name) = attr_value(e, "name")
         {
-            attr.id = name;
+            attr.id = name.into();
         }
         if let Some(lead) = leading {
             out.push(lead);
@@ -708,7 +708,10 @@ impl Converter {
             Inline::Link(
                 Box::new(attr),
                 trimmed,
-                Box::new(Target { url: href, title }),
+                Box::new(Target {
+                    url: href.into(),
+                    title: title.into(),
+                }),
             )
         } else {
             Inline::Span(Box::new(attr), trimmed)
@@ -727,7 +730,10 @@ fn codify(out: &mut Vec<Inline>, inlines: Vec<Inline>, attr: &Attr) {
     let mut run = String::new();
     let flush = |run: &mut String, out: &mut Vec<Inline>| {
         if !run.is_empty() {
-            out.push(Inline::Code(Box::new(attr.clone()), std::mem::take(run)));
+            out.push(Inline::Code(
+                Box::new(attr.clone()),
+                std::mem::take(run).into(),
+            ));
         }
     };
     for inline in inlines {
@@ -853,7 +859,7 @@ fn resolve_smart(items: &[Item], lo: usize, hi: usize) -> Vec<Inline> {
         match items.get(i) {
             Some(Item::Math(math_type, content)) => {
                 flush_run(&mut buf, &mut out);
-                out.push(Inline::Math(math_type.clone(), content.clone()));
+                out.push(Inline::Math(math_type.clone(), content.clone().into()));
                 i += 1;
             }
             Some(Item::Lit('"')) => {
@@ -915,7 +921,7 @@ fn emit_math_only(items: &[Item], out: &mut Vec<Inline>) {
                     push_text(out, &buf);
                     buf.clear();
                 }
-                out.push(Inline::Math(math_type.clone(), content.clone()));
+                out.push(Inline::Math(math_type.clone(), content.clone().into()));
             }
             Item::Lit(c) => buf.push(*c),
         }
@@ -951,7 +957,7 @@ fn emit_code(items: &[Item], smart: bool, out: &mut Vec<Inline>) {
                     push_str(out, &result);
                     result.clear();
                 }
-                out.push(Inline::Math(math_type.clone(), content.clone()));
+                out.push(Inline::Math(math_type.clone(), content.clone().into()));
                 i += 1;
             }
             Some(Item::Lit('"')) if smart => {
@@ -1219,7 +1225,10 @@ fn image(e: &Element) -> Inline {
     Inline::Image(
         Box::new(attr),
         inlines_from_text(&alt),
-        Box::new(Target { url, title }),
+        Box::new(Target {
+            url: url.into(),
+            title: title.into(),
+        }),
     )
 }
 
@@ -1230,11 +1239,11 @@ fn extract_attr(e: &Element, exclude: &[&str]) -> Attr {
             continue;
         }
         match key.as_str() {
-            "id" => attr.id.clone_from(value),
-            "class" => attr.classes = value.split_whitespace().map(str::to_string).collect(),
+            "id" => attr.id = value.as_str().into(),
+            "class" => attr.classes = value.split_whitespace().map(Into::into).collect(),
             _ => {
                 let name = key.strip_prefix("data-").unwrap_or(key).to_string();
-                attr.attributes.push((name, value.clone()));
+                attr.attributes.push((name.into(), value.clone().into()));
             }
         }
     }
@@ -1249,7 +1258,7 @@ fn is_line_block_div(e: &Element) -> bool {
 fn div_attr(e: &Element, sectioning: bool) -> Attr {
     let mut attr = extract_attr(e, &[]);
     if sectioning {
-        attr.classes.insert(0, e.name.clone());
+        attr.classes.insert(0, e.name.clone().into());
     }
     attr
 }
@@ -1304,7 +1313,7 @@ fn push_text(out: &mut Vec<Inline>, text: &str) {
             push_break(out, newline);
         } else {
             if !matches!(out.last(), Some(Inline::Str(_))) {
-                out.push(Inline::Str(String::new()));
+                out.push(Inline::Str(carta_ast::Text::default()));
             }
             if let Some(Inline::Str(existing)) = out.last_mut() {
                 while let Some(&w) = chars.peek() {
@@ -1323,7 +1332,7 @@ fn push_str(out: &mut Vec<Inline>, word: &str) {
     if let Some(Inline::Str(existing)) = out.last_mut() {
         existing.push_str(word);
     } else {
-        out.push(Inline::Str(word.to_string()));
+        out.push(Inline::Str(word.to_string().into()));
     }
 }
 

--- a/crates/carta-readers/src/html/mod.rs
+++ b/crates/carta-readers/src/html/mod.rs
@@ -48,7 +48,7 @@ fn parse(input: &str, ext: Extensions) -> Document {
     let meta = head.map(extract_meta).unwrap_or_default();
     let blocks = converter.blocks(&body, false);
     Document {
-        meta,
+        meta: meta.into_iter().map(|(k, v)| (k.into(), v)).collect(),
         blocks,
         ..Document::default()
     }
@@ -189,8 +189,8 @@ mod tests {
         let Some(Block::Para(inlines)) = result.first() else {
             panic!("expected paragraph");
         };
-        assert!(inlines.contains(&Inline::Str("&".to_string())));
-        assert!(inlines.contains(&Inline::Str("\u{a9}".to_string())));
+        assert!(inlines.contains(&Inline::Str("&".to_string().into())));
+        assert!(inlines.contains(&Inline::Str("\u{a9}".to_string().into())));
     }
 
     #[test]
@@ -199,7 +199,7 @@ mod tests {
         let Some(Block::Para(inlines)) = result.first() else {
             panic!("expected paragraph");
         };
-        assert_eq!(inlines.as_slice(), [Inline::Str("ab".to_string())]);
+        assert_eq!(inlines.as_slice(), [Inline::Str("ab".to_string().into())]);
     }
 
     #[test]
@@ -238,9 +238,9 @@ mod tests {
         assert_eq!(
             inlines.as_slice(),
             [
-                Inline::Str("a".to_string()),
+                Inline::Str("a".to_string().into()),
                 Inline::SoftBreak,
-                Inline::Str("b".to_string())
+                Inline::Str("b".to_string().into())
             ]
         );
     }
@@ -293,7 +293,7 @@ mod tests {
             panic!("expected definition list");
         };
         let (term, defs) = items.into_iter().next().expect("an item");
-        assert_eq!(term, vec![Inline::Str("term".to_string())]);
+        assert_eq!(term, vec![Inline::Str("term".to_string().into())]);
         assert_eq!(defs.len(), 2);
     }
 
@@ -310,7 +310,7 @@ mod tests {
         let Block::Div(attr, _) = first_block("<section><p>x</p></section>") else {
             panic!("expected div");
         };
-        assert!(attr.classes.contains(&"section".to_string()));
+        assert!(attr.classes.contains(&"section".into()));
     }
 
     #[test]
@@ -421,7 +421,7 @@ mod tests {
         let classes: Vec<&str> = inlines
             .iter()
             .filter_map(|inline| match inline {
-                Inline::Span(attr, _) => attr.classes.first().map(String::as_str),
+                Inline::Span(attr, _) => attr.classes.first().map(carta_ast::Text::as_str),
                 _ => None,
             })
             .collect();
@@ -434,7 +434,9 @@ mod tests {
         let classes: Vec<Vec<String>> = inlines
             .iter()
             .filter_map(|inline| match inline {
-                Inline::Code(attr, _) => Some(attr.classes.clone()),
+                Inline::Code(attr, _) => {
+                    Some(attr.classes.iter().map(ToString::to_string).collect())
+                }
                 _ => None,
             })
             .collect();
@@ -463,11 +465,11 @@ mod tests {
         assert_eq!(
             *target,
             Box::new(Target {
-                url: "/u".to_string(),
-                title: "T".to_string()
+                url: "/u".to_string().into(),
+                title: "T".to_string().into()
             })
         );
-        assert!(attr.classes.contains(&"x".to_string()));
+        assert!(attr.classes.contains(&"x".into()));
     }
 
     #[test]
@@ -490,9 +492,9 @@ mod tests {
         assert_eq!(
             alt.as_slice(),
             [
-                Inline::Str("alt".to_string()),
+                Inline::Str("alt".to_string().into()),
                 Inline::Space,
-                Inline::Str("text".to_string())
+                Inline::Str("text".to_string().into())
             ]
         );
     }
@@ -500,7 +502,7 @@ mod tests {
     #[test]
     fn unknown_inline_element_is_transparent() {
         let inlines = para_inlines("<p>a<bogus>b</bogus>c</p>");
-        assert_eq!(inlines.as_slice(), [Inline::Str("abc".to_string())]);
+        assert_eq!(inlines.as_slice(), [Inline::Str("abc".to_string().into())]);
     }
 
     #[test]
@@ -511,7 +513,7 @@ mod tests {
         assert_eq!(attr.id, "d");
         assert!(
             attr.attributes
-                .contains(&("role".to_string(), "note".to_string()))
+                .contains(&("role".to_string().into(), "note".to_string().into()))
         );
     }
 
@@ -527,13 +529,19 @@ mod tests {
     #[test]
     fn numeric_and_named_references_decode() {
         let inlines = para_inlines("<p>&#65;&#x42;&#X43;&copy</p>");
-        assert_eq!(inlines.as_slice(), [Inline::Str("ABC\u{a9}".to_string())]);
+        assert_eq!(
+            inlines.as_slice(),
+            [Inline::Str("ABC\u{a9}".to_string().into())]
+        );
     }
 
     #[test]
     fn unknown_entity_is_left_verbatim() {
         let inlines = para_inlines("<p>&notreal;</p>");
-        assert_eq!(inlines.as_slice(), [Inline::Str("&notreal;".to_string())]);
+        assert_eq!(
+            inlines.as_slice(),
+            [Inline::Str("&notreal;".to_string().into())]
+        );
     }
 
     #[test]
@@ -554,7 +562,7 @@ mod tests {
     #[test]
     fn cdata_and_processing_instructions_are_skipped() {
         let inlines = para_inlines("<p>a<![CDATA[ junk ]]><?pi here?>b</p>");
-        assert_eq!(inlines.as_slice(), [Inline::Str("ab".to_string())]);
+        assert_eq!(inlines.as_slice(), [Inline::Str("ab".to_string().into())]);
     }
 
     #[test]
@@ -704,7 +712,7 @@ mod tests {
     #[test]
     fn checkbox_outside_item_is_dropped() {
         let inlines = para_inlines(r#"<p><input type="checkbox"/>text</p>"#);
-        assert_eq!(inlines.as_slice(), [Inline::Str("text".to_string())]);
+        assert_eq!(inlines.as_slice(), [Inline::Str("text".to_string().into())]);
     }
 
     #[test]
@@ -759,7 +767,7 @@ mod tests {
         let Some(Block::Para(inlines)) = plain.first() else {
             panic!("expected paragraph");
         };
-        assert_eq!(inlines.as_slice(), [Inline::Str("x".to_string())]);
+        assert_eq!(inlines.as_slice(), [Inline::Str("x".to_string().into())]);
 
         let caps = read_with(
             "<p><span style=\"font-variant: small-caps\">x</span></p>",
@@ -768,7 +776,7 @@ mod tests {
         let Some(Block::Para(inlines)) = caps.first() else {
             panic!("expected paragraph");
         };
-        assert_eq!(inlines.as_slice(), [Inline::Str("x".to_string())]);
+        assert_eq!(inlines.as_slice(), [Inline::Str("x".to_string().into())]);
     }
 
     #[test]
@@ -829,13 +837,13 @@ mod tests {
         assert_eq!(
             inlines.as_slice(),
             [
-                Inline::Str("\"a\"".to_string()),
+                Inline::Str("\"a\"".to_string().into()),
                 Inline::Space,
-                Inline::Str("--".to_string()),
+                Inline::Str("--".to_string().into()),
                 Inline::Space,
-                Inline::Str("...".to_string()),
+                Inline::Str("...".to_string().into()),
                 Inline::Space,
-                Inline::Str("---".to_string()),
+                Inline::Str("---".to_string().into()),
             ]
         );
     }
@@ -848,14 +856,14 @@ mod tests {
             [
                 Inline::Quoted(
                     carta_ast::QuoteType::DoubleQuote,
-                    vec![Inline::Str("a".to_string())]
+                    vec![Inline::Str("a".to_string().into())]
                 ),
                 Inline::Space,
-                Inline::Str("\u{2013}".to_string()),
+                Inline::Str("\u{2013}".to_string().into()),
                 Inline::Space,
-                Inline::Str("\u{2026}".to_string()),
+                Inline::Str("\u{2026}".to_string().into()),
                 Inline::Space,
-                Inline::Str("\u{2014}".to_string()),
+                Inline::Str("\u{2014}".to_string().into()),
             ]
         );
     }
@@ -866,11 +874,11 @@ mod tests {
         assert_eq!(
             inlines.as_slice(),
             [
-                Inline::Str("$x^2$".to_string()),
+                Inline::Str("$x^2$".to_string().into()),
                 Inline::Space,
-                Inline::Str("and".to_string()),
+                Inline::Str("and".to_string().into()),
                 Inline::Space,
-                Inline::Str("$$y$$".to_string()),
+                Inline::Str("$$y$$".to_string().into()),
             ]
         );
     }
@@ -881,11 +889,11 @@ mod tests {
         assert_eq!(
             inlines.as_slice(),
             [
-                Inline::Math(MathType::InlineMath, "x^2".to_string()),
+                Inline::Math(MathType::InlineMath, "x^2".to_string().into()),
                 Inline::Space,
-                Inline::Str("and".to_string()),
+                Inline::Str("and".to_string().into()),
                 Inline::Space,
-                Inline::Math(MathType::DisplayMath, "y".to_string()),
+                Inline::Math(MathType::DisplayMath, "y".to_string().into()),
             ]
         );
     }
@@ -899,11 +907,11 @@ mod tests {
         assert_eq!(
             inlines.as_slice(),
             [
-                Inline::Math(MathType::InlineMath, "x".to_string()),
+                Inline::Math(MathType::InlineMath, "x".to_string().into()),
                 Inline::Space,
-                Inline::Str("and".to_string()),
+                Inline::Str("and".to_string().into()),
                 Inline::Space,
-                Inline::Math(MathType::DisplayMath, "y".to_string()),
+                Inline::Math(MathType::DisplayMath, "y".to_string().into()),
             ]
         );
     }
@@ -917,11 +925,11 @@ mod tests {
         assert_eq!(
             inlines.as_slice(),
             [
-                Inline::Math(MathType::InlineMath, "x".to_string()),
+                Inline::Math(MathType::InlineMath, "x".to_string().into()),
                 Inline::Space,
-                Inline::Str("and".to_string()),
+                Inline::Str("and".to_string().into()),
                 Inline::Space,
-                Inline::Math(MathType::DisplayMath, "y".to_string()),
+                Inline::Math(MathType::DisplayMath, "y".to_string().into()),
             ]
         );
     }
@@ -938,11 +946,11 @@ mod tests {
         assert_eq!(
             result.as_slice(),
             [Block::Plain(vec![
-                Inline::Str("text".to_string()),
+                Inline::Str("text".to_string().into()),
                 Inline::Note(vec![Block::Para(vec![
-                    Inline::Str("the".to_string()),
+                    Inline::Str("the".to_string().into()),
                     Inline::Space,
-                    Inline::Str("note".to_string()),
+                    Inline::Str("note".to_string().into()),
                 ])]),
             ])]
         );
@@ -954,7 +962,7 @@ mod tests {
         assert_eq!(
             result.as_slice(),
             [Block::Plain(vec![
-                Inline::Str("text".to_string()),
+                Inline::Str("text".to_string().into()),
                 Inline::Note(Vec::new()),
             ])]
         );
@@ -964,7 +972,7 @@ mod tests {
         read_with_text_ext(input, added)
             .into_iter()
             .filter_map(|block| match block {
-                Block::Header(_, attr, _) => Some(attr.id),
+                Block::Header(_, attr, _) => Some(attr.id.to_string()),
                 _ => None,
             })
             .collect()
@@ -998,7 +1006,7 @@ mod tests {
         )
         .into_iter()
         .filter_map(|block| match block {
-            Block::Header(_, attr, _) => Some(attr.id),
+            Block::Header(_, attr, _) => Some(attr.id.to_string()),
             _ => None,
         })
         .collect::<Vec<_>>();
@@ -1012,11 +1020,11 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Strong(vec![Inline::Str("a".to_string())]),
+                Inline::Strong(vec![Inline::Str("a".to_string().into())]),
                 Inline::Space,
-                Inline::Str("b".to_string()),
+                Inline::Str("b".to_string().into()),
                 Inline::Space,
-                Inline::Code(Box::default(), "c".to_string()),
+                Inline::Code(Box::default(), "c".to_string().into()),
             ]
         );
     }
@@ -1028,18 +1036,21 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Str("a".to_string()),
+                Inline::Str("a".to_string().into()),
                 Inline::Space,
-                Inline::Str("&".to_string()),
+                Inline::Str("&".to_string().into()),
                 Inline::Space,
-                Inline::Str("b".to_string()),
+                Inline::Str("b".to_string().into()),
             ]
         );
     }
 
     #[cfg(feature = "opml")]
     fn raw(tag: &str) -> Inline {
-        Inline::RawInline(carta_ast::Format("html".to_string()), tag.to_string())
+        Inline::RawInline(
+            carta_ast::Format("html".to_string().into()),
+            tag.to_string().into(),
+        )
     }
 
     #[cfg(feature = "opml")]
@@ -1050,7 +1061,7 @@ mod tests {
             inlines,
             vec![
                 raw("<cite>"),
-                Inline::Str("Book".to_string()),
+                Inline::Str("Book".to_string().into()),
                 raw("</cite>")
             ]
         );
@@ -1064,7 +1075,7 @@ mod tests {
             inlines,
             vec![
                 raw("<time datetime=\"2020\">"),
-                Inline::Str("y".to_string()),
+                Inline::Str("y".to_string().into()),
                 raw("</time>"),
             ]
         );
@@ -1078,7 +1089,7 @@ mod tests {
             inlines,
             vec![
                 raw("<x-foo a=\"1&lt;2&amp;3\" hidden>"),
-                Inline::Str("z".to_string()),
+                Inline::Str("z".to_string().into()),
                 raw("</x-foo>"),
             ]
         );
@@ -1090,7 +1101,11 @@ mod tests {
         let inlines = super::parse_inline_fragment("<CITE>b</CITE>");
         assert_eq!(
             inlines,
-            vec![raw("<cite>"), Inline::Str("b".to_string()), raw("</cite>")]
+            vec![
+                raw("<cite>"),
+                Inline::Str("b".to_string().into()),
+                raw("</cite>")
+            ]
         );
     }
 
@@ -1101,11 +1116,11 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Str("a".to_string()),
+                Inline::Str("a".to_string().into()),
                 Inline::Space,
                 raw("<wbr>"),
                 Inline::Space,
-                Inline::Str("b".to_string()),
+                Inline::Str("b".to_string().into()),
             ]
         );
     }
@@ -1124,10 +1139,10 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Str("a".to_string()),
+                Inline::Str("a".to_string().into()),
                 Inline::Space,
                 raw("<cite>"),
-                Inline::Str("open-only".to_string()),
+                Inline::Str("open-only".to_string().into()),
             ]
         );
     }
@@ -1141,7 +1156,7 @@ mod tests {
             vec![
                 raw("</cite>"),
                 Inline::Space,
-                Inline::Str("tail".to_string()),
+                Inline::Str("tail".to_string().into()),
             ]
         );
     }
@@ -1154,7 +1169,7 @@ mod tests {
             inlines,
             vec![
                 raw("<cite>"),
-                Inline::Emph(vec![Inline::Str("x".to_string())]),
+                Inline::Emph(vec![Inline::Str("x".to_string().into())]),
                 raw("</cite>"),
             ]
         );
@@ -1167,11 +1182,11 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Emph(vec![Inline::Str("e".to_string())]),
+                Inline::Emph(vec![Inline::Str("e".to_string().into())]),
                 Inline::Space,
-                Inline::Strong(vec![Inline::Str("s".to_string())]),
+                Inline::Strong(vec![Inline::Str("s".to_string().into())]),
                 Inline::Space,
-                Inline::Superscript(vec![Inline::Str("2".to_string())]),
+                Inline::Superscript(vec![Inline::Str("2".to_string().into())]),
             ]
         );
     }

--- a/crates/carta-readers/src/html/table.rs
+++ b/crates/carta-readers/src/html/table.rs
@@ -56,7 +56,7 @@ pub(super) fn normalize_cell_style(attr: &mut Attr) {
     if declarations.is_empty() {
         attr.attributes.remove(index);
     } else if let Some(entry) = attr.attributes.get_mut(index) {
-        entry.1 = declarations.join("; ");
+        entry.1 = declarations.join("; ").into();
     }
 }
 

--- a/crates/carta-readers/src/ipynb.rs
+++ b/crates/carta-readers/src/ipynb.rs
@@ -24,7 +24,9 @@
 
 use std::collections::BTreeMap;
 
-use carta_ast::{ApiVersion, Attr, Block, Document, Format, Inline, MetaValue, Target};
+use carta_ast::{
+    ApiVersion, Attr, Block, Document, Format, Inline, MetaValue, Target, ToCompactString,
+};
 use carta_core::{Error, Reader, ReaderOptions, Result};
 use serde_json::Value;
 
@@ -92,11 +94,11 @@ fn build_meta(notebook: &Value, nbformat: i64, nbformat_minor: i64) -> BTreeMap<
     }
     jupyter.insert(
         "nbformat".to_owned(),
-        MetaValue::MetaString(nbformat.to_string().into()),
+        MetaValue::MetaString(nbformat.to_compact_string()),
     );
     jupyter.insert(
         "nbformat_minor".to_owned(),
-        MetaValue::MetaString(nbformat_minor.to_string().into()),
+        MetaValue::MetaString(nbformat_minor.to_compact_string()),
     );
     let mut meta = BTreeMap::new();
     meta.insert(
@@ -362,7 +364,7 @@ fn code_cell_blocks(cell: &Value, language: &str) -> Vec<Block> {
     let source = multiline_text(cell.get("source"));
     let source_attr = Attr {
         id: carta_ast::Text::default(),
-        classes: vec![language.to_owned().into()],
+        classes: vec![language.into()],
         attributes: Vec::new(),
     };
     let mut blocks = vec![Block::CodeBlock(Box::new(source_attr), source.into())];
@@ -411,11 +413,7 @@ fn stream_output(output: &Value) -> Block {
     let text = strip_ansi(&multiline_text(output.get("text")));
     let attr = Attr {
         id: carta_ast::Text::default(),
-        classes: vec![
-            "output".to_owned().into(),
-            "stream".to_owned().into(),
-            name.to_owned().into(),
-        ],
+        classes: vec!["output".into(), "stream".into(), name.into()],
         attributes: Vec::new(),
     };
     Block::Div(
@@ -438,7 +436,7 @@ fn result_output(output: &Value, is_result: bool) -> Block {
     }
     let attr = Attr {
         id: carta_ast::Text::default(),
-        classes: vec!["output".to_owned().into(), kind.to_owned().into()],
+        classes: vec!["output".into(), kind.into()],
         attributes: attributes
             .into_iter()
             .map(|(k, v)| (k.into(), v.into()))
@@ -477,10 +475,10 @@ fn error_output(output: &Value) -> Block {
     };
     let attr = Attr {
         id: carta_ast::Text::default(),
-        classes: vec!["output".to_owned().into(), "error".to_owned().into()],
+        classes: vec!["output".into(), "error".into()],
         attributes: vec![
-            ("ename".to_owned().into(), ename.into()),
-            ("evalue".to_owned().into(), evalue.into()),
+            ("ename".into(), ename.into()),
+            ("evalue".into(), evalue.into()),
         ],
     };
     Block::Div(
@@ -523,23 +521,17 @@ fn non_image_block(mime: &str, value: &Value) -> Block {
         return Block::CodeBlock(
             Box::new(Attr {
                 id: carta_ast::Text::default(),
-                classes: vec!["json".to_owned().into()],
+                classes: vec!["json".into()],
                 attributes: Vec::new(),
             }),
             json_render(value).into(),
         );
     }
     match mime {
-        "text/html" => Block::RawBlock(
-            Format("html".to_owned().into()),
-            multiline_text(Some(value)).into(),
-        ),
-        "text/latex" => Block::RawBlock(
-            Format("latex".to_owned().into()),
-            multiline_text(Some(value)).into(),
-        ),
+        "text/html" => Block::RawBlock(Format("html".into()), multiline_text(Some(value)).into()),
+        "text/latex" => Block::RawBlock(Format("latex".into()), multiline_text(Some(value)).into()),
         "text/markdown" => Block::RawBlock(
-            Format("markdown".to_owned().into()),
+            Format("markdown".into()),
             multiline_text(Some(value)).into(),
         ),
         // The fallthrough is plain text; the preference list only routes the cases above here.
@@ -739,7 +731,7 @@ fn strip_attachment_inlines(inlines: &mut [Inline], prefix: Option<&str>) {
                 if let Some(bare) = target.url.strip_prefix("attachment:") {
                     target.url = match prefix {
                         Some(prefix) => format!("{prefix}{bare}").into(),
-                        None => bare.to_owned().into(),
+                        None => bare.into(),
                     };
                 }
                 strip_attachment_inlines(alt, prefix);

--- a/crates/carta-readers/src/ipynb.rs
+++ b/crates/carta-readers/src/ipynb.rs
@@ -63,7 +63,7 @@ impl Reader for IpynbReader {
         }
         Ok(Document {
             api_version: ApiVersion::default(),
-            meta,
+            meta: meta.into_iter().map(|(k, v)| (k.into(), v)).collect(),
             blocks,
         })
     }
@@ -92,14 +92,17 @@ fn build_meta(notebook: &Value, nbformat: i64, nbformat_minor: i64) -> BTreeMap<
     }
     jupyter.insert(
         "nbformat".to_owned(),
-        MetaValue::MetaString(nbformat.to_string()),
+        MetaValue::MetaString(nbformat.to_string().into()),
     );
     jupyter.insert(
         "nbformat_minor".to_owned(),
-        MetaValue::MetaString(nbformat_minor.to_string()),
+        MetaValue::MetaString(nbformat_minor.to_string().into()),
     );
     let mut meta = BTreeMap::new();
-    meta.insert("jupyter".to_owned(), MetaValue::MetaMap(jupyter));
+    meta.insert(
+        "jupyter".to_owned(),
+        MetaValue::MetaMap(jupyter.into_iter().map(|(k, v)| (k.into(), v)).collect()),
+    );
     meta
 }
 
@@ -110,14 +113,14 @@ fn build_meta(notebook: &Value, nbformat: i64, nbformat_minor: i64) -> BTreeMap<
 /// large magnitudes.
 fn meta_value(value: &Value) -> MetaValue {
     match value {
-        Value::Null => MetaValue::MetaString(String::new()),
+        Value::Null => MetaValue::MetaString(carta_ast::Text::default()),
         Value::Bool(flag) => MetaValue::MetaBool(*flag),
-        Value::Number(number) => MetaValue::MetaString(meta_number(number)),
-        Value::String(text) => MetaValue::MetaString(text.clone()),
+        Value::Number(number) => MetaValue::MetaString(meta_number(number).into()),
+        Value::String(text) => MetaValue::MetaString(text.clone().into()),
         Value::Array(items) => MetaValue::MetaList(items.iter().map(meta_value).collect()),
         Value::Object(map) => MetaValue::MetaMap(
             map.iter()
-                .map(|(key, value)| (key.clone(), meta_value(value)))
+                .map(|(key, value)| (key.clone().into(), meta_value(value)))
                 .collect(),
         ),
     }
@@ -301,9 +304,12 @@ fn cell_attr(cell: &Value, kind: &str) -> Attr {
         }
     }
     Attr {
-        id,
-        classes,
-        attributes,
+        id: id.into(),
+        classes: classes.into_iter().map(Into::into).collect(),
+        attributes: attributes
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect(),
     }
 }
 
@@ -355,11 +361,11 @@ fn markdown_cell_blocks(cell: &Value, options: &ReaderOptions) -> Result<Vec<Blo
 fn code_cell_blocks(cell: &Value, language: &str) -> Vec<Block> {
     let source = multiline_text(cell.get("source"));
     let source_attr = Attr {
-        id: String::new(),
-        classes: vec![language.to_owned()],
+        id: carta_ast::Text::default(),
+        classes: vec![language.to_owned().into()],
         attributes: Vec::new(),
     };
-    let mut blocks = vec![Block::CodeBlock(Box::new(source_attr), source)];
+    let mut blocks = vec![Block::CodeBlock(Box::new(source_attr), source.into())];
     if let Some(Value::Array(outputs)) = cell.get("outputs") {
         for output in outputs {
             if let Some(block) = output_to_block(output) {
@@ -381,7 +387,7 @@ fn raw_cell_block(cell: &Value) -> Block {
         .or_else(|| metadata.and_then(|metadata| metadata.get("format")))
         .and_then(Value::as_str);
     let format = mime.map_or_else(|| "ipynb".to_owned(), format_from_mime);
-    Block::RawBlock(Format(format), source)
+    Block::RawBlock(Format(format.into()), source.into())
 }
 
 /// Convert one execution output into its `Div`, or `None` for an unrecognized output kind.
@@ -404,11 +410,18 @@ fn stream_output(output: &Value) -> Block {
         .unwrap_or("stdout");
     let text = strip_ansi(&multiline_text(output.get("text")));
     let attr = Attr {
-        id: String::new(),
-        classes: vec!["output".to_owned(), "stream".to_owned(), name.to_owned()],
+        id: carta_ast::Text::default(),
+        classes: vec![
+            "output".to_owned().into(),
+            "stream".to_owned().into(),
+            name.to_owned().into(),
+        ],
         attributes: Vec::new(),
     };
-    Block::Div(Box::new(attr), vec![Block::CodeBlock(Box::default(), text)])
+    Block::Div(
+        Box::new(attr),
+        vec![Block::CodeBlock(Box::default(), text.into())],
+    )
 }
 
 /// An `execute_result` or `display_data` output: the richest renderable bundle from its `data`,
@@ -424,9 +437,12 @@ fn result_output(output: &Value, is_result: bool) -> Block {
         attributes.push(("execution_count".to_owned(), count.to_string()));
     }
     let attr = Attr {
-        id: String::new(),
-        classes: vec!["output".to_owned(), kind.to_owned()],
-        attributes,
+        id: carta_ast::Text::default(),
+        classes: vec!["output".to_owned().into(), kind.to_owned().into()],
+        attributes: attributes
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect(),
     };
     Block::Div(
         Box::new(attr),
@@ -460,13 +476,19 @@ fn error_output(output: &Value) -> Block {
         _ => String::new(),
     };
     let attr = Attr {
-        id: String::new(),
-        classes: vec!["output".to_owned(), "error".to_owned()],
-        attributes: vec![("ename".to_owned(), ename), ("evalue".to_owned(), evalue)],
+        id: carta_ast::Text::default(),
+        classes: vec!["output".to_owned().into(), "error".to_owned().into()],
+        attributes: vec![
+            ("ename".to_owned().into(), ename.into()),
+            ("evalue".to_owned().into(), evalue.into()),
+        ],
     };
     Block::Div(
         Box::new(attr),
-        vec![Block::CodeBlock(Box::default(), strip_ansi(&traceback))],
+        vec![Block::CodeBlock(
+            Box::default(),
+            strip_ansi(&traceback).into(),
+        )],
     )
 }
 
@@ -500,21 +522,31 @@ fn non_image_block(mime: &str, value: &Value) -> Block {
     if is_json_like(mime) {
         return Block::CodeBlock(
             Box::new(Attr {
-                id: String::new(),
-                classes: vec!["json".to_owned()],
+                id: carta_ast::Text::default(),
+                classes: vec!["json".to_owned().into()],
                 attributes: Vec::new(),
             }),
-            json_render(value),
+            json_render(value).into(),
         );
     }
     match mime {
-        "text/html" => Block::RawBlock(Format("html".to_owned()), multiline_text(Some(value))),
-        "text/latex" => Block::RawBlock(Format("latex".to_owned()), multiline_text(Some(value))),
-        "text/markdown" => {
-            Block::RawBlock(Format("markdown".to_owned()), multiline_text(Some(value)))
-        }
+        "text/html" => Block::RawBlock(
+            Format("html".to_owned().into()),
+            multiline_text(Some(value)).into(),
+        ),
+        "text/latex" => Block::RawBlock(
+            Format("latex".to_owned().into()),
+            multiline_text(Some(value)).into(),
+        ),
+        "text/markdown" => Block::RawBlock(
+            Format("markdown".to_owned().into()),
+            multiline_text(Some(value)).into(),
+        ),
         // The fallthrough is plain text; the preference list only routes the cases above here.
-        _ => Block::CodeBlock(Box::default(), strip_ansi(&multiline_text(Some(value)))),
+        _ => Block::CodeBlock(
+            Box::default(),
+            strip_ansi(&multiline_text(Some(value))).into(),
+        ),
     }
 }
 
@@ -534,8 +566,8 @@ fn image_block(mime: &str, value: &Value, metadata: Option<&Value>) -> Block {
         Box::new(image_attr(mime, metadata)),
         Vec::new(),
         Box::new(Target {
-            url: name,
-            title: String::new(),
+            url: name.into(),
+            title: carta_ast::Text::default(),
         }),
     )])
 }
@@ -552,9 +584,12 @@ fn image_attr(mime: &str, metadata: Option<&Value>) -> Attr {
         }
     }
     Attr {
-        id: String::new(),
+        id: carta_ast::Text::default(),
         classes: Vec::new(),
-        attributes,
+        attributes: attributes
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect(),
     }
 }
 
@@ -703,8 +738,8 @@ fn strip_attachment_inlines(inlines: &mut [Inline], prefix: Option<&str>) {
             Inline::Image(_, alt, target) => {
                 if let Some(bare) = target.url.strip_prefix("attachment:") {
                     target.url = match prefix {
-                        Some(prefix) => format!("{prefix}{bare}"),
-                        None => bare.to_owned(),
+                        Some(prefix) => format!("{prefix}{bare}").into(),
+                        None => bare.to_owned().into(),
                     };
                 }
                 strip_attachment_inlines(alt, prefix);
@@ -879,7 +914,7 @@ mod tests {
         IpynbReader.read(input, &options).expect("notebook parses")
     }
 
-    fn jupyter(document: &Document) -> &BTreeMap<String, MetaValue> {
+    fn jupyter(document: &Document) -> &BTreeMap<carta_ast::Text, MetaValue> {
         match document.meta.get("jupyter") {
             Some(MetaValue::MetaMap(map)) => map,
             _ => panic!("expected a jupyter metadata map"),
@@ -915,11 +950,11 @@ mod tests {
         let map = jupyter(&document);
         assert_eq!(
             map.get("nbformat"),
-            Some(&MetaValue::MetaString("4".to_owned()))
+            Some(&MetaValue::MetaString("4".to_owned().into()))
         );
         assert_eq!(
             map.get("nbformat_minor"),
-            Some(&MetaValue::MetaString("5".to_owned()))
+            Some(&MetaValue::MetaString("5".to_owned().into()))
         );
     }
 
@@ -928,7 +963,7 @@ mod tests {
         let document = read(r#"{"cells": [], "metadata": {}, "nbformat": 4}"#);
         assert_eq!(
             jupyter(&document).get("nbformat_minor"),
-            Some(&MetaValue::MetaString("0".to_owned()))
+            Some(&MetaValue::MetaString("0".to_owned().into()))
         );
     }
 
@@ -942,23 +977,23 @@ mod tests {
         let map = jupyter(&document);
         assert_eq!(
             map.get("afloat"),
-            Some(&MetaValue::MetaString("3".to_owned()))
+            Some(&MetaValue::MetaString("3".to_owned().into()))
         );
         assert_eq!(
             map.get("aint"),
-            Some(&MetaValue::MetaString("7".to_owned()))
+            Some(&MetaValue::MetaString("7".to_owned().into()))
         );
         assert_eq!(map.get("abool"), Some(&MetaValue::MetaBool(true)));
         assert_eq!(
             map.get("anull"),
-            Some(&MetaValue::MetaString(String::new()))
+            Some(&MetaValue::MetaString(carta_ast::Text::default()))
         );
         assert_eq!(
             map.get("alist"),
             Some(&MetaValue::MetaList(vec![
-                MetaValue::MetaString("1".to_owned()),
-                MetaValue::MetaString("two".to_owned()),
-                MetaValue::MetaString("3".to_owned()),
+                MetaValue::MetaString("1".to_owned().into()),
+                MetaValue::MetaString("two".to_owned().into()),
+                MetaValue::MetaString("3".to_owned().into()),
             ]))
         );
         let Some(MetaValue::MetaMap(nested)) = map.get("amap") else {
@@ -966,11 +1001,11 @@ mod tests {
         };
         assert_eq!(
             nested.get("a"),
-            Some(&MetaValue::MetaString("2".to_owned()))
+            Some(&MetaValue::MetaString("2".to_owned().into()))
         );
         assert_eq!(
             nested.get("z"),
-            Some(&MetaValue::MetaString("1".to_owned()))
+            Some(&MetaValue::MetaString("1".to_owned().into()))
         );
     }
 
@@ -1073,8 +1108,8 @@ mod tests {
         assert_eq!(
             attr.attributes,
             vec![
-                ("execution_count".to_owned(), "5".to_owned()),
-                ("scrolled".to_owned(), "true".to_owned()),
+                ("execution_count".into(), "5".into()),
+                ("scrolled".into(), "true".into()),
             ]
         );
         // Source code block tagged with the language.
@@ -1111,7 +1146,7 @@ mod tests {
         );
         assert_eq!(
             result_attr.attributes,
-            vec![("execution_count".to_owned(), "5".to_owned())]
+            vec![("execution_count".into(), "5".into())]
         );
         assert!(matches!(
             result_body.first(),
@@ -1124,10 +1159,7 @@ mod tests {
         };
         assert_eq!(
             error_attr.attributes,
-            vec![
-                ("ename".to_owned(), "E".to_owned()),
-                ("evalue".to_owned(), "v".to_owned()),
-            ]
+            vec![("ename".into(), "E".into()), ("evalue".into(), "v".into()),]
         );
         assert!(matches!(
             error_body.first(),
@@ -1233,9 +1265,9 @@ mod tests {
         assert_eq!(
             attr.attributes,
             vec![
-                ("height".to_owned(), "50".to_owned()),
-                ("needs_background".to_owned(), "light".to_owned()),
-                ("width".to_owned(), "100".to_owned()),
+                ("height".into(), "50".into()),
+                ("needs_background".into(), "light".into()),
+                ("width".into(), "100".into()),
             ]
         );
     }
@@ -1270,10 +1302,7 @@ mod tests {
         let Some(Block::Div(attr, body)) = document.blocks.first() else {
             panic!("expected a raw cell div");
         };
-        assert_eq!(
-            attr.attributes,
-            vec![("format".to_owned(), "text/html".to_owned())]
-        );
+        assert_eq!(attr.attributes, vec![("format".into(), "text/html".into())]);
         assert!(matches!(
             body.first(),
             Some(Block::RawBlock(Format(name), text)) if name == "html" && text == "<b>x</b>"

--- a/crates/carta-readers/src/jira.rs
+++ b/crates/carta-readers/src/jira.rs
@@ -9,6 +9,7 @@
 use carta_ast::{
     Alignment, Attr, Block, Caption, Cell, ColSpec, ColWidth, Document, Inline, ListAttributes,
     ListNumberDelim, ListNumberStyle, Row, Table, TableBody, TableFoot, TableHead, Target,
+    ToCompactString,
 };
 use carta_core::{Reader, ReaderOptions, Result};
 
@@ -405,7 +406,7 @@ impl BlockParser<'_> {
         let attr = Attr {
             id: carta_ast::Text::default(),
             classes: Vec::new(),
-            attributes: vec![("color".to_string().into(), value.into())],
+            attributes: vec![("color".into(), value.into())],
         };
         Some(Block::Div(Box::new(attr), inner))
     }
@@ -696,7 +697,7 @@ impl BlockParser<'_> {
             inner.push(Block::Div(
                 Box::new(Attr {
                     id: carta_ast::Text::default(),
-                    classes: vec!["panelheader".to_string().into()],
+                    classes: vec!["panelheader".into()],
                     attributes: Vec::new(),
                 }),
                 vec![Block::Plain(vec![Inline::Strong(plain_inlines(&title))])],
@@ -706,7 +707,7 @@ impl BlockParser<'_> {
         Some(vec![Block::Div(
             Box::new(Attr {
                 id: carta_ast::Text::default(),
-                classes: vec!["panel".to_string().into()],
+                classes: vec!["panel".into()],
                 attributes: attributes
                     .into_iter()
                     .map(|(k, v)| (k.into(), v.into()))
@@ -1439,7 +1440,7 @@ fn finalize(toks: Vec<Tok>) -> Vec<Inline> {
     for tok in toks {
         let inline = match tok {
             Tok::Text(s) => Inline::Str(s.into()),
-            Tok::Delim { marker, .. } => Inline::Str(marker.to_string().into()),
+            Tok::Delim { marker, .. } => Inline::Str(marker.to_compact_string()),
             Tok::Atom(node) => node,
         };
         let inline = match out.last_mut() {
@@ -1655,7 +1656,7 @@ fn parse_brace_inline(
         let attr = Attr {
             id: carta_ast::Text::default(),
             classes: Vec::new(),
-            attributes: vec![("color".to_string().into(), value.into())],
+            attributes: vec![("color".into(), value.into())],
         };
         return Some((Inline::Span(Box::new(attr), inner), close + "{color}".len()));
     }
@@ -1844,7 +1845,7 @@ fn image_properties(props: &str) -> Option<(Attr, String)> {
         return Some((
             Attr {
                 id: carta_ast::Text::default(),
-                classes: vec!["thumbnail".to_string().into()],
+                classes: vec!["thumbnail".into()],
                 attributes: Vec::new(),
             },
             String::new(),

--- a/crates/carta-readers/src/jira.rs
+++ b/crates/carta-readers/src/jira.rs
@@ -403,9 +403,9 @@ impl BlockParser<'_> {
         let close_line_end = self.line_end_from(close_line_start);
         self.pos = next_line_start(close_line_end, self.len());
         let attr = Attr {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             classes: Vec::new(),
-            attributes: vec![("color".to_string(), value)],
+            attributes: vec![("color".to_string().into(), value.into())],
         };
         Some(Block::Div(Box::new(attr), inner))
     }
@@ -571,13 +571,16 @@ impl BlockParser<'_> {
         let content_start = next_line_start(open_line_end, self.len());
         let (classes, attributes) = verbatim_params(MacroKind::Code, params);
         let attr = Attr {
-            id: String::new(),
-            classes,
-            attributes,
+            id: carta_ast::Text::default(),
+            classes: classes.into_iter().map(Into::into).collect(),
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         };
         if let Some((content, resume)) = self.scan_code_content(content_start) {
             self.pos = resume;
-            Some(vec![Block::CodeBlock(Box::new(attr), content)])
+            Some(vec![Block::CodeBlock(Box::new(attr), content.into())])
         } else {
             self.pos = self.len();
             Some(Vec::new())
@@ -626,14 +629,17 @@ impl BlockParser<'_> {
         };
         let (classes, attributes) = verbatim_params(MacroKind::Noformat, params);
         let attr = Attr {
-            id: String::new(),
-            classes,
-            attributes,
+            id: carta_ast::Text::default(),
+            classes: classes.into_iter().map(Into::into).collect(),
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         };
         if let Some(close) = find_token(self.chars, content_start, CLOSE) {
             let content = slice_to_string(self.chars, content_start, close);
             self.pos = close + CLOSE.chars().count();
-            vec![Block::CodeBlock(Box::new(attr), content)]
+            vec![Block::CodeBlock(Box::new(attr), content.into())]
         } else {
             self.pos = self.len();
             Vec::new()
@@ -689,8 +695,8 @@ impl BlockParser<'_> {
         if let Some(title) = title {
             inner.push(Block::Div(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["panelheader".to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["panelheader".to_string().into()],
                     attributes: Vec::new(),
                 }),
                 vec![Block::Plain(vec![Inline::Strong(plain_inlines(&title))])],
@@ -699,9 +705,12 @@ impl BlockParser<'_> {
         inner.extend(parse_blocks_from_str(&content));
         Some(vec![Block::Div(
             Box::new(Attr {
-                id: String::new(),
-                classes: vec!["panel".to_string()],
-                attributes,
+                id: carta_ast::Text::default(),
+                classes: vec!["panel".to_string().into()],
+                attributes: attributes
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect(),
             }),
             inner,
         )])
@@ -987,7 +996,7 @@ fn plain_inlines(text: &str) -> Vec<Inline> {
     for ch in text.chars() {
         if is_space(ch) {
             if !word.is_empty() {
-                out.push(Inline::Str(std::mem::take(&mut word)));
+                out.push(Inline::Str(std::mem::take(&mut word).into()));
             }
             if out.last() != Some(&Inline::Space) {
                 out.push(Inline::Space);
@@ -997,7 +1006,7 @@ fn plain_inlines(text: &str) -> Vec<Inline> {
         }
     }
     if !word.is_empty() {
-        out.push(Inline::Str(word));
+        out.push(Inline::Str(word.into()));
     }
     out
 }
@@ -1038,7 +1047,7 @@ fn inlines_with(chars: &[char], lo: usize, hi: usize, autolink: bool, depth: usi
         return if text.is_empty() {
             Vec::new()
         } else {
-            vec![Inline::Str(text)]
+            vec![Inline::Str(text.into())]
         };
     }
     finalize(resolve(scan_tokens(chars, lo, hi, autolink, depth)))
@@ -1079,10 +1088,10 @@ fn scan_tokens(chars: &[char], lo: usize, hi: usize, autolink: bool, depth: usiz
             let url = slice_to_string(chars, i, end);
             toks.push(Tok::Atom(Inline::Link(
                 Box::default(),
-                vec![Inline::Str(url.clone())],
+                vec![Inline::Str(url.clone().into())],
                 Box::new(Target {
-                    url,
-                    title: String::new(),
+                    url: url.into(),
+                    title: carta_ast::Text::default(),
                 }),
             )));
             i = end;
@@ -1429,8 +1438,8 @@ fn finalize(toks: Vec<Tok>) -> Vec<Inline> {
     let mut out: Vec<Inline> = Vec::new();
     for tok in toks {
         let inline = match tok {
-            Tok::Text(s) => Inline::Str(s),
-            Tok::Delim { marker, .. } => Inline::Str(marker.to_string()),
+            Tok::Text(s) => Inline::Str(s.into()),
+            Tok::Delim { marker, .. } => Inline::Str(marker.to_string().into()),
             Tok::Atom(node) => node,
         };
         let inline = match out.last_mut() {
@@ -1634,7 +1643,7 @@ fn parse_brace_inline(
         let close = match_monospace_close(chars, i, hi)?;
         let inner = inlines_with(chars, i + 2, close, autolink, depth + 1);
         let text = carta_ast::to_plain_text(&inner);
-        return Some((Inline::Code(Box::default(), text), close + 2));
+        return Some((Inline::Code(Box::default(), text.into()), close + 2));
     }
 
     if matches_at(chars, i, "{color:") {
@@ -1644,9 +1653,9 @@ fn parse_brace_inline(
         let close = match_color_close(chars, value_end + 1, hi)?;
         let inner = inlines_with(chars, value_end + 1, close, autolink, depth + 1);
         let attr = Attr {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             classes: Vec::new(),
-            attributes: vec![("color".to_string(), value)],
+            attributes: vec![("color".to_string().into(), value.into())],
         };
         return Some((Inline::Span(Box::new(attr), inner), close + "{color}".len()));
     }
@@ -1661,7 +1670,7 @@ fn parse_brace_inline(
             .filter(|c| !is_space(**c))
             .collect();
         let attr = Attr {
-            id: name,
+            id: name.into(),
             classes: Vec::new(),
             attributes: Vec::new(),
         };
@@ -1741,13 +1750,13 @@ fn parse_link(chars: &[char], i: usize, hi: usize, depth: usize) -> Option<(Inli
 
     let label = match label_range {
         Some((ls, le)) if le > ls => inlines_with(chars, ls, le, false, depth + 1),
-        _ => vec![Inline::Str(default_label)],
+        _ => vec![Inline::Str(default_label.into())],
     };
     let mut classes: Vec<String> = class.into_iter().map(str::to_string).collect();
     classes.extend(smart_class);
     let attr = Attr {
-        id: String::new(),
-        classes,
+        id: carta_ast::Text::default(),
+        classes: classes.into_iter().map(Into::into).collect(),
         attributes: Vec::new(),
     };
     Some((
@@ -1755,8 +1764,8 @@ fn parse_link(chars: &[char], i: usize, hi: usize, depth: usize) -> Option<(Inli
             Box::new(attr),
             label,
             Box::new(Target {
-                url,
-                title: String::new(),
+                url: url.into(),
+                title: carta_ast::Text::default(),
             }),
         ),
         close + 1,
@@ -1811,7 +1820,10 @@ fn parse_image(chars: &[char], i: usize, hi: usize) -> Option<(Inline, usize)> {
         Inline::Image(
             Box::new(attr),
             Vec::new(),
-            Box::new(Target { url: src, title }),
+            Box::new(Target {
+                url: src.into(),
+                title: title.into(),
+            }),
         ),
         close + 1,
     ))
@@ -1831,8 +1843,8 @@ fn image_properties(props: &str) -> Option<(Attr, String)> {
     if props == "thumbnail" {
         return Some((
             Attr {
-                id: String::new(),
-                classes: vec!["thumbnail".to_string()],
+                id: carta_ast::Text::default(),
+                classes: vec!["thumbnail".to_string().into()],
                 attributes: Vec::new(),
             },
             String::new(),
@@ -1858,9 +1870,12 @@ fn image_properties(props: &str) -> Option<(Attr, String)> {
     }
     Some((
         Attr {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             classes: Vec::new(),
-            attributes,
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         },
         title,
     ))
@@ -1984,7 +1999,7 @@ mod tests {
     }
 
     fn str_node(text: &str) -> Inline {
-        Inline::Str(text.to_string())
+        Inline::Str(text.to_string().into())
     }
 
     #[test]
@@ -2037,7 +2052,7 @@ mod tests {
     fn monospace_stringifies_inner_markup() {
         assert_eq!(
             para("{{a *b* c}}"),
-            vec![Inline::Code(Box::default(), "a b c".to_string())]
+            vec![Inline::Code(Box::default(), "a b c".to_string().into())]
         );
     }
 
@@ -2047,9 +2062,9 @@ mod tests {
             para("{color:red}x{color}"),
             vec![Inline::Span(
                 Box::new(Attr {
-                    id: String::new(),
+                    id: carta_ast::Text::default(),
                     classes: Vec::new(),
-                    attributes: vec![("color".to_string(), "red".to_string())],
+                    attributes: vec![("color".to_string().into(), "red".to_string().into())],
                 }),
                 vec![str_node("x")],
             )]
@@ -2059,9 +2074,9 @@ mod tests {
     #[test]
     fn color_block_wraps_in_div() {
         let attr = Attr {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             classes: Vec::new(),
-            attributes: vec![("color".to_string(), "red".to_string())],
+            attributes: vec![("color".to_string().into(), "red".to_string().into())],
         };
         assert_eq!(
             blocks("{color:red}\nstuff\n{color}"),
@@ -2084,7 +2099,7 @@ mod tests {
             vec![
                 Inline::Span(
                     Box::new(Attr {
-                        id: "foo".to_string(),
+                        id: "foo".to_string().into(),
                         classes: Vec::new(),
                         attributes: Vec::new(),
                     }),
@@ -2186,8 +2201,8 @@ mod tests {
                 Box::default(),
                 vec![str_node("home")],
                 Box::new(Target {
-                    url: "http://example.com".to_string(),
-                    title: String::new(),
+                    url: "http://example.com".to_string().into(),
+                    title: carta_ast::Text::default(),
                 }),
             )]
         );
@@ -2201,8 +2216,8 @@ mod tests {
                 Box::default(),
                 vec![str_node("http://example.com")],
                 Box::new(Target {
-                    url: "http://example.com".to_string(),
-                    title: String::new(),
+                    url: "http://example.com".to_string().into(),
+                    title: carta_ast::Text::default(),
                 }),
             )]
         );
@@ -2214,14 +2229,14 @@ mod tests {
             para("[^file.txt]"),
             vec![Inline::Link(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["attachment".to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["attachment".to_string().into()],
                     attributes: Vec::new(),
                 }),
                 vec![str_node("file.txt")],
                 Box::new(Target {
-                    url: "file.txt".to_string(),
-                    title: String::new(),
+                    url: "file.txt".to_string().into(),
+                    title: carta_ast::Text::default(),
                 }),
             )]
         );
@@ -2238,8 +2253,8 @@ mod tests {
                     Box::default(),
                     vec![str_node("http://example.com")],
                     Box::new(Target {
-                        url: "http://example.com".to_string(),
-                        title: String::new(),
+                        url: "http://example.com".to_string().into(),
+                        title: carta_ast::Text::default(),
                     }),
                 ),
                 Inline::Space,
@@ -2254,17 +2269,17 @@ mod tests {
             para("!pic.png|align=right, vspace=4!"),
             vec![Inline::Image(
                 Box::new(Attr {
-                    id: String::new(),
+                    id: carta_ast::Text::default(),
                     classes: Vec::new(),
                     attributes: vec![
-                        ("align".to_string(), "right".to_string()),
-                        ("vspace".to_string(), "4".to_string()),
+                        ("align".to_string().into(), "right".to_string().into()),
+                        ("vspace".to_string().into(), "4".to_string().into()),
                     ],
                 }),
                 Vec::new(),
                 Box::new(Target {
-                    url: "pic.png".to_string(),
-                    title: String::new(),
+                    url: "pic.png".to_string().into(),
+                    title: carta_ast::Text::default(),
                 }),
             )]
         );
@@ -2276,14 +2291,14 @@ mod tests {
             para("!pic.png|thumbnail!"),
             vec![Inline::Image(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["thumbnail".to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["thumbnail".to_string().into()],
                     attributes: Vec::new(),
                 }),
                 Vec::new(),
                 Box::new(Target {
-                    url: "pic.png".to_string(),
-                    title: String::new(),
+                    url: "pic.png".to_string().into(),
+                    title: carta_ast::Text::default(),
                 }),
             )]
         );
@@ -2357,11 +2372,11 @@ mod tests {
             blocks("{code}\nint x = 1;\n{code}"),
             vec![Block::CodeBlock(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["java".to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["java".to_string().into()],
                     attributes: Vec::new(),
                 }),
-                "int x = 1;\n".to_string(),
+                "int x = 1;\n".to_string().into(),
             )]
         );
     }
@@ -2372,11 +2387,11 @@ mod tests {
             blocks("{code:python}\npass\n{code}"),
             vec![Block::CodeBlock(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["python".to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["python".to_string().into()],
                     attributes: Vec::new(),
                 }),
-                "pass\n".to_string(),
+                "pass\n".to_string().into(),
             )]
         );
     }
@@ -2385,7 +2400,7 @@ mod tests {
     fn noformat_has_no_language_class() {
         assert_eq!(
             blocks("{noformat}\nraw\n{noformat}"),
-            vec![Block::CodeBlock(Box::default(), "raw\n".to_string())]
+            vec![Block::CodeBlock(Box::default(), "raw\n".to_string().into())]
         );
     }
 
@@ -2410,15 +2425,15 @@ mod tests {
             blocks("{panel:title=Note}\nbody\n{panel}"),
             vec![Block::Div(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["panel".to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["panel".to_string().into()],
                     attributes: Vec::new(),
                 }),
                 vec![
                     Block::Div(
                         Box::new(Attr {
-                            id: String::new(),
-                            classes: vec!["panelheader".to_string()],
+                            id: carta_ast::Text::default(),
+                            classes: vec!["panelheader".to_string().into()],
                             attributes: Vec::new(),
                         }),
                         vec![Block::Plain(vec![Inline::Strong(vec![str_node("Note")])])],

--- a/crates/carta-readers/src/latex.rs
+++ b/crates/carta-readers/src/latex.rs
@@ -66,7 +66,11 @@ impl Reader for LatexReader {
         let blocks = parser.parse_blocks(&Stop::Env("document"));
 
         Ok(Document {
-            meta: parser.meta,
+            meta: parser
+                .meta
+                .into_iter()
+                .map(|(k, v)| (k.into(), v))
+                .collect(),
             blocks,
             ..Document::default()
         })
@@ -487,12 +491,12 @@ impl Parser {
         };
         let mut classes = Vec::new();
         if starred {
-            classes.push("unnumbered".to_owned());
+            classes.push("unnumbered".to_owned().into());
         }
         Block::Header(
             level,
             Box::new(Attr {
-                id,
+                id: id.into(),
                 classes,
                 attributes: Vec::new(),
             }),
@@ -527,7 +531,7 @@ impl Parser {
                 && content.is_empty()
                 && attr.attributes.iter().any(|(k, _)| k == "label")
             {
-                *label = Some(attr.id.clone());
+                *label = Some(attr.id.to_string());
                 continue;
             }
             kept.push(inline);
@@ -573,8 +577,8 @@ impl Parser {
                 self.consume_env_marker("\\end");
                 vec![Block::Div(
                     Box::new(Attr {
-                        id: String::new(),
-                        classes: vec![env.to_owned()],
+                        id: carta_ast::Text::default(),
+                        classes: vec![env.to_owned().into()],
                         attributes: Vec::new(),
                     }),
                     inner,
@@ -588,8 +592,8 @@ impl Parser {
                 self.consume_env_marker("\\end");
                 vec![Block::Div(
                     Box::new(Attr {
-                        id: String::new(),
-                        classes: vec!["minipage".to_owned()],
+                        id: carta_ast::Text::default(),
+                        classes: vec!["minipage".to_owned().into()],
                         attributes: Vec::new(),
                     }),
                     inner,
@@ -629,8 +633,8 @@ impl Parser {
                     self.consume_env_marker("\\end");
                     vec![Block::Div(
                         Box::new(Attr {
-                            id: String::new(),
-                            classes: vec![env.to_owned()],
+                            id: carta_ast::Text::default(),
+                            classes: vec![env.to_owned().into()],
                             attributes: Vec::new(),
                         }),
                         inner,
@@ -656,7 +660,10 @@ impl Parser {
         raw.push_str(env);
         raw.push('}');
         self.consume_env_marker("\\end");
-        vec![Block::RawBlock(Format("latex".to_owned()), raw)]
+        vec![Block::RawBlock(
+            Format("latex".to_owned().into()),
+            raw.into(),
+        )]
     }
 
     /// Skips to and consumes the matching `\end{env}`.
@@ -739,7 +746,7 @@ impl Parser {
             if let Some(opts) = self.read_optional_raw() {
                 for (k, v) in parse_key_values(&opts) {
                     if k == "language" && !v.is_empty() {
-                        classes.push(v.to_lowercase());
+                        classes.push(v.to_lowercase().into());
                     }
                     attributes.push((k, v));
                 }
@@ -749,17 +756,20 @@ impl Parser {
             if let Some(lang) = self.read_group_raw()
                 && !lang.is_empty()
             {
-                classes.push(lang.to_lowercase());
+                classes.push(lang.to_lowercase().into());
             }
         }
         let content = self.read_verbatim_body(env);
         vec![Block::CodeBlock(
             Box::new(Attr {
-                id: String::new(),
+                id: carta_ast::Text::default(),
                 classes,
-                attributes,
+                attributes: attributes
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect(),
             }),
-            content,
+            content.into(),
         )]
     }
 
@@ -793,7 +803,7 @@ impl Parser {
         self.in_figure = was_in_figure;
         Block::Figure(
             Box::new(Attr {
-                id: id.unwrap_or_default(),
+                id: id.unwrap_or_default().into(),
                 classes: Vec::new(),
                 attributes: Vec::new(),
             }),
@@ -817,7 +827,7 @@ impl Parser {
                 long: caption,
             };
             if let Some(id) = id {
-                table.attr.id = id;
+                table.attr.id = id.into();
             }
         }
         blocks
@@ -889,15 +899,15 @@ impl Parser {
         let body = self.read_environment_source(env);
         self.consume_env_marker("\\end");
         match env {
-            "math" => Inline::Math(MathType::InlineMath, body.trim().to_owned()),
-            "displaymath" => Inline::Math(MathType::DisplayMath, body.trim().to_owned()),
+            "math" => Inline::Math(MathType::InlineMath, body.trim().to_owned().into()),
+            "displaymath" => Inline::Math(MathType::DisplayMath, body.trim().to_owned().into()),
             _ => {
                 // The environment markers are re-emitted on their own lines around the body, with
                 // trailing whitespace stripped but leading indentation of the first line preserved.
                 let content = body.trim_end().trim_start_matches(['\n', '\r']);
                 Inline::Math(
                     MathType::DisplayMath,
-                    format!("\\begin{{{env}}}\n{content}\n\\end{{{env}}}"),
+                    format!("\\begin{{{env}}}\n{content}\n\\end{{{env}}}").into(),
                 )
             }
         }
@@ -1119,7 +1129,7 @@ impl Parser {
                 self.bump();
                 out.push(Inline::Quoted(QuoteType::DoubleQuote, inner));
             } else {
-                out.push(Inline::Str("\u{201c}".to_owned()));
+                out.push(Inline::Str("\u{201c}".to_owned().into()));
                 out.extend(inner);
             }
         } else {
@@ -1129,7 +1139,7 @@ impl Parser {
                 self.bump();
                 out.push(Inline::Quoted(QuoteType::SingleQuote, inner));
             } else {
-                out.push(Inline::Str("\u{2018}".to_owned()));
+                out.push(Inline::Str("\u{2018}".to_owned().into()));
                 out.extend(inner);
             }
         }
@@ -1169,11 +1179,11 @@ impl Parser {
             }
             '[' => {
                 let text = self.read_math_body("\\]");
-                emit(out, buf, Inline::Math(MathType::DisplayMath, text));
+                emit(out, buf, Inline::Math(MathType::DisplayMath, text.into()));
             }
             '(' => {
                 let text = self.read_math_body("\\)");
-                emit(out, buf, Inline::Math(MathType::InlineMath, text));
+                emit(out, buf, Inline::Math(MathType::InlineMath, text.into()));
             }
             // An explicit inter-word space is a non-breaking space.
             ' ' | '\n' | '\t' => buf.push('\u{a0}'),
@@ -1244,9 +1254,12 @@ impl Parser {
                     "color"
                 };
                 let attr = Attr {
-                    id: String::new(),
+                    id: carta_ast::Text::default(),
                     classes: Vec::new(),
-                    attributes: vec![("style".to_owned(), format!("{property}: {}", color.trim()))],
+                    attributes: vec![(
+                        "style".to_owned().into(),
+                        format!("{property}: {}", color.trim()).into(),
+                    )],
                 };
                 emit(out, buf, Inline::Span(Box::new(attr), inner));
             }
@@ -1258,12 +1271,12 @@ impl Parser {
                 emit(
                     out,
                     buf,
-                    Inline::Code(Box::default(), to_plain_text(&inner)),
+                    Inline::Code(Box::default(), to_plain_text(&inner).into()),
                 );
             }
             "verb" => {
                 if let Some(code) = self.read_verb() {
-                    emit(out, buf, Inline::Code(Box::default(), code));
+                    emit(out, buf, Inline::Code(Box::default(), code.into()));
                 }
             }
             "footnote" | "footnotetext" | "thanks" => {
@@ -1279,14 +1292,14 @@ impl Parser {
                         buf,
                         Inline::Link(
                             Box::new(Attr {
-                                id: String::new(),
-                                classes: vec!["uri".to_owned()],
+                                id: carta_ast::Text::default(),
+                                classes: vec!["uri".to_owned().into()],
                                 attributes: Vec::new(),
                             }),
-                            vec![Inline::Str(url.clone())],
+                            vec![Inline::Str(url.clone().into())],
                             Box::new(Target {
-                                url,
-                                title: String::new(),
+                                url: url.into(),
+                                title: carta_ast::Text::default(),
                             }),
                         ),
                     );
@@ -1305,8 +1318,8 @@ impl Parser {
                         Box::default(),
                         text,
                         Box::new(Target {
-                            url,
-                            title: String::new(),
+                            url: url.into(),
+                            title: carta_ast::Text::default(),
                         }),
                     ),
                 );
@@ -1318,21 +1331,24 @@ impl Parser {
                 let alt = if self.in_figure {
                     Vec::new()
                 } else {
-                    vec![Inline::Str("image".to_owned())]
+                    vec![Inline::Str("image".to_owned().into())]
                 };
                 emit(
                     out,
                     buf,
                     Inline::Image(
                         Box::new(Attr {
-                            id: String::new(),
+                            id: carta_ast::Text::default(),
                             classes: Vec::new(),
-                            attributes,
+                            attributes: attributes
+                                .into_iter()
+                                .map(|(k, v)| (k.into(), v.into()))
+                                .collect(),
                         }),
                         alt,
                         Box::new(Target {
-                            url: path,
-                            title: String::new(),
+                            url: path.into(),
+                            title: carta_ast::Text::default(),
                         }),
                     ),
                 );
@@ -1344,9 +1360,9 @@ impl Parser {
                         buf,
                         Inline::Span(
                             Box::new(Attr {
-                                id: id.clone(),
+                                id: id.clone().into(),
                                 classes: Vec::new(),
-                                attributes: vec![("label".to_owned(), id)],
+                                attributes: vec![("label".to_owned().into(), id.into())],
                             }),
                             Vec::new(),
                         ),
@@ -1381,7 +1397,7 @@ impl Parser {
                 emit(
                     out,
                     buf,
-                    Inline::Math(MathType::InlineMath, body.trim().to_owned()),
+                    Inline::Math(MathType::InlineMath, body.trim().to_owned().into()),
                 );
             }
             "footnotemark" | "protect" | "noindent" | "indent" | "bigskip" | "medskip"
@@ -1408,7 +1424,11 @@ impl Parser {
                     buf.push_str(text);
                 } else if self.ext.contains(Extension::RawTex) {
                     let raw = self.reconstruct_command(name);
-                    emit(out, buf, Inline::RawInline(Format("latex".to_owned()), raw));
+                    emit(
+                        out,
+                        buf,
+                        Inline::RawInline(Format("latex".to_owned().into()), raw.into()),
+                    );
                 } else {
                     // Unknown command: drop it along with any adjacent bracket/brace arguments.
                     self.skip_adjacent_arguments();
@@ -1476,7 +1496,7 @@ impl Parser {
                 continue;
             }
             citations.push(Citation {
-                id: key.to_owned(),
+                id: key.to_owned().into(),
                 prefix: Vec::new(),
                 suffix: Vec::new(),
                 mode: mode.clone(),
@@ -1504,7 +1524,10 @@ impl Parser {
         raw.push('}');
         out.push(Inline::Cite(
             citations,
-            vec![Inline::RawInline(Format("latex".to_owned()), raw)],
+            vec![Inline::RawInline(
+                Format("latex".to_owned().into()),
+                raw.into(),
+            )],
         ));
     }
 
@@ -1574,10 +1597,10 @@ impl Parser {
         if self.cur() == Some('$') && self.at(1) == Some('$') {
             self.bump();
             self.bump();
-            Inline::Math(MathType::DisplayMath, self.read_math_body("$$"))
+            Inline::Math(MathType::DisplayMath, self.read_math_body("$$").into())
         } else {
             self.bump();
-            Inline::Math(MathType::InlineMath, self.read_math_body("$"))
+            Inline::Math(MathType::InlineMath, self.read_math_body("$").into())
         }
     }
 
@@ -1833,7 +1856,10 @@ impl Parser {
             .unwrap_or_default()
             .iter()
             .collect();
-        vec![Block::RawBlock(Format("latex".to_owned()), raw)]
+        vec![Block::RawBlock(
+            Format("latex".to_owned().into()),
+            raw.into(),
+        )]
     }
 
     /// Reads a `\newcommand`-style target name, whether written `{\name}` or bare `\name`.
@@ -1940,7 +1966,7 @@ impl Parser {
 /// Appends the accumulated text buffer as a single [`Inline::Str`] and clears it.
 fn flush_buf(buf: &mut String, out: &mut Vec<Inline>) {
     if !buf.is_empty() {
-        out.push(Inline::Str(std::mem::take(buf)));
+        out.push(Inline::Str(std::mem::take(buf).into()));
     }
 }
 
@@ -2071,8 +2097,8 @@ fn extract_spaces<F: FnOnce(Vec<Inline>) -> Inline>(
 fn span_class(inlines: Vec<Inline>, class: &str) -> Inline {
     Inline::Span(
         Box::new(Attr {
-            id: String::new(),
-            classes: vec![class.to_owned()],
+            id: carta_ast::Text::default(),
+            classes: vec![class.to_owned().into()],
             attributes: Vec::new(),
         }),
         inlines,
@@ -2088,17 +2114,17 @@ fn reference_link(name: &str, target: &str) -> Inline {
     };
     Inline::Link(
         Box::new(Attr {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             classes: Vec::new(),
             attributes: vec![
-                ("reference-type".to_owned(), kind.to_owned()),
-                ("reference".to_owned(), target.to_owned()),
+                ("reference-type".to_owned().into(), kind.to_owned().into()),
+                ("reference".to_owned().into(), target.to_owned().into()),
             ],
         }),
-        vec![Inline::Str(format!("[{target}]"))],
+        vec![Inline::Str(format!("[{target}]").into())],
         Box::new(Target {
-            url: format!("#{target}"),
-            title: String::new(),
+            url: format!("#{target}").into(),
+            title: carta_ast::Text::default(),
         }),
     )
 }
@@ -2118,7 +2144,7 @@ impl Switch {
             Switch::Strong => Inline::Strong(inner),
             Switch::Emph => Inline::Emph(inner),
             Switch::SmallCaps => Inline::SmallCaps(inner),
-            Switch::Code => Inline::Code(Box::default(), to_plain_text(&inner)),
+            Switch::Code => Inline::Code(Box::default(), to_plain_text(&inner).into()),
         }
     }
 }
@@ -2972,9 +2998,12 @@ mod tests {
 
     fn attr(attributes: Vec<(String, String)>) -> Attr {
         Attr {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             classes: Vec::new(),
-            attributes,
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         }
     }
 
@@ -2987,7 +3016,9 @@ mod tests {
             blocks,
             vec![Block::Para(vec![Inline::Math(
                 MathType::DisplayMath,
-                "\\begin{equation}\n  f(x) = x + 1\n\\end{equation}".to_owned(),
+                "\\begin{equation}\n  f(x) = x + 1\n\\end{equation}"
+                    .to_owned()
+                    .into(),
             )])],
         );
     }
@@ -3001,21 +3032,21 @@ mod tests {
         assert_eq!(
             blocks,
             vec![Block::Para(vec![
-                Inline::Str("See".to_owned()),
+                Inline::Str("See".to_owned().into()),
                 Inline::Space,
-                Inline::Str("Section\u{a0}".to_owned()),
+                Inline::Str("Section\u{a0}".to_owned().into()),
                 Inline::Link(
                     Box::new(attr(vec![
                         ("reference-type".to_owned(), "ref".to_owned()),
                         ("reference".to_owned(), "sec:intro".to_owned()),
                     ])),
-                    vec![Inline::Str("[sec:intro]".to_owned())],
+                    vec![Inline::Str("[sec:intro]".to_owned().into())],
                     Box::new(Target {
-                        url: "#sec:intro".to_owned(),
-                        title: String::new(),
+                        url: "#sec:intro".to_owned().into(),
+                        title: carta_ast::Text::default(),
                     }),
                 ),
-                Inline::Str(".".to_owned()),
+                Inline::Str(".".to_owned().into()),
             ])],
         );
     }
@@ -3051,18 +3082,18 @@ mod tests {
         assert_eq!(
             blocks,
             vec![Block::Para(vec![
-                Inline::Str("x".to_owned()),
+                Inline::Str("x".to_owned().into()),
                 Inline::Space,
                 Inline::Image(
                     Box::new(attr(vec![("width".to_owned(), "50%".to_owned())])),
-                    vec![Inline::Str("image".to_owned())],
+                    vec![Inline::Str("image".to_owned().into())],
                     Box::new(Target {
-                        url: "diagram.png".to_owned(),
-                        title: String::new(),
+                        url: "diagram.png".to_owned().into(),
+                        title: carta_ast::Text::default(),
                     }),
                 ),
                 Inline::Space,
-                Inline::Str("y".to_owned()),
+                Inline::Str("y".to_owned().into()),
             ])],
         );
     }
@@ -3076,8 +3107,8 @@ mod tests {
         assert_eq!(
             blocks,
             vec![Block::RawBlock(
-                Format("latex".to_owned()),
-                "\\newcommand{\\foo}{bar}".to_owned(),
+                Format("latex".to_owned().into()),
+                "\\newcommand{\\foo}{bar}".to_owned().into(),
             )],
         );
     }

--- a/crates/carta-readers/src/latex.rs
+++ b/crates/carta-readers/src/latex.rs
@@ -491,7 +491,7 @@ impl Parser {
         };
         let mut classes = Vec::new();
         if starred {
-            classes.push("unnumbered".to_owned().into());
+            classes.push("unnumbered".into());
         }
         Block::Header(
             level,
@@ -578,7 +578,7 @@ impl Parser {
                 vec![Block::Div(
                     Box::new(Attr {
                         id: carta_ast::Text::default(),
-                        classes: vec![env.to_owned().into()],
+                        classes: vec![env.into()],
                         attributes: Vec::new(),
                     }),
                     inner,
@@ -593,7 +593,7 @@ impl Parser {
                 vec![Block::Div(
                     Box::new(Attr {
                         id: carta_ast::Text::default(),
-                        classes: vec!["minipage".to_owned().into()],
+                        classes: vec!["minipage".into()],
                         attributes: Vec::new(),
                     }),
                     inner,
@@ -634,7 +634,7 @@ impl Parser {
                     vec![Block::Div(
                         Box::new(Attr {
                             id: carta_ast::Text::default(),
-                            classes: vec![env.to_owned().into()],
+                            classes: vec![env.into()],
                             attributes: Vec::new(),
                         }),
                         inner,
@@ -660,10 +660,7 @@ impl Parser {
         raw.push_str(env);
         raw.push('}');
         self.consume_env_marker("\\end");
-        vec![Block::RawBlock(
-            Format("latex".to_owned().into()),
-            raw.into(),
-        )]
+        vec![Block::RawBlock(Format("latex".into()), raw.into())]
     }
 
     /// Skips to and consumes the matching `\end{env}`.
@@ -899,8 +896,8 @@ impl Parser {
         let body = self.read_environment_source(env);
         self.consume_env_marker("\\end");
         match env {
-            "math" => Inline::Math(MathType::InlineMath, body.trim().to_owned().into()),
-            "displaymath" => Inline::Math(MathType::DisplayMath, body.trim().to_owned().into()),
+            "math" => Inline::Math(MathType::InlineMath, body.trim().into()),
+            "displaymath" => Inline::Math(MathType::DisplayMath, body.trim().into()),
             _ => {
                 // The environment markers are re-emitted on their own lines around the body, with
                 // trailing whitespace stripped but leading indentation of the first line preserved.
@@ -1129,7 +1126,7 @@ impl Parser {
                 self.bump();
                 out.push(Inline::Quoted(QuoteType::DoubleQuote, inner));
             } else {
-                out.push(Inline::Str("\u{201c}".to_owned().into()));
+                out.push(Inline::Str("\u{201c}".into()));
                 out.extend(inner);
             }
         } else {
@@ -1139,7 +1136,7 @@ impl Parser {
                 self.bump();
                 out.push(Inline::Quoted(QuoteType::SingleQuote, inner));
             } else {
-                out.push(Inline::Str("\u{2018}".to_owned().into()));
+                out.push(Inline::Str("\u{2018}".into()));
                 out.extend(inner);
             }
         }
@@ -1257,7 +1254,7 @@ impl Parser {
                     id: carta_ast::Text::default(),
                     classes: Vec::new(),
                     attributes: vec![(
-                        "style".to_owned().into(),
+                        "style".into(),
                         format!("{property}: {}", color.trim()).into(),
                     )],
                 };
@@ -1293,7 +1290,7 @@ impl Parser {
                         Inline::Link(
                             Box::new(Attr {
                                 id: carta_ast::Text::default(),
-                                classes: vec!["uri".to_owned().into()],
+                                classes: vec!["uri".into()],
                                 attributes: Vec::new(),
                             }),
                             vec![Inline::Str(url.clone().into())],
@@ -1331,7 +1328,7 @@ impl Parser {
                 let alt = if self.in_figure {
                     Vec::new()
                 } else {
-                    vec![Inline::Str("image".to_owned().into())]
+                    vec![Inline::Str("image".into())]
                 };
                 emit(
                     out,
@@ -1362,7 +1359,7 @@ impl Parser {
                             Box::new(Attr {
                                 id: id.clone().into(),
                                 classes: Vec::new(),
-                                attributes: vec![("label".to_owned().into(), id.into())],
+                                attributes: vec![("label".into(), id.into())],
                             }),
                             Vec::new(),
                         ),
@@ -1397,7 +1394,7 @@ impl Parser {
                 emit(
                     out,
                     buf,
-                    Inline::Math(MathType::InlineMath, body.trim().to_owned().into()),
+                    Inline::Math(MathType::InlineMath, body.trim().into()),
                 );
             }
             "footnotemark" | "protect" | "noindent" | "indent" | "bigskip" | "medskip"
@@ -1427,7 +1424,7 @@ impl Parser {
                     emit(
                         out,
                         buf,
-                        Inline::RawInline(Format("latex".to_owned().into()), raw.into()),
+                        Inline::RawInline(Format("latex".into()), raw.into()),
                     );
                 } else {
                     // Unknown command: drop it along with any adjacent bracket/brace arguments.
@@ -1496,7 +1493,7 @@ impl Parser {
                 continue;
             }
             citations.push(Citation {
-                id: key.to_owned().into(),
+                id: key.into(),
                 prefix: Vec::new(),
                 suffix: Vec::new(),
                 mode: mode.clone(),
@@ -1524,10 +1521,7 @@ impl Parser {
         raw.push('}');
         out.push(Inline::Cite(
             citations,
-            vec![Inline::RawInline(
-                Format("latex".to_owned().into()),
-                raw.into(),
-            )],
+            vec![Inline::RawInline(Format("latex".into()), raw.into())],
         ));
     }
 
@@ -1856,10 +1850,7 @@ impl Parser {
             .unwrap_or_default()
             .iter()
             .collect();
-        vec![Block::RawBlock(
-            Format("latex".to_owned().into()),
-            raw.into(),
-        )]
+        vec![Block::RawBlock(Format("latex".into()), raw.into())]
     }
 
     /// Reads a `\newcommand`-style target name, whether written `{\name}` or bare `\name`.
@@ -2098,7 +2089,7 @@ fn span_class(inlines: Vec<Inline>, class: &str) -> Inline {
     Inline::Span(
         Box::new(Attr {
             id: carta_ast::Text::default(),
-            classes: vec![class.to_owned().into()],
+            classes: vec![class.into()],
             attributes: Vec::new(),
         }),
         inlines,
@@ -2117,8 +2108,8 @@ fn reference_link(name: &str, target: &str) -> Inline {
             id: carta_ast::Text::default(),
             classes: Vec::new(),
             attributes: vec![
-                ("reference-type".to_owned().into(), kind.to_owned().into()),
-                ("reference".to_owned().into(), target.to_owned().into()),
+                ("reference-type".into(), kind.into()),
+                ("reference".into(), target.into()),
             ],
         }),
         vec![Inline::Str(format!("[{target}]").into())],

--- a/crates/carta-readers/src/man.rs
+++ b/crates/carta-readers/src/man.rs
@@ -58,7 +58,11 @@ impl Reader for ManReader {
         let mut parser = Parser::new(lines, options.extensions);
         let blocks = parser.parse_blocks(Ctx::TOP);
         Ok(Document {
-            meta: parser.meta,
+            meta: parser
+                .meta
+                .into_iter()
+                .map(|(k, v)| (k.into(), v))
+                .collect(),
             blocks,
             ..Document::default()
         })
@@ -137,7 +141,7 @@ impl Font {
 fn code_inline(inlines: &[Inline]) -> Inline {
     let mut text = String::new();
     collect_code_text(inlines, &mut text);
-    Inline::Code(Box::default(), text)
+    Inline::Code(Box::default(), text.into())
 }
 
 fn collect_code_text(inlines: &[Inline], out: &mut String) {
@@ -392,7 +396,7 @@ impl Parser {
                     blocks.push(Block::Header(
                         level,
                         Box::new(Attr {
-                            id,
+                            id: id.into(),
                             ..Attr::default()
                         }),
                         inlines,
@@ -659,7 +663,7 @@ impl Parser {
                 text_lines.push(flatten(&line, &self.strings));
             }
         }
-        Block::CodeBlock(Box::default(), text_lines.join("\n"))
+        Block::CodeBlock(Box::default(), text_lines.join("\n").into())
     }
 
     /// Parses a tbl table region (`.TS`/`.TE`) into a [`Block::Table`]. The region's structure is the
@@ -853,8 +857,8 @@ impl Parser {
                 Box::default(),
                 label,
                 Box::new(Target {
-                    url,
-                    title: String::new(),
+                    url: url.into(),
+                    title: carta_ast::Text::default(),
                 }),
             )],
         );
@@ -966,7 +970,7 @@ fn alternating(rest: &str, fonts: [Font; 2], strings: &Strings) -> Vec<Inline> {
 /// optional argument (the rest) roman, the whole bracketed as optional — `[ -name argument ]`.
 fn option_synopsis(rest: &str, strings: &Strings) -> Vec<Inline> {
     let args = split_args(rest);
-    let mut out = vec![Inline::Str("[".to_owned())];
+    let mut out = vec![Inline::Str("[".to_owned().into())];
     if let Some(name) = args.first() {
         out.push(Inline::Space);
         out.extend(font_macro(Font::Bold, name, strings));
@@ -977,7 +981,7 @@ fn option_synopsis(rest: &str, strings: &Strings) -> Vec<Inline> {
         out.extend(tokenize(&argument, Font::Regular, strings));
     }
     out.push(Inline::Space);
-    out.push(Inline::Str("]".to_owned()));
+    out.push(Inline::Str("]".to_owned().into()));
     out
 }
 
@@ -997,7 +1001,7 @@ fn inlines_from_plain(text: &str) -> Vec<Inline> {
         if !out.is_empty() {
             out.push(Inline::Space);
         }
-        out.push(Inline::Str(word.to_owned()));
+        out.push(Inline::Str(word.to_owned().into()));
     }
     out
 }
@@ -1385,14 +1389,14 @@ fn tokenize(text: &str, start_font: Font, strings: &Strings) -> Vec<Inline> {
             if *pending_space {
                 run.push(Inline::Space);
             }
-            run.push(Inline::Str(text));
+            run.push(Inline::Str(text.into()));
         } else {
             flush_run(run, *run_font, result);
             if *pending_space {
                 push_space(result);
             }
             *run_font = word_font;
-            run.push(Inline::Str(text));
+            run.push(Inline::Str(text.into()));
         }
         *pending_space = false;
     };
@@ -1766,7 +1770,7 @@ fn build_tbl(region: &[String]) -> Option<Block> {
         .iter()
         .any(|line| format_has_span(line))
     {
-        return Some(Block::Para(vec![Inline::Str("TABLE".to_owned())]));
+        return Some(Block::Para(vec![Inline::Str("TABLE".to_owned().into())]));
     }
 
     let data = collapse_text_blocks(region.get(data_start..).unwrap_or(&[]), &separator);
@@ -1976,7 +1980,7 @@ fn tbl_cell(field: &str) -> Cell {
         if !inlines.is_empty() {
             inlines.push(Inline::Space);
         }
-        inlines.push(Inline::Str(word.to_owned()));
+        inlines.push(Inline::Str(word.to_owned().into()));
     }
     let content = if inlines.is_empty() {
         Vec::new()
@@ -2684,7 +2688,7 @@ mod tests {
                 ],
                 Box::new(Target {
                     url: "https://example.com".into(),
-                    title: String::new(),
+                    title: carta_ast::Text::default(),
                 }),
             )]))
         );

--- a/crates/carta-readers/src/man.rs
+++ b/crates/carta-readers/src/man.rs
@@ -970,7 +970,7 @@ fn alternating(rest: &str, fonts: [Font; 2], strings: &Strings) -> Vec<Inline> {
 /// optional argument (the rest) roman, the whole bracketed as optional — `[ -name argument ]`.
 fn option_synopsis(rest: &str, strings: &Strings) -> Vec<Inline> {
     let args = split_args(rest);
-    let mut out = vec![Inline::Str("[".to_owned().into())];
+    let mut out = vec![Inline::Str("[".into())];
     if let Some(name) = args.first() {
         out.push(Inline::Space);
         out.extend(font_macro(Font::Bold, name, strings));
@@ -981,7 +981,7 @@ fn option_synopsis(rest: &str, strings: &Strings) -> Vec<Inline> {
         out.extend(tokenize(&argument, Font::Regular, strings));
     }
     out.push(Inline::Space);
-    out.push(Inline::Str("]".to_owned().into()));
+    out.push(Inline::Str("]".into()));
     out
 }
 
@@ -1001,7 +1001,7 @@ fn inlines_from_plain(text: &str) -> Vec<Inline> {
         if !out.is_empty() {
             out.push(Inline::Space);
         }
-        out.push(Inline::Str(word.to_owned().into()));
+        out.push(Inline::Str(word.into()));
     }
     out
 }
@@ -1770,7 +1770,7 @@ fn build_tbl(region: &[String]) -> Option<Block> {
         .iter()
         .any(|line| format_has_span(line))
     {
-        return Some(Block::Para(vec![Inline::Str("TABLE".to_owned().into())]));
+        return Some(Block::Para(vec![Inline::Str("TABLE".into())]));
     }
 
     let data = collapse_text_blocks(region.get(data_start..).unwrap_or(&[]), &separator);
@@ -1980,7 +1980,7 @@ fn tbl_cell(field: &str) -> Cell {
         if !inlines.is_empty() {
             inlines.push(Inline::Space);
         }
-        inlines.push(Inline::Str(word.to_owned().into()));
+        inlines.push(Inline::Str(word.into()));
     }
     let content = if inlines.is_empty() {
         Vec::new()

--- a/crates/carta-readers/src/mediawiki.rs
+++ b/crates/carta-readers/src/mediawiki.rs
@@ -22,7 +22,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use carta_ast::{
     Alignment, ApiVersion, Attr, Block, Caption, Cell, ColSpec, ColWidth, Document, Format, Inline,
     ListAttributes, ListNumberDelim, ListNumberStyle, MathType, MetaValue, QuoteType, Row, Table,
-    TableBody, TableFoot, TableHead, Target, slug_gfm, to_plain_text,
+    TableBody, TableFoot, TableHead, Target, ToCompactString, slug_gfm, to_plain_text,
 };
 use carta_core::{Extension, Extensions, Reader, ReaderOptions, Result};
 
@@ -1045,10 +1045,7 @@ impl Parser {
                     Some((inner_end, after)) => {
                         let inner = collect_range(chars, after_open, inner_end);
                         Some((
-                            vec![Inline::Math(
-                                MathType::InlineMath,
-                                inner.trim().to_string().into(),
-                            )],
+                            vec![Inline::Math(MathType::InlineMath, inner.trim().into())],
                             after,
                         ))
                     }
@@ -1167,7 +1164,7 @@ impl Parser {
                 let inner = collect_range(chars, after_open, inner_end);
                 let attr = Attr {
                     id: carta_ast::Text::default(),
-                    classes: vec![class.to_string().into()],
+                    classes: vec![class.into()],
                     attributes: Vec::new(),
                 };
                 (
@@ -1196,7 +1193,7 @@ impl Parser {
         }
         let text = if label.is_empty() {
             self.link_counter += 1;
-            vec![Inline::Str(self.link_counter.to_string().into())]
+            vec![Inline::Str(self.link_counter.to_compact_string())]
         } else {
             self.parse_inlines(&label)
         };
@@ -1239,7 +1236,7 @@ impl Parser {
                 let title = title_text(&text);
                 let attr = Attr {
                     id: carta_ast::Text::default(),
-                    classes: vec!["wikilink".to_string().into()],
+                    classes: vec!["wikilink".into()],
                     attributes: Vec::new(),
                 };
                 self.categories.push(Inline::Link(
@@ -1284,7 +1281,7 @@ impl Parser {
         }
         let attr = Attr {
             id: carta_ast::Text::default(),
-            classes: vec!["wikilink".to_string().into()],
+            classes: vec!["wikilink".into()],
             attributes: Vec::new(),
         };
         let url = wikilink_url(&target);
@@ -1727,7 +1724,7 @@ fn parse_runs(
                     pos = next;
                     continue;
                 }
-                nodes.push(Inline::Str("'".to_string().into()));
+                nodes.push(Inline::Str("'".into()));
                 pos += 1;
             }
         }
@@ -3919,7 +3916,7 @@ fn degraded_blocks(chars: &[char]) -> Vec<Block> {
     if trimmed.is_empty() {
         Vec::new()
     } else {
-        vec![Block::Para(vec![Inline::Str(trimmed.to_string().into())])]
+        vec![Block::Para(vec![Inline::Str(trimmed.into())])]
     }
 }
 
@@ -4021,15 +4018,15 @@ fn flush_word(word: &mut String, toks: &mut Vec<Tok>) {
 }
 
 fn raw_html(text: String) -> Inline {
-    Inline::RawInline(Format("html".to_string().into()), text.into())
+    Inline::RawInline(Format("html".into()), text.into())
 }
 
 fn format_mediawiki() -> Format {
-    Format("mediawiki".to_string().into())
+    Format("mediawiki".into())
 }
 
 fn format_html() -> Format {
-    Format("html".to_string().into())
+    Format("html".into())
 }
 
 fn at(chars: &[char], i: usize) -> Option<char> {

--- a/crates/carta-readers/src/mediawiki.rs
+++ b/crates/carta-readers/src/mediawiki.rs
@@ -58,7 +58,7 @@ impl Reader for MediawikiReader {
         }
         Ok(Document {
             api_version: ApiVersion::default(),
-            meta,
+            meta: meta.into_iter().map(|(k, v)| (k.into(), v)).collect(),
             blocks,
         })
     }
@@ -196,7 +196,7 @@ impl Parser {
                     && let Some(after) = balanced_braces(chars, pos)
                 {
                     let raw = collect_range(chars, pos, after);
-                    blocks.push(Block::RawBlock(format_mediawiki(), raw));
+                    blocks.push(Block::RawBlock(format_mediawiki(), raw.into()));
                     let (np, ls) = finish_inline_block(chars, after);
                     pos = np;
                     line_start = ls;
@@ -216,7 +216,7 @@ impl Parser {
                 {
                     let id = self.make_id(&inlines);
                     let attr = Attr {
-                        id,
+                        id: id.into(),
                         classes: Vec::new(),
                         attributes: Vec::new(),
                     };
@@ -506,7 +506,10 @@ impl Parser {
             }
             "pre" => {
                 let (inner, after) = enclosed(chars, after_open, "pre");
-                Some((Block::CodeBlock(Box::default(), trim_code(&inner)), after))
+                Some((
+                    Block::CodeBlock(Box::default(), trim_code(&inner).into()),
+                    after,
+                ))
             }
             "source" | "syntaxhighlight" => {
                 let (inner, after) = enclosed(chars, after_open, &name);
@@ -514,14 +517,17 @@ impl Parser {
                 if let Some(lang) = tag_attribute(&raw_open, "lang")
                     && !lang.is_empty()
                 {
-                    classes.push(lang);
+                    classes.push(lang.into());
                 }
                 let attr = Attr {
-                    id: String::new(),
+                    id: carta_ast::Text::default(),
                     classes,
                     attributes: Vec::new(),
                 };
-                Some((Block::CodeBlock(Box::new(attr), trim_code(&inner)), after))
+                Some((
+                    Block::CodeBlock(Box::new(attr), trim_code(&inner).into()),
+                    after,
+                ))
             }
             "ul" => Some(self.parse_html_list(chars, after_open, false, &raw_open, self_closing)),
             "ol" => Some(self.parse_html_list(chars, after_open, true, &raw_open, self_closing)),
@@ -667,7 +673,7 @@ impl Parser {
             match tok {
                 Tok::BlockRaw(raw) => {
                     flush_para_segment(&mut segment, &mut blocks, smart, east_asian);
-                    blocks.push(Block::RawBlock(format_html(), raw));
+                    blocks.push(Block::RawBlock(format_html(), raw.into()));
                 }
                 Tok::Block(block) => {
                     flush_para_segment(&mut segment, &mut blocks, smart, east_asian);
@@ -939,7 +945,10 @@ impl Parser {
                 {
                     flush_word(&mut word, &mut toks);
                     let raw = collect_range(chars, i, after);
-                    toks.push(Tok::Inline(Inline::RawInline(format_mediawiki(), raw)));
+                    toks.push(Tok::Inline(Inline::RawInline(
+                        format_mediawiki(),
+                        raw.into(),
+                    )));
                     i = after;
                     continue;
                 }
@@ -1036,7 +1045,10 @@ impl Parser {
                     Some((inner_end, after)) => {
                         let inner = collect_range(chars, after_open, inner_end);
                         Some((
-                            vec![Inline::Math(MathType::InlineMath, inner.trim().to_string())],
+                            vec![Inline::Math(
+                                MathType::InlineMath,
+                                inner.trim().to_string().into(),
+                            )],
                             after,
                         ))
                     }
@@ -1154,8 +1166,8 @@ impl Parser {
             Some((inner_end, after)) => {
                 let inner = collect_range(chars, after_open, inner_end);
                 let attr = Attr {
-                    id: String::new(),
-                    classes: vec![class.to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec![class.to_string().into()],
                     attributes: Vec::new(),
                 };
                 (
@@ -1184,7 +1196,7 @@ impl Parser {
         }
         let text = if label.is_empty() {
             self.link_counter += 1;
-            vec![Inline::Str(self.link_counter.to_string())]
+            vec![Inline::Str(self.link_counter.to_string().into())]
         } else {
             self.parse_inlines(&label)
         };
@@ -1193,8 +1205,8 @@ impl Parser {
                 Box::default(),
                 text,
                 Box::new(Target {
-                    url: encode_url_target(&url),
-                    title: String::new(),
+                    url: encode_url_target(&url).into(),
+                    title: carta_ast::Text::default(),
                 }),
             )],
             close + 1,
@@ -1226,16 +1238,16 @@ impl Parser {
                 };
                 let title = title_text(&text);
                 let attr = Attr {
-                    id: String::new(),
-                    classes: vec!["wikilink".to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["wikilink".to_string().into()],
                     attributes: Vec::new(),
                 };
                 self.categories.push(Inline::Link(
                     Box::new(attr),
                     text,
                     Box::new(Target {
-                        url: wikilink_url(&target),
-                        title,
+                        url: wikilink_url(&target).into(),
+                        title: title.into(),
                     }),
                 ));
                 return Some((Vec::new(), close + 2));
@@ -1267,12 +1279,12 @@ impl Parser {
         };
         let title = title_text(&label);
         if !trail.is_empty() {
-            label.push(Inline::Str(trail));
+            label.push(Inline::Str(trail.into()));
             label = coalesce(label);
         }
         let attr = Attr {
-            id: String::new(),
-            classes: vec!["wikilink".to_string()],
+            id: carta_ast::Text::default(),
+            classes: vec!["wikilink".to_string().into()],
             attributes: Vec::new(),
         };
         let url = wikilink_url(&target);
@@ -1280,7 +1292,10 @@ impl Parser {
             vec![Inline::Link(
                 Box::new(attr),
                 label,
-                Box::new(Target { url, title }),
+                Box::new(Target {
+                    url: url.into(),
+                    title: title.into(),
+                }),
             )],
             after,
         ))
@@ -1329,14 +1344,20 @@ impl Parser {
         let alt = self.parse_inlines(&caption);
         let title = title_text(&alt);
         let attr = Attr {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             classes: Vec::new(),
-            attributes,
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         };
         Some(Inline::Image(
             Box::new(attr),
             alt,
-            Box::new(Target { url, title }),
+            Box::new(Target {
+                url: url.into(),
+                title: title.into(),
+            }),
         ))
     }
 
@@ -1706,7 +1727,7 @@ fn parse_runs(
                     pos = next;
                     continue;
                 }
-                nodes.push(Inline::Str("'".to_string()));
+                nodes.push(Inline::Str("'".to_string().into()));
                 pos += 1;
             }
         }
@@ -1827,7 +1848,7 @@ fn resolve_double_quotes(units: &[SmartUnit], lo: usize, hi: usize) -> Vec<Inlin
 
 fn flush_smart_buf(buf: &mut String, out: &mut Vec<Inline>) {
     if !buf.is_empty() {
-        out.push(Inline::Str(std::mem::take(buf)));
+        out.push(Inline::Str(std::mem::take(buf).into()));
     }
 }
 
@@ -1987,14 +2008,17 @@ fn preformat_transform(inlines: Vec<Inline>) -> Vec<Inline> {
             Inline::Space | Inline::SoftBreak => run.push('\u{a0}'),
             other => {
                 if !run.is_empty() {
-                    out.push(Inline::Code(Box::default(), std::mem::take(&mut run)));
+                    out.push(Inline::Code(
+                        Box::default(),
+                        std::mem::take(&mut run).into(),
+                    ));
                 }
                 out.push(preformat_descend(other));
             }
         }
     }
     if !run.is_empty() {
-        out.push(Inline::Code(Box::default(), run));
+        out.push(Inline::Code(Box::default(), run.into()));
     }
     out
 }
@@ -2030,7 +2054,7 @@ fn plain_inlines(text: &str) -> Vec<Inline> {
         let Some(c) = at(&chars, i) else { break };
         if c.is_whitespace() {
             if !word.is_empty() {
-                out.push(Inline::Str(std::mem::take(&mut word)));
+                out.push(Inline::Str(std::mem::take(&mut word).into()));
             }
             let (token, next) = whitespace_token(&chars, i);
             out.push(token);
@@ -2049,7 +2073,7 @@ fn plain_inlines(text: &str) -> Vec<Inline> {
         }
     }
     if !word.is_empty() {
-        out.push(Inline::Str(word));
+        out.push(Inline::Str(word.into()));
     }
     out
 }
@@ -2457,10 +2481,10 @@ fn bare_url(chars: &[char], i: usize) -> Option<(Inline, usize)> {
     Some((
         Inline::Link(
             Box::default(),
-            vec![Inline::Str(display)],
+            vec![Inline::Str(display.into())],
             Box::new(Target {
-                url: target,
-                title: String::new(),
+                url: target.into(),
+                title: carta_ast::Text::default(),
             }),
         ),
         i + consumed,
@@ -3895,7 +3919,7 @@ fn degraded_blocks(chars: &[char]) -> Vec<Block> {
     if trimmed.is_empty() {
         Vec::new()
     } else {
-        vec![Block::Para(vec![Inline::Str(trimmed.to_string())])]
+        vec![Block::Para(vec![Inline::Str(trimmed.to_string().into())])]
     }
 }
 
@@ -3947,12 +3971,12 @@ fn verbatim_code(
         Some((inner_end, after)) => {
             let inner = collect_range(chars, after_open, inner_end);
             let attr = Attr {
-                id: String::new(),
-                classes: classes.iter().map(|s| (*s).to_string()).collect(),
+                id: carta_ast::Text::default(),
+                classes: classes.iter().map(|s| (*s).into()).collect(),
                 attributes: Vec::new(),
             };
             (
-                vec![Inline::Code(Box::new(attr), decode_entities(&inner))],
+                vec![Inline::Code(Box::new(attr), decode_entities(&inner).into())],
                 after,
             )
         }
@@ -3992,20 +4016,20 @@ fn trim_code(inner: &str) -> String {
 
 fn flush_word(word: &mut String, toks: &mut Vec<Tok>) {
     if !word.is_empty() {
-        toks.push(Tok::Inline(Inline::Str(std::mem::take(word))));
+        toks.push(Tok::Inline(Inline::Str(std::mem::take(word).into())));
     }
 }
 
 fn raw_html(text: String) -> Inline {
-    Inline::RawInline(Format("html".to_string()), text)
+    Inline::RawInline(Format("html".to_string().into()), text.into())
 }
 
 fn format_mediawiki() -> Format {
-    Format("mediawiki".to_string())
+    Format("mediawiki".to_string().into())
 }
 
 fn format_html() -> Format {
-    Format("html".to_string())
+    Format("html".to_string().into())
 }
 
 fn at(chars: &[char], i: usize) -> Option<char> {
@@ -4336,9 +4360,12 @@ fn parse_cell_attrs(s: &str) -> Option<CellAttrs> {
         col_span,
         row_span,
         attr: Attr {
-            id,
-            classes,
-            attributes,
+            id: id.into(),
+            classes: classes.into_iter().map(Into::into).collect(),
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         },
     })
 }
@@ -4573,7 +4600,7 @@ mod tests {
         let ids: Vec<String> = blocks
             .iter()
             .filter_map(|b| match b {
-                Block::Header(_, attr, _) => Some(attr.id.clone()),
+                Block::Header(_, attr, _) => Some(attr.id.to_string()),
                 _ => None,
             })
             .collect();
@@ -4595,7 +4622,7 @@ mod tests {
         let ids: Vec<String> = blocks
             .iter()
             .filter_map(|b| match b {
-                Block::Header(_, attr, _) => Some(attr.id.clone()),
+                Block::Header(_, attr, _) => Some(attr.id.to_string()),
                 _ => None,
             })
             .collect();
@@ -4667,7 +4694,7 @@ mod tests {
             parse("[[Page]]s"),
             vec![Block::Para(vec![Inline::Link(
                 Box::new(Attr {
-                    id: String::new(),
+                    id: carta_ast::Text::default(),
                     classes: vec!["wikilink".into()],
                     attributes: vec![],
                 }),
@@ -4740,7 +4767,7 @@ mod tests {
                 }),
                 vec![Block::Plain(vec![Inline::Image(
                     Box::new(Attr {
-                        id: String::new(),
+                        id: carta_ast::Text::default(),
                         classes: vec![],
                         attributes: vec![
                             ("width".into(), "100".into()),
@@ -4782,7 +4809,7 @@ mod tests {
             parse("[[File:]]"),
             vec![Block::Para(vec![Inline::Link(
                 Box::new(Attr {
-                    id: String::new(),
+                    id: carta_ast::Text::default(),
                     classes: vec!["wikilink".into()],
                     attributes: vec![],
                 }),
@@ -4805,7 +4832,7 @@ mod tests {
                     vec![Inline::Str("lbl".into())],
                     Box::new(Target {
                         url: "http://x.com".into(),
-                        title: String::new(),
+                        title: carta_ast::Text::default(),
                     }),
                 ),
                 Inline::Space,
@@ -4814,7 +4841,7 @@ mod tests {
                     vec![Inline::Str("1".into())],
                     Box::new(Target {
                         url: "http://y.com".into(),
-                        title: String::new(),
+                        title: carta_ast::Text::default(),
                     }),
                 ),
             ])]
@@ -4833,7 +4860,7 @@ mod tests {
                     vec![Inline::Str("http://x.com".into())],
                     Box::new(Target {
                         url: "http://x.com".into(),
-                        title: String::new(),
+                        title: carta_ast::Text::default(),
                     }),
                 ),
                 Inline::Str(".".into()),
@@ -4925,7 +4952,7 @@ mod tests {
             parse("<syntaxhighlight lang=\"rust\">\nfn main(){}\n</syntaxhighlight>"),
             vec![Block::CodeBlock(
                 Box::new(Attr {
-                    id: String::new(),
+                    id: carta_ast::Text::default(),
                     classes: vec!["rust".into()],
                     attributes: vec![],
                 }),

--- a/crates/carta-readers/src/metadata.rs
+++ b/crates/carta-readers/src/metadata.rs
@@ -41,7 +41,9 @@ mod tests {
     use carta_ast::{Inline, MetaValue};
 
     fn emph(text: &str) -> MetaValue {
-        MetaValue::MetaInlines(vec![Inline::Emph(vec![Inline::Str(text.to_owned())])])
+        MetaValue::MetaInlines(vec![Inline::Emph(vec![Inline::Str(
+            text.to_owned().into(),
+        )])])
     }
 
     #[test]

--- a/crates/carta-readers/src/native.rs
+++ b/crates/carta-readers/src/native.rs
@@ -517,7 +517,7 @@ impl Parser {
             let meta = self.parse_meta()?;
             let blocks = self.parse_block_list()?;
             return Ok(Document {
-                meta,
+                meta: meta.into_iter().map(|(k, v)| (k.into(), v)).collect(),
                 blocks,
                 ..Default::default()
             });
@@ -587,12 +587,17 @@ impl Parser {
     fn parse_meta_value(&mut self) -> Result<MetaValue> {
         let name = self.constructor()?;
         match name.as_str() {
-            "MetaMap" => Ok(MetaValue::MetaMap(self.parse_from_list()?)),
+            "MetaMap" => Ok(MetaValue::MetaMap(
+                self.parse_from_list()?
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v))
+                    .collect(),
+            )),
             "MetaList" => Ok(MetaValue::MetaList(
                 self.parse_list(Self::parse_meta_value)?,
             )),
             "MetaBool" => Ok(MetaValue::MetaBool(self.parse_bool()?)),
-            "MetaString" => Ok(MetaValue::MetaString(self.parse_string()?)),
+            "MetaString" => Ok(MetaValue::MetaString(self.parse_string()?.into())),
             "MetaInlines" => Ok(MetaValue::MetaInlines(self.parse_inline_list()?)),
             "MetaBlocks" => Ok(MetaValue::MetaBlocks(self.parse_block_list()?)),
             other => Err(syntax_error(format!("unknown metadata value '{other}'"))),
@@ -624,12 +629,12 @@ impl Parser {
             "CodeBlock" => {
                 let attr = self.parse_attr()?;
                 let text = self.parse_string()?;
-                Ok(Block::CodeBlock(Box::new(attr), text))
+                Ok(Block::CodeBlock(Box::new(attr), text.into()))
             }
             "RawBlock" => {
                 let format = self.parse_format()?;
                 let text = self.parse_string()?;
-                Ok(Block::RawBlock(format, text))
+                Ok(Block::RawBlock(format, text.into()))
             }
             "BlockQuote" => Ok(Block::BlockQuote(self.parse_block_list()?)),
             "OrderedList" => {
@@ -667,7 +672,7 @@ impl Parser {
     fn parse_inline(&mut self) -> Result<Inline> {
         let name = self.constructor()?;
         match name.as_str() {
-            "Str" => Ok(Inline::Str(self.parse_string()?)),
+            "Str" => Ok(Inline::Str(self.parse_string()?.into())),
             "Emph" => Ok(Inline::Emph(self.parse_inline_list()?)),
             "Underline" => Ok(Inline::Underline(self.parse_inline_list()?)),
             "Strong" => Ok(Inline::Strong(self.parse_inline_list()?)),
@@ -688,7 +693,7 @@ impl Parser {
             "Code" => {
                 let attr = self.parse_attr()?;
                 let text = self.parse_string()?;
-                Ok(Inline::Code(Box::new(attr), text))
+                Ok(Inline::Code(Box::new(attr), text.into()))
             }
             "Space" => Ok(Inline::Space),
             "SoftBreak" => Ok(Inline::SoftBreak),
@@ -696,12 +701,12 @@ impl Parser {
             "Math" => {
                 let math = self.parse_math_type()?;
                 let text = self.parse_string()?;
-                Ok(Inline::Math(math, text))
+                Ok(Inline::Math(math, text.into()))
             }
             "RawInline" => {
                 let format = self.parse_format()?;
                 let text = self.parse_string()?;
-                Ok(Inline::RawInline(format, text))
+                Ok(Inline::RawInline(format, text.into()))
             }
             "Link" => {
                 let attr = self.parse_attr()?;
@@ -734,9 +739,12 @@ impl Parser {
         let attributes = self.parse_list(Self::parse_string_pair)?;
         self.eat(&Token::RParen)?;
         Ok(Attr {
-            id,
-            classes,
-            attributes,
+            id: id.into(),
+            classes: classes.into_iter().map(Into::into).collect(),
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         })
     }
 
@@ -755,7 +763,10 @@ impl Parser {
         self.eat(&Token::Comma)?;
         let title = self.parse_string()?;
         self.eat(&Token::RParen)?;
-        Ok(Target { url, title })
+        Ok(Target {
+            url: url.into(),
+            title: title.into(),
+        })
     }
 
     fn parse_format(&mut self) -> Result<Format> {
@@ -763,7 +774,7 @@ impl Parser {
         self.eat_ident("Format")?;
         let name = self.parse_string()?;
         self.close_if(opened)?;
-        Ok(Format(name))
+        Ok(Format(name.into()))
     }
 
     fn parse_list_attributes(&mut self) -> Result<ListAttributes> {
@@ -864,7 +875,7 @@ impl Parser {
         self.eat_ident("Citation")?;
         self.eat(&Token::LBrace)?;
         let mut citation = Citation {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             prefix: Vec::new(),
             suffix: Vec::new(),
             mode: CitationMode::NormalCitation,
@@ -875,7 +886,7 @@ impl Parser {
             let field = self.constructor()?;
             self.eat(&Token::Equals)?;
             match field.as_str() {
-                "citationId" => citation.id = self.parse_string()?,
+                "citationId" => citation.id = self.parse_string()?.into(),
                 "citationPrefix" => citation.prefix = self.parse_inline_list()?,
                 "citationSuffix" => citation.suffix = self.parse_inline_list()?,
                 "citationMode" => citation.mode = self.parse_citation_mode()?,
@@ -1040,7 +1051,7 @@ mod tests {
     }
 
     fn str_inline(text: &str) -> Inline {
-        Inline::Str(text.to_string())
+        Inline::Str(text.to_string().into())
     }
 
     #[test]
@@ -1063,9 +1074,12 @@ mod tests {
         assert_eq!(
             document.meta.get("m"),
             Some(&MetaValue::MetaMap(
-                [("k".to_string(), MetaValue::MetaString("v".to_string()))]
-                    .into_iter()
-                    .collect()
+                [(
+                    "k".to_string().into(),
+                    MetaValue::MetaString("v".to_string().into())
+                )]
+                .into_iter()
+                .collect()
             ))
         );
         assert_eq!(
@@ -1129,11 +1143,11 @@ mod tests {
             only_block(r#"CodeBlock ("i", ["rust", "numberLines"], [("k", "v")]) "let x = 1;""#),
             Block::CodeBlock(
                 Box::new(Attr {
-                    id: "i".to_string(),
-                    classes: vec!["rust".to_string(), "numberLines".to_string()],
-                    attributes: vec![("k".to_string(), "v".to_string())],
+                    id: "i".to_string().into(),
+                    classes: vec!["rust".to_string().into(), "numberLines".to_string().into()],
+                    attributes: vec![("k".to_string().into(), "v".to_string().into())],
                 }),
-                "let x = 1;".to_string()
+                "let x = 1;".to_string().into()
             )
         );
     }
@@ -1142,7 +1156,7 @@ mod tests {
     fn parses_raw_block_with_format_in_parens() {
         assert_eq!(
             only_block(r#"RawBlock (Format "html") "<hr>""#),
-            Block::RawBlock(Format("html".to_string()), "<hr>".to_string())
+            Block::RawBlock(Format("html".to_string().into()), "<hr>".to_string().into())
         );
     }
 
@@ -1187,7 +1201,7 @@ mod tests {
             Block::Header(
                 2,
                 Box::new(Attr {
-                    id: "h".to_string(),
+                    id: "h".to_string().into(),
                     classes: vec![],
                     attributes: vec![],
                 }),
@@ -1202,7 +1216,7 @@ mod tests {
             only_block(r#"Div ("d", [], []) [BlockQuote [Para [Str "q"]]]"#),
             Block::Div(
                 Box::new(Attr {
-                    id: "d".to_string(),
+                    id: "d".to_string().into(),
                     classes: vec![],
                     attributes: vec![],
                 }),
@@ -1266,8 +1280,8 @@ mod tests {
             block,
             Block::Para(vec![
                 Inline::Quoted(QuoteType::DoubleQuote, vec![str_inline("q")]),
-                Inline::Math(MathType::InlineMath, "x^2".to_string()),
-                Inline::Code(Box::default(), "f()".to_string()),
+                Inline::Math(MathType::InlineMath, "x^2".to_string().into()),
+                Inline::Code(Box::default(), "f()".to_string().into()),
             ])
         );
     }
@@ -1284,21 +1298,21 @@ mod tests {
                     Box::default(),
                     vec![str_inline("t")],
                     Box::new(Target {
-                        url: "/u".to_string(),
-                        title: "ti".to_string()
+                        url: "/u".to_string().into(),
+                        title: "ti".to_string().into()
                     })
                 ),
                 Inline::Image(
                     Box::default(),
                     vec![str_inline("alt")],
                     Box::new(Target {
-                        url: "/i".to_string(),
-                        title: String::new()
+                        url: "/i".to_string().into(),
+                        title: carta_ast::Text::default()
                     })
                 ),
                 Inline::Span(
                     Box::new(Attr {
-                        id: "sp".to_string(),
+                        id: "sp".to_string().into(),
                         classes: vec![],
                         attributes: vec![],
                     }),
@@ -1315,8 +1329,8 @@ mod tests {
         assert_eq!(
             block,
             Block::Para(vec![Inline::RawInline(
-                Format("tex".to_string()),
-                "\\hi".to_string()
+                Format("tex".to_string().into()),
+                "\\hi".to_string().into()
             )])
         );
     }

--- a/crates/carta-readers/src/opml.rs
+++ b/crates/carta-readers/src/opml.rs
@@ -35,7 +35,10 @@ impl Reader for OpmlReader {
         }
         Ok(Document {
             api_version: carta_ast::ApiVersion::default(),
-            meta: build_meta(head),
+            meta: build_meta(head)
+                .into_iter()
+                .map(|(k, v)| (k.into(), v))
+                .collect(),
             blocks,
         })
     }
@@ -83,8 +86,8 @@ fn emit_outline(outline: &Element, level: i32, blocks: &mut Vec<Block>) -> Resul
             Box::default(),
             heading,
             Box::new(Target {
-                url,
-                title: String::new(),
+                url: url.into(),
+                title: carta_ast::Text::default(),
             }),
         )]
     } else {
@@ -159,7 +162,7 @@ fn tokenize_meta(text: &str) -> Vec<Inline> {
     while let Some(ch) = chars.next() {
         if ch.is_whitespace() {
             if !word.is_empty() {
-                out.push(Inline::Str(std::mem::take(&mut word)));
+                out.push(Inline::Str(std::mem::take(&mut word).into()));
             }
             let mut has_newline = ch == '\n' || ch == '\r';
             while let Some(&next) = chars.peek() {
@@ -179,7 +182,7 @@ fn tokenize_meta(text: &str) -> Vec<Inline> {
         }
     }
     if !word.is_empty() {
-        out.push(Inline::Str(word));
+        out.push(Inline::Str(word.into()));
     }
     out
 }
@@ -482,8 +485,8 @@ fn smart_inlines(inlines: Vec<Inline>) -> Vec<Inline> {
 /// [`pair_quotes`], which sees the whole run.
 fn fold_inline(inline: Inline) -> Inline {
     match inline {
-        Inline::Str(text) => Inline::Str(fold_text(&text)),
-        Inline::Code(attr, text) => Inline::Code(attr, smart_code(&text)),
+        Inline::Str(text) => Inline::Str(fold_text(&text).into()),
+        Inline::Code(attr, text) => Inline::Code(attr, smart_code(&text).into()),
         Inline::Emph(children) => Inline::Emph(smart_inlines(children)),
         Inline::Underline(children) => Inline::Underline(smart_inlines(children)),
         Inline::Strong(children) => Inline::Strong(smart_inlines(children)),
@@ -811,7 +814,7 @@ fn render_items(items: &[Item], cursor: &mut usize) -> Vec<Inline> {
     let mut pending = String::new();
     let flush = |pending: &mut String, out: &mut Vec<Inline>| {
         if !pending.is_empty() {
-            out.push(Inline::Str(std::mem::take(pending)));
+            out.push(Inline::Str(std::mem::take(pending).into()));
         }
     };
     while let Some(item) = items.get(*cursor) {
@@ -987,11 +990,11 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Strong(vec![Inline::Str("Bold".to_owned())]),
+                Inline::Strong(vec![Inline::Str("Bold".to_owned().into())]),
                 Inline::Space,
-                Inline::Str("and".to_owned()),
+                Inline::Str("and".to_owned().into()),
                 Inline::Space,
-                Inline::Emph(vec![Inline::Str("it".to_owned())]),
+                Inline::Emph(vec![Inline::Str("it".to_owned().into())]),
             ]
         );
     }
@@ -1004,15 +1007,15 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Str("a".to_owned()),
+                Inline::Str("a".to_owned().into()),
                 Inline::Space,
-                Inline::Code(Box::default(), "c".to_owned()),
+                Inline::Code(Box::default(), "c".to_owned().into()),
                 Inline::Space,
-                Inline::Str("b".to_owned()),
+                Inline::Str("b".to_owned().into()),
                 Inline::Space,
-                Inline::Str("&".to_owned()),
+                Inline::Str("&".to_owned().into()),
                 Inline::Space,
-                Inline::Str("z".to_owned()),
+                Inline::Str("z".to_owned().into()),
             ]
         );
     }
@@ -1025,7 +1028,7 @@ mod tests {
         assert_eq!(
             inlines,
             vec![Inline::Strong(vec![Inline::Emph(vec![Inline::Str(
-                "both".to_owned()
+                "both".to_owned().into()
             )])])]
         );
     }
@@ -1038,9 +1041,9 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Str("x".to_owned()),
-                Inline::Superscript(vec![Inline::Str("2".to_owned())]),
-                Inline::Subscript(vec![Inline::Str("n".to_owned())]),
+                Inline::Str("x".to_owned().into()),
+                Inline::Superscript(vec![Inline::Str("2".to_owned().into())]),
+                Inline::Subscript(vec![Inline::Str("n".to_owned().into())]),
             ]
         );
     }
@@ -1053,7 +1056,7 @@ mod tests {
         let Some(Inline::Link(_, label, target)) = inlines.first() else {
             panic!("expected a link");
         };
-        assert_eq!(label, &vec![Inline::Str("l".to_owned())]);
+        assert_eq!(label, &vec![Inline::Str("l".to_owned().into())]);
         assert_eq!(target.url, "http://e.com");
     }
 
@@ -1064,11 +1067,11 @@ mod tests {
         assert_eq!(
             inlines,
             vec![
-                Inline::Str("c".to_owned()),
+                Inline::Str("c".to_owned().into()),
                 Inline::Space,
-                Inline::Str("\u{a9}".to_owned()),
+                Inline::Str("\u{a9}".to_owned().into()),
                 Inline::Space,
-                Inline::Str("r".to_owned()),
+                Inline::Str("r".to_owned().into()),
             ]
         );
     }
@@ -1084,7 +1087,7 @@ mod tests {
         let Some(Inline::Link(_, label, target)) = inlines.first() else {
             panic!("expected a link heading");
         };
-        assert_eq!(label, &vec![Inline::Str("Site".to_owned())]);
+        assert_eq!(label, &vec![Inline::Str("Site".to_owned().into())]);
         assert_eq!(target.url, "http://e.com/p");
         assert_eq!(target.title, "");
     }
@@ -1108,7 +1111,7 @@ mod tests {
         let Some(Block::Header(_, _, inlines)) = document.blocks.first() else {
             panic!("expected a header");
         };
-        assert_eq!(inlines.as_slice(), [Inline::Str("Site".to_owned())]);
+        assert_eq!(inlines.as_slice(), [Inline::Str("Site".to_owned().into())]);
     }
 
     #[test]
@@ -1206,7 +1209,7 @@ mod tests {
             inlines,
             vec![Inline::Quoted(
                 QuoteType::DoubleQuote,
-                vec![Inline::Str("hi".to_owned())]
+                vec![Inline::Str("hi".to_owned().into())]
             )]
         );
     }
@@ -1218,7 +1221,7 @@ mod tests {
             inlines,
             vec![Inline::Quoted(
                 QuoteType::SingleQuote,
-                vec![Inline::Str("hi".to_owned())]
+                vec![Inline::Str("hi".to_owned().into())]
             )]
         );
     }
@@ -1226,7 +1229,7 @@ mod tests {
     #[test]
     fn text_attribute_curls_an_apostrophe() {
         let inlines = first_header_inlines(&outline("it&apos;s"));
-        assert_eq!(inlines, vec![Inline::Str("it\u{2019}s".to_owned())]);
+        assert_eq!(inlines, vec![Inline::Str("it\u{2019}s".to_owned().into())]);
     }
 
     #[test]
@@ -1235,7 +1238,9 @@ mod tests {
         // Three hyphens fold to an em dash, two to an en dash, three dots to an ellipsis.
         assert_eq!(
             inlines,
-            vec![Inline::Str("a\u{2014}b\u{2013}c\u{2026}d".to_owned())]
+            vec![Inline::Str(
+                "a\u{2014}b\u{2013}c\u{2026}d".to_owned().into()
+            )]
         );
     }
 
@@ -1266,10 +1271,13 @@ mod tests {
         let opener = first_header_inlines(&outline("&quot;open only"));
         assert_eq!(
             opener.first(),
-            Some(&Inline::Str("\u{201c}open".to_owned()))
+            Some(&Inline::Str("\u{201c}open".to_owned().into()))
         );
         let closer = first_header_inlines(&outline("close only&quot;"));
-        assert_eq!(closer.last(), Some(&Inline::Str("only\u{201d}".to_owned())));
+        assert_eq!(
+            closer.last(),
+            Some(&Inline::Str("only\u{201d}".to_owned().into()))
+        );
     }
 
     #[test]
@@ -1281,11 +1289,11 @@ mod tests {
             vec![
                 Inline::Quoted(
                     QuoteType::DoubleQuote,
-                    vec![Inline::Str("a".to_owned()), Inline::Space]
+                    vec![Inline::Str("a".to_owned().into()), Inline::Space]
                 ),
-                Inline::Str("b\u{201d}".to_owned()),
+                Inline::Str("b\u{201d}".to_owned().into()),
                 Inline::Space,
-                Inline::Str("c\u{201d}".to_owned()),
+                Inline::Str("c\u{201d}".to_owned().into()),
             ]
         );
     }
@@ -1298,11 +1306,14 @@ mod tests {
             vec![Inline::Quoted(
                 QuoteType::DoubleQuote,
                 vec![
-                    Inline::Str("a".to_owned()),
+                    Inline::Str("a".to_owned().into()),
                     Inline::Space,
-                    Inline::Quoted(QuoteType::SingleQuote, vec![Inline::Str("b".to_owned())]),
+                    Inline::Quoted(
+                        QuoteType::SingleQuote,
+                        vec![Inline::Str("b".to_owned().into())]
+                    ),
                     Inline::Space,
-                    Inline::Str("c".to_owned()),
+                    Inline::Str("c".to_owned().into()),
                 ]
             )]
         );
@@ -1311,7 +1322,10 @@ mod tests {
     #[test]
     fn two_straight_single_quotes_stay_apostrophes() {
         let inlines = first_header_inlines(&outline("&apos;&apos;"));
-        assert_eq!(inlines, vec![Inline::Str("\u{2019}\u{2019}".to_owned())]);
+        assert_eq!(
+            inlines,
+            vec![Inline::Str("\u{2019}\u{2019}".to_owned().into())]
+        );
     }
 
     #[test]
@@ -1320,7 +1334,10 @@ mod tests {
         // A matched pair inside a code span renders as its left and right glyphs, not a Quoted node.
         assert_eq!(
             inlines,
-            vec![Inline::Code(Box::default(), "\u{2018}q\u{2019}".to_owned())]
+            vec![Inline::Code(
+                Box::default(),
+                "\u{2018}q\u{2019}".to_owned().into()
+            )]
         );
     }
 
@@ -1331,7 +1348,7 @@ mod tests {
             inlines,
             vec![Inline::Code(
                 Box::default(),
-                "it\u{2019}s \u{2014} x".to_owned()
+                "it\u{2019}s \u{2014} x".to_owned().into()
             )]
         );
     }
@@ -1343,7 +1360,7 @@ mod tests {
             inlines,
             vec![Inline::Emph(vec![Inline::Quoted(
                 QuoteType::DoubleQuote,
-                vec![Inline::Str("hi".to_owned())]
+                vec![Inline::Str("hi".to_owned().into())]
             )])]
         );
     }
@@ -1370,7 +1387,7 @@ mod tests {
         let Some(Block::Para(inlines)) = document.blocks.get(1) else {
             panic!("expected a note paragraph");
         };
-        assert_eq!(inlines, &vec![Inline::Str("it\u{2019}s".to_owned())]);
+        assert_eq!(inlines, &vec![Inline::Str("it\u{2019}s".to_owned().into())]);
     }
 
     #[test]
@@ -1382,13 +1399,13 @@ mod tests {
         assert_eq!(
             title_inlines(&document),
             vec![
-                Inline::Str("\"a\"".to_owned()),
+                Inline::Str("\"a\"".to_owned().into()),
                 Inline::Space,
-                Inline::Str("---".to_owned()),
+                Inline::Str("---".to_owned().into()),
                 Inline::Space,
-                Inline::Str("it's".to_owned()),
+                Inline::Str("it's".to_owned().into()),
                 Inline::Space,
-                Inline::Str("...".to_owned()),
+                Inline::Str("...".to_owned().into()),
             ]
         );
     }
@@ -1400,9 +1417,9 @@ mod tests {
             title_inlines(&document),
             vec![
                 Inline::Space,
-                Inline::Str("a".to_owned()),
+                Inline::Str("a".to_owned().into()),
                 Inline::Space,
-                Inline::Str("b".to_owned()),
+                Inline::Str("b".to_owned().into()),
                 Inline::Space,
             ]
         );
@@ -1415,13 +1432,13 @@ mod tests {
         assert_eq!(
             title_inlines(&document),
             vec![
-                Inline::Str("line".to_owned()),
+                Inline::Str("line".to_owned().into()),
                 Inline::Space,
-                Inline::Str("one".to_owned()),
+                Inline::Str("one".to_owned().into()),
                 Inline::SoftBreak,
-                Inline::Str("line".to_owned()),
+                Inline::Str("line".to_owned().into()),
                 Inline::Space,
-                Inline::Str("two".to_owned()),
+                Inline::Str("two".to_owned().into()),
             ]
         );
     }

--- a/crates/carta-readers/src/org.rs
+++ b/crates/carta-readers/src/org.rs
@@ -237,7 +237,7 @@ fn parse_blocks(
         // Fixed-width (colon) block.
         if is_fixed_width(line) {
             let (text, consumed) = collect_fixed_width(lines, i);
-            out.push(Block::CodeBlock(Box::default(), text));
+            out.push(Block::CodeBlock(Box::default(), text.into()));
             i += consumed;
             pending = Affiliated::default();
             continue;
@@ -254,7 +254,7 @@ fn parse_blocks(
             }
             let body = parse_blocks(&inner, ext, notes, ids, meta);
             let attr = Attr {
-                classes: vec![name, "drawer".to_owned()],
+                classes: vec![name.into(), "drawer".to_owned().into()],
                 ..Attr::default()
             };
             out.push(Block::Div(Box::new(attr), body));
@@ -326,7 +326,7 @@ fn apply_affiliated(block: Block, pending: &mut Affiliated) -> Block {
     match block {
         Block::Para(inlines) if is_lone_image(&inlines) => {
             let attr = Attr {
-                id: name.unwrap_or_default(),
+                id: name.unwrap_or_default().into(),
                 ..Attr::default()
             };
             let long = caption.map(|c| vec![Block::Plain(c)]).unwrap_or_default();
@@ -338,7 +338,7 @@ fn apply_affiliated(block: Block, pending: &mut Affiliated) -> Block {
         }
         Block::CodeBlock(mut attr, text) => {
             if let Some(name) = name {
-                attr.id = name;
+                attr.id = name.into();
             }
             Block::CodeBlock(attr, text)
         }
@@ -397,14 +397,14 @@ fn build_headline(
         inlines.push(Inline::Space);
         for (n, tag) in tags.iter().enumerate() {
             if n > 0 {
-                inlines.push(Inline::Str("\u{a0}".to_owned()));
+                inlines.push(Inline::Str("\u{a0}".to_owned().into()));
             }
             inlines.push(tag_span(tag));
         }
     }
 
     let attr = Attr {
-        id,
+        id: id.into(),
         ..Attr::default()
     };
     let level = i32::try_from(level).unwrap_or(6).clamp(1, 6);
@@ -414,21 +414,21 @@ fn build_headline(
 fn todo_span(keyword: &str) -> Inline {
     let state = if keyword == "DONE" { "done" } else { "todo" };
     let attr = Attr {
-        classes: vec![state.to_owned(), keyword.to_owned()],
+        classes: vec![state.to_owned().into(), keyword.to_owned().into()],
         ..Attr::default()
     };
-    Inline::Span(Box::new(attr), vec![Inline::Str(keyword.to_owned())])
+    Inline::Span(Box::new(attr), vec![Inline::Str(keyword.to_owned().into())])
 }
 
 fn tag_span(tag: &str) -> Inline {
     let attr = Attr {
-        classes: vec!["tag".to_owned()],
-        attributes: vec![("tag-name".to_owned(), tag.to_owned())],
+        classes: vec!["tag".to_owned().into()],
+        attributes: vec![("tag-name".to_owned().into(), tag.to_owned().into())],
         ..Attr::default()
     };
     Inline::Span(
         Box::new(attr),
-        vec![Inline::SmallCaps(vec![Inline::Str(tag.to_owned())])],
+        vec![Inline::SmallCaps(vec![Inline::Str(tag.to_owned().into())])],
     )
 }
 
@@ -568,19 +568,32 @@ fn parse_greater_block(
                 .unwrap_or("")
                 .to_owned();
             let attr = Attr {
-                classes: if lang.is_empty() { vec![] } else { vec![lang] },
+                classes: if lang.is_empty() {
+                    vec![]
+                } else {
+                    vec![lang.into()]
+                },
                 ..Attr::default()
             };
-            Some(Block::CodeBlock(Box::new(attr), dedent_verbatim(&content)))
+            Some(Block::CodeBlock(
+                Box::new(attr),
+                dedent_verbatim(&content).into(),
+            ))
         }
-        "example" => Some(Block::CodeBlock(Box::default(), dedent_verbatim(&content))),
+        "example" => Some(Block::CodeBlock(
+            Box::default(),
+            dedent_verbatim(&content).into(),
+        )),
         "export" => {
             let fmt = header_args
                 .split_whitespace()
                 .next()
                 .unwrap_or("")
                 .to_owned();
-            Some(Block::RawBlock(Format(fmt), verbatim(&content)))
+            Some(Block::RawBlock(
+                Format(fmt.into()),
+                verbatim(&content).into(),
+            ))
         }
         "quote" => Some(Block::BlockQuote(parse_blocks(
             &content, ext, notes, ids, meta,
@@ -594,7 +607,7 @@ fn parse_greater_block(
         "comment" => None,
         _ => {
             let attr = Attr {
-                classes: vec![name.to_owned()],
+                classes: vec![name.to_owned().into()],
                 ..Attr::default()
             };
             Some(Block::Div(
@@ -679,12 +692,15 @@ fn handle_keyword(
     match upper.as_str() {
         "TITLE" | "SUBTITLE" | "AUTHOR" | "DATE" | "KEYWORDS" | "DESCRIPTION" => {
             meta.insert(
-                upper.to_ascii_lowercase(),
+                upper.to_ascii_lowercase().into(),
                 MetaValue::MetaInlines(parse_inlines(value, ext, notes)),
             );
         }
         "LANGUAGE" => {
-            meta.insert("lang".to_owned(), MetaValue::MetaString(value.to_owned()));
+            meta.insert(
+                "lang".to_owned().into(),
+                MetaValue::MetaString(value.to_owned().into()),
+            );
         }
         "CAPTION" => pending.caption = Some(parse_inlines(value, ext, notes)),
         "NAME" | "LABEL" => pending.name = Some(value.to_owned()),
@@ -699,19 +715,19 @@ fn handle_keyword(
             append_header_include(meta, "html", value);
         }
         _ => out.push(Block::RawBlock(
-            Format("org".to_owned()),
-            line.trim_end().to_owned(),
+            Format("org".to_owned().into()),
+            line.trim_end().to_owned().into(),
         )),
     }
 }
 
 fn append_header_include(meta: &mut BTreeMap<Text, MetaValue>, format: &str, value: &str) {
     let entry = MetaValue::MetaInlines(vec![Inline::RawInline(
-        Format(format.to_owned()),
-        value.to_owned(),
+        Format(format.to_owned().into()),
+        value.to_owned().into(),
     )]);
     match meta
-        .entry("header-includes".to_owned())
+        .entry("header-includes".to_owned().into())
         .or_insert_with(|| MetaValue::MetaList(Vec::new()))
     {
         MetaValue::MetaList(list) => list.push(entry),
@@ -887,7 +903,7 @@ fn build_table(
 
     let table = Table {
         attr: Attr {
-            id: name.unwrap_or_default(),
+            id: name.unwrap_or_default().into(),
             ..Attr::default()
         },
         caption,
@@ -1152,9 +1168,9 @@ fn strip_checkbox(line: &str) -> Option<(&'static str, &str)> {
 fn prepend_checkbox(blocks: &mut Vec<Block>, glyph: &str) {
     match blocks.first_mut() {
         Some(Block::Plain(inlines) | Block::Para(inlines)) => {
-            inlines.splice(0..0, [Inline::Str(glyph.to_owned()), Inline::Space]);
+            inlines.splice(0..0, [Inline::Str(glyph.to_owned().into()), Inline::Space]);
         }
-        _ => blocks.insert(0, Block::Plain(vec![Inline::Str(glyph.to_owned())])),
+        _ => blocks.insert(0, Block::Plain(vec![Inline::Str(glyph.to_owned().into())])),
     }
 }
 
@@ -1241,7 +1257,7 @@ impl Inlines<'_> {
 
     fn flush(&mut self) {
         if !self.word.is_empty() {
-            self.out.push(Inline::Str(mem::take(&mut self.word)));
+            self.out.push(Inline::Str(mem::take(&mut self.word).into()));
         }
     }
 
@@ -1264,7 +1280,7 @@ impl Inlines<'_> {
             if is_url_boundary(prev)
                 && let Some((url, end)) = self.scan_bare_url(i)
             {
-                self.push_inline(link(&url, vec![Inline::Str(url.clone())]));
+                self.push_inline(link(&url, vec![Inline::Str(url.clone().into())]));
                 i = end;
                 continue;
             }
@@ -1452,7 +1468,7 @@ impl Inlines<'_> {
             end = close + 1;
         } else {
             let (text, stop) = self.scan_bare_script(i + 1)?;
-            content = vec![Inline::Str(text)];
+            content = vec![Inline::Str(text.into())];
             end = stop;
         }
         let inline = if sup {
@@ -1545,7 +1561,7 @@ impl Inlines<'_> {
         while j < self.chars.len() {
             if self.matches_at(j, &closing) {
                 let inner: String = self.chars.get(start..j).unwrap_or(&[]).iter().collect();
-                self.push_inline(Inline::Math(kind, inner));
+                self.push_inline(Inline::Math(kind, inner.into()));
                 return j + closing.len();
             }
             j += 1;
@@ -1570,8 +1586,8 @@ impl Inlines<'_> {
             self.word.push_str(replacement);
         } else {
             self.push_inline(Inline::RawInline(
-                Format("latex".to_owned()),
-                format!("\\{name}"),
+                Format("latex".to_owned().into()),
+                format!("\\{name}").into(),
             ));
         }
         end
@@ -1623,7 +1639,10 @@ impl Inlines<'_> {
                 if is_image_target(&target) {
                     Some((image(&target, Vec::new()), end))
                 } else {
-                    Some((link(&target, vec![Inline::Str(target_raw.to_owned())]), end))
+                    Some((
+                        link(&target, vec![Inline::Str(target_raw.to_owned().into())]),
+                        end,
+                    ))
                 }
             }
         }
@@ -1715,7 +1734,7 @@ impl Inlines<'_> {
                     .iter()
                     .collect();
                 let attr = Attr {
-                    id: name,
+                    id: name.into(),
                     ..Attr::default()
                 };
                 // A target absorbs the whitespace that follows it.
@@ -1737,7 +1756,10 @@ impl Inlines<'_> {
         }
         let content: String = self.chars.get(i + 1..j).unwrap_or(&[]).iter().collect();
         if is_uri(&content) {
-            return Some((link(&content, vec![Inline::Str(content.clone())]), j + 1));
+            return Some((
+                link(&content, vec![Inline::Str(content.clone().into())]),
+                j + 1,
+            ));
         }
         None
     }
@@ -1752,7 +1774,7 @@ impl Inlines<'_> {
             while j + 1 < self.chars.len() {
                 if self.at(j) == Some('$') && self.at(j + 1) == Some('$') {
                     let inner: String = self.chars.get(start..j).unwrap_or(&[]).iter().collect();
-                    return Some((Inline::Math(MathType::DisplayMath, inner), j + 2));
+                    return Some((Inline::Math(MathType::DisplayMath, inner.into()), j + 2));
                 }
                 j += 1;
             }
@@ -1776,7 +1798,7 @@ impl Inlines<'_> {
                 && !self.at(j + 1).is_some_and(char::is_alphanumeric)
             {
                 let inner: String = self.chars.get(i + 1..j).unwrap_or(&[]).iter().collect();
-                return Some((Inline::Math(MathType::InlineMath, inner), j + 1));
+                return Some((Inline::Math(MathType::InlineMath, inner.into()), j + 1));
             }
             j += 1;
         }
@@ -1809,7 +1831,7 @@ impl Inlines<'_> {
                     .unwrap_or(&[])
                     .iter()
                     .collect();
-                return Some((Inline::RawInline(Format(fmt), content), k + 2));
+                return Some((Inline::RawInline(Format(fmt.into()), content.into()), k + 2));
             }
             k += 1;
         }
@@ -1917,7 +1939,7 @@ fn plain_words(text: &str) -> Vec<Inline> {
         if !out.is_empty() {
             out.push(Inline::Space);
         }
-        out.push(Inline::Str(word.to_owned()));
+        out.push(Inline::Str(word.to_owned().into()));
     }
     out
 }
@@ -1939,13 +1961,13 @@ fn verbatim_code(marker: char, inner: &[char]) -> Inline {
         .collect();
     let attr = if marker == '=' {
         Attr {
-            classes: vec!["verbatim".to_owned()],
+            classes: vec!["verbatim".to_owned().into()],
             ..Attr::default()
         }
     } else {
         Attr::default()
     };
-    Inline::Code(Box::new(attr), text)
+    Inline::Code(Box::new(attr), text.into())
 }
 
 fn link(target: &str, desc: Vec<Inline>) -> Inline {
@@ -1953,8 +1975,8 @@ fn link(target: &str, desc: Vec<Inline>) -> Inline {
         Box::default(),
         desc,
         Box::new(carta_ast::Target {
-            url: target.to_owned(),
-            title: String::new(),
+            url: target.to_owned().into(),
+            title: carta_ast::Text::default(),
         }),
     )
 }
@@ -1964,8 +1986,8 @@ fn image(target: &str, alt: Vec<Inline>) -> Inline {
         Box::default(),
         alt,
         Box::new(carta_ast::Target {
-            url: target.to_owned(),
-            title: String::new(),
+            url: target.to_owned().into(),
+            title: carta_ast::Text::default(),
         }),
     )
 }
@@ -2085,7 +2107,7 @@ fn parse_citation_items(
     if let (Some(suffix), Some(last)) = (trailing_suffix, items.last_mut()) {
         let mut combined = last.2.clone();
         if !combined.is_empty() {
-            combined.push(Inline::Str(";".to_owned()));
+            combined.push(Inline::Str(";".to_owned().into()));
         }
         combined.extend(parse_inlines(suffix.trim(), ext, notes));
         last.2 = combined;
@@ -2095,7 +2117,7 @@ fn parse_citation_items(
         .into_iter()
         .enumerate()
         .map(|(idx, (id, prefix, suffix))| carta_ast::Citation {
-            id,
+            id: id.into(),
             prefix,
             suffix,
             mode: if idx == 0 {

--- a/crates/carta-readers/src/org.rs
+++ b/crates/carta-readers/src/org.rs
@@ -254,7 +254,7 @@ fn parse_blocks(
             }
             let body = parse_blocks(&inner, ext, notes, ids, meta);
             let attr = Attr {
-                classes: vec![name.into(), "drawer".to_owned().into()],
+                classes: vec![name.into(), "drawer".into()],
                 ..Attr::default()
             };
             out.push(Block::Div(Box::new(attr), body));
@@ -397,7 +397,7 @@ fn build_headline(
         inlines.push(Inline::Space);
         for (n, tag) in tags.iter().enumerate() {
             if n > 0 {
-                inlines.push(Inline::Str("\u{a0}".to_owned().into()));
+                inlines.push(Inline::Str("\u{a0}".into()));
             }
             inlines.push(tag_span(tag));
         }
@@ -414,21 +414,21 @@ fn build_headline(
 fn todo_span(keyword: &str) -> Inline {
     let state = if keyword == "DONE" { "done" } else { "todo" };
     let attr = Attr {
-        classes: vec![state.to_owned().into(), keyword.to_owned().into()],
+        classes: vec![state.into(), keyword.into()],
         ..Attr::default()
     };
-    Inline::Span(Box::new(attr), vec![Inline::Str(keyword.to_owned().into())])
+    Inline::Span(Box::new(attr), vec![Inline::Str(keyword.into())])
 }
 
 fn tag_span(tag: &str) -> Inline {
     let attr = Attr {
-        classes: vec!["tag".to_owned().into()],
-        attributes: vec![("tag-name".to_owned().into(), tag.to_owned().into())],
+        classes: vec!["tag".into()],
+        attributes: vec![("tag-name".into(), tag.into())],
         ..Attr::default()
     };
     Inline::Span(
         Box::new(attr),
-        vec![Inline::SmallCaps(vec![Inline::Str(tag.to_owned().into())])],
+        vec![Inline::SmallCaps(vec![Inline::Str(tag.into())])],
     )
 }
 
@@ -607,7 +607,7 @@ fn parse_greater_block(
         "comment" => None,
         _ => {
             let attr = Attr {
-                classes: vec![name.to_owned().into()],
+                classes: vec![name.into()],
                 ..Attr::default()
             };
             Some(Block::Div(
@@ -697,10 +697,7 @@ fn handle_keyword(
             );
         }
         "LANGUAGE" => {
-            meta.insert(
-                "lang".to_owned().into(),
-                MetaValue::MetaString(value.to_owned().into()),
-            );
+            meta.insert("lang".into(), MetaValue::MetaString(value.into()));
         }
         "CAPTION" => pending.caption = Some(parse_inlines(value, ext, notes)),
         "NAME" | "LABEL" => pending.name = Some(value.to_owned()),
@@ -715,19 +712,17 @@ fn handle_keyword(
             append_header_include(meta, "html", value);
         }
         _ => out.push(Block::RawBlock(
-            Format("org".to_owned().into()),
-            line.trim_end().to_owned().into(),
+            Format("org".into()),
+            line.trim_end().into(),
         )),
     }
 }
 
 fn append_header_include(meta: &mut BTreeMap<Text, MetaValue>, format: &str, value: &str) {
-    let entry = MetaValue::MetaInlines(vec![Inline::RawInline(
-        Format(format.to_owned().into()),
-        value.to_owned().into(),
-    )]);
+    let entry =
+        MetaValue::MetaInlines(vec![Inline::RawInline(Format(format.into()), value.into())]);
     match meta
-        .entry("header-includes".to_owned().into())
+        .entry("header-includes".into())
         .or_insert_with(|| MetaValue::MetaList(Vec::new()))
     {
         MetaValue::MetaList(list) => list.push(entry),
@@ -1168,9 +1163,9 @@ fn strip_checkbox(line: &str) -> Option<(&'static str, &str)> {
 fn prepend_checkbox(blocks: &mut Vec<Block>, glyph: &str) {
     match blocks.first_mut() {
         Some(Block::Plain(inlines) | Block::Para(inlines)) => {
-            inlines.splice(0..0, [Inline::Str(glyph.to_owned().into()), Inline::Space]);
+            inlines.splice(0..0, [Inline::Str(glyph.into()), Inline::Space]);
         }
-        _ => blocks.insert(0, Block::Plain(vec![Inline::Str(glyph.to_owned().into())])),
+        _ => blocks.insert(0, Block::Plain(vec![Inline::Str(glyph.into())])),
     }
 }
 
@@ -1586,7 +1581,7 @@ impl Inlines<'_> {
             self.word.push_str(replacement);
         } else {
             self.push_inline(Inline::RawInline(
-                Format("latex".to_owned().into()),
+                Format("latex".into()),
                 format!("\\{name}").into(),
             ));
         }
@@ -1639,10 +1634,7 @@ impl Inlines<'_> {
                 if is_image_target(&target) {
                     Some((image(&target, Vec::new()), end))
                 } else {
-                    Some((
-                        link(&target, vec![Inline::Str(target_raw.to_owned().into())]),
-                        end,
-                    ))
+                    Some((link(&target, vec![Inline::Str(target_raw.into())]), end))
                 }
             }
         }
@@ -1939,7 +1931,7 @@ fn plain_words(text: &str) -> Vec<Inline> {
         if !out.is_empty() {
             out.push(Inline::Space);
         }
-        out.push(Inline::Str(word.to_owned().into()));
+        out.push(Inline::Str(word.into()));
     }
     out
 }
@@ -1961,7 +1953,7 @@ fn verbatim_code(marker: char, inner: &[char]) -> Inline {
         .collect();
     let attr = if marker == '=' {
         Attr {
-            classes: vec!["verbatim".to_owned().into()],
+            classes: vec!["verbatim".into()],
             ..Attr::default()
         }
     } else {
@@ -1975,7 +1967,7 @@ fn link(target: &str, desc: Vec<Inline>) -> Inline {
         Box::default(),
         desc,
         Box::new(carta_ast::Target {
-            url: target.to_owned().into(),
+            url: target.into(),
             title: carta_ast::Text::default(),
         }),
     )
@@ -1986,7 +1978,7 @@ fn image(target: &str, alt: Vec<Inline>) -> Inline {
         Box::default(),
         alt,
         Box::new(carta_ast::Target {
-            url: target.to_owned().into(),
+            url: target.into(),
             title: carta_ast::Text::default(),
         }),
     )
@@ -2107,7 +2099,7 @@ fn parse_citation_items(
     if let (Some(suffix), Some(last)) = (trailing_suffix, items.last_mut()) {
         let mut combined = last.2.clone();
         if !combined.is_empty() {
-            combined.push(Inline::Str(";".to_owned().into()));
+            combined.push(Inline::Str(";".into()));
         }
         combined.extend(parse_inlines(suffix.trim(), ext, notes));
         last.2 = combined;

--- a/crates/carta-readers/src/rst.rs
+++ b/crates/carta-readers/src/rst.rs
@@ -1918,7 +1918,7 @@ impl Parser<'_> {
         match name {
             "raw" => {
                 out.push(Block::RawBlock(
-                    Format(argument.trim().to_string().into()),
+                    Format(argument.trim().into()),
                     content.join("\n").into(),
                 ));
             }
@@ -1967,7 +1967,7 @@ impl Parser<'_> {
                     .map(Into::into)
                     .collect();
                 if alt.is_empty() {
-                    alt = vec![Inline::Str("image".to_string().into())];
+                    alt = vec![Inline::Str("image".into())];
                 }
                 let image = Inline::Image(
                     Box::new(attr),
@@ -1986,7 +1986,7 @@ impl Parser<'_> {
                 let mut blocks = vec![Block::Div(
                     Box::new(Attr {
                         id: carta_ast::Text::default(),
-                        classes: vec!["title".to_string().into()],
+                        classes: vec!["title".into()],
                         attributes: Vec::new(),
                     }),
                     vec![Block::Para(vec![Inline::Str(title.into())])],
@@ -2221,7 +2221,7 @@ impl Parser<'_> {
                 let term = vec![Inline::Span(
                     Box::new(Attr {
                         id: label.clone().into(),
-                        classes: vec!["citation-label".to_string().into()],
+                        classes: vec!["citation-label".into()],
                         attributes: Vec::new(),
                     }),
                     vec![Inline::Str(label.clone().into())],
@@ -2231,7 +2231,7 @@ impl Parser<'_> {
             .collect();
         Some(Block::Div(
             Box::new(Attr {
-                id: "citations".to_string().into(),
+                id: "citations".into(),
                 classes: Vec::new(),
                 attributes: Vec::new(),
             }),
@@ -3084,12 +3084,12 @@ impl Parser<'_> {
             "strong" => Inline::Strong(self.inlines_no_trim(content)),
             "subscript" | "sub" => Inline::Subscript(self.inlines_no_trim(content)),
             "superscript" | "sup" => Inline::Superscript(self.inlines_no_trim(content)),
-            "math" => Inline::Math(MathType::InlineMath, content.to_string().into()),
+            "math" => Inline::Math(MathType::InlineMath, content.into()),
             // A raw role emits its content verbatim under the format its chain declares (empty when
             // none is given); the accumulated classes do not apply to raw inlines.
             "raw" => Inline::RawInline(
                 Format(chain.format.unwrap_or_default().into()),
-                content.to_string().into(),
+                content.into(),
             ),
             // A code/literal role's content is verbatim; a chain's classes lead, then the language.
             "literal" | "code" => {
@@ -3097,7 +3097,7 @@ impl Parser<'_> {
                 if let Some(language) = chain.language {
                     classes.push(language);
                 }
-                Inline::Code(Box::new(class_attr(classes)), content.to_string().into())
+                Inline::Code(Box::new(class_attr(classes)), content.into())
             }
             "title-reference" | "title" | "t" => {
                 let mut classes = chain.classes;
@@ -3115,10 +3115,10 @@ impl Parser<'_> {
             other => Inline::Code(
                 Box::new(Attr {
                     id: carta_ast::Text::default(),
-                    classes: vec!["interpreted-text".to_string().into()],
-                    attributes: vec![("role".to_string().into(), other.to_string().into())],
+                    classes: vec!["interpreted-text".into()],
+                    attributes: vec![("role".into(), other.into())],
                 }),
-                content.to_string().into(),
+                content.into(),
             ),
         }
     }
@@ -3270,7 +3270,7 @@ impl Parser<'_> {
             let link = Inline::Link(
                 Box::new(Attr {
                     id: carta_ast::Text::default(),
-                    classes: vec!["citation".to_string().into()],
+                    classes: vec!["citation".into()],
                     attributes: Vec::new(),
                 }),
                 vec![Inline::Str(format!("[{label}]").into())],

--- a/crates/carta-readers/src/rst.rs
+++ b/crates/carta-readers/src/rst.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, VecDeque};
 use carta_ast::{
     Alignment, Attr, Block, Caption, Cell, ColSpec, ColWidth, Document, Format, Inline,
     ListAttributes, ListNumberDelim, ListNumberStyle, MathType, QuoteType, Row, Table, TableBody,
-    TableFoot, TableHead, Target,
+    TableFoot, TableHead, Target, Text,
 };
 use carta_core::{Extension, Extensions, Reader, ReaderOptions, Result};
 
@@ -958,7 +958,10 @@ fn parse_substitution(
         "replace" => Some((name, Substitution::Replace(argument))),
         "image" => {
             let (mut attr, mut alt, url) = image_parts(&argument, &options);
-            attr.classes = image_classes(&options);
+            attr.classes = image_classes(&options)
+                .into_iter()
+                .map(Into::into)
+                .collect();
             // A substitution image with no explicit alt text falls back to the substitution name.
             if alt.is_empty() {
                 push_text(&mut alt, &name);
@@ -1370,9 +1373,16 @@ impl Parser<'_> {
             // An empty `class` directive leaves a marker whose classes wrap the next block.
             if let Some(Block::Div(attr, content)) = out.last()
                 && content.is_empty()
-                && attr.classes.first().map(String::as_str) == Some(PENDING_CLASS)
+                && attr.classes.first().map(Text::as_str) == Some(PENDING_CLASS)
             {
-                pending_classes = Some(attr.classes.get(1..).unwrap_or(&[]).to_vec());
+                pending_classes = Some(
+                    attr.classes
+                        .get(1..)
+                        .unwrap_or(&[])
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect(),
+                );
                 out.pop();
             }
         }
@@ -1503,7 +1513,7 @@ impl Parser<'_> {
         Block::Header(
             level,
             Box::new(Attr {
-                id,
+                id: id.into(),
                 classes: Vec::new(),
                 attributes: Vec::new(),
             }),
@@ -1621,7 +1631,7 @@ impl Parser<'_> {
             text_lines.pop();
         }
         Some((
-            Block::CodeBlock(Box::default(), text_lines.join("\n")),
+            Block::CodeBlock(Box::default(), text_lines.join("\n").into()),
             end + 1,
         ))
     }
@@ -1646,7 +1656,10 @@ impl Parser<'_> {
         if text_lines.is_empty() {
             return None;
         }
-        Some((Block::CodeBlock(Box::default(), text_lines.join("\n")), i))
+        Some((
+            Block::CodeBlock(Box::default(), text_lines.join("\n").into()),
+            i,
+        ))
     }
 
     fn line_block(&mut self, lines: &[String], start: usize, out: &mut Vec<Block>) -> usize {
@@ -1861,7 +1874,7 @@ impl Parser<'_> {
             };
             let end = explicit_extent(lines, i, 0);
             let body = explicit_body(lines, i, end, value_col);
-            let term_inline = vec![Inline::Code(Box::default(), term)];
+            let term_inline = vec![Inline::Code(Box::default(), term.into())];
             items.push((term_inline, vec![self.blocks(&body)]));
             i = end;
         }
@@ -1905,8 +1918,8 @@ impl Parser<'_> {
         match name {
             "raw" => {
                 out.push(Block::RawBlock(
-                    Format(argument.trim().to_string()),
-                    content.join("\n"),
+                    Format(argument.trim().to_string().into()),
+                    content.join("\n").into(),
                 ));
             }
             "code" | "code-block" | "sourcecode" => {
@@ -1915,7 +1928,7 @@ impl Parser<'_> {
                 while text.ends_with('\n') {
                     text.pop();
                 }
-                out.push(Block::CodeBlock(Box::new(attr), text));
+                out.push(Block::CodeBlock(Box::new(attr), text.into()));
             }
             "math" => {
                 let mut equations = Vec::new();
@@ -1925,7 +1938,7 @@ impl Parser<'_> {
                 equations.extend(blank_separated(&content));
                 let math: Vec<Inline> = equations
                     .into_iter()
-                    .map(|eq| Inline::Math(MathType::DisplayMath, eq))
+                    .map(|eq| Inline::Math(MathType::DisplayMath, eq.into()))
                     .collect();
                 let (id, classes, attributes) = common_options(&options);
                 // Options (a `:label:`, `:nowrap:`, …) attach to the whole equation group through a
@@ -1935,9 +1948,12 @@ impl Parser<'_> {
                 } else {
                     vec![Inline::Span(
                         Box::new(Attr {
-                            id,
-                            classes,
-                            attributes,
+                            id: id.into(),
+                            classes: classes.into_iter().map(Into::into).collect(),
+                            attributes: attributes
+                                .into_iter()
+                                .map(|(k, v)| (k.into(), v.into()))
+                                .collect(),
                         }),
                         math,
                     )]
@@ -1946,16 +1962,19 @@ impl Parser<'_> {
             }
             "image" => {
                 let (mut attr, mut alt, url) = image_parts(&argument, &options);
-                attr.classes = image_classes(&options);
+                attr.classes = image_classes(&options)
+                    .into_iter()
+                    .map(Into::into)
+                    .collect();
                 if alt.is_empty() {
-                    alt = vec![Inline::Str("image".to_string())];
+                    alt = vec![Inline::Str("image".to_string().into())];
                 }
                 let image = Inline::Image(
                     Box::new(attr),
                     alt,
                     Box::new(Target {
-                        url,
-                        title: String::new(),
+                        url: url.into(),
+                        title: carta_ast::Text::default(),
                     }),
                 );
                 out.push(Block::Para(vec![Self::wrap_target(image, &options)]));
@@ -1966,11 +1985,11 @@ impl Parser<'_> {
                 let title = capitalize(name);
                 let mut blocks = vec![Block::Div(
                     Box::new(Attr {
-                        id: String::new(),
-                        classes: vec!["title".to_string()],
+                        id: carta_ast::Text::default(),
+                        classes: vec!["title".to_string().into()],
                         attributes: Vec::new(),
                     }),
-                    vec![Block::Para(vec![Inline::Str(title)])],
+                    vec![Block::Para(vec![Inline::Str(title.into())])],
                 )];
                 blocks.extend(self.blocks(&directive_content(&body)));
                 out.push(options_div(name, &options, blocks));
@@ -2103,8 +2122,8 @@ impl Parser<'_> {
                 Box::default(),
                 vec![image],
                 Box::new(Target {
-                    url: url.clone(),
-                    title: String::new(),
+                    url: url.clone().into(),
+                    title: carta_ast::Text::default(),
                 }),
             )
         } else {
@@ -2139,8 +2158,8 @@ impl Parser<'_> {
             Box::new(img_attr),
             description,
             Box::new(Target {
-                url,
-                title: String::new(),
+                url: url.into(),
+                title: carta_ast::Text::default(),
             }),
         );
         let body = vec![Block::Plain(vec![image])];
@@ -2201,18 +2220,18 @@ impl Parser<'_> {
             .map(|(label, body)| {
                 let term = vec![Inline::Span(
                     Box::new(Attr {
-                        id: label.clone(),
-                        classes: vec!["citation-label".to_string()],
+                        id: label.clone().into(),
+                        classes: vec!["citation-label".to_string().into()],
                         attributes: Vec::new(),
                     }),
-                    vec![Inline::Str(label.clone())],
+                    vec![Inline::Str(label.clone().into())],
                 )];
                 (term, vec![self.blocks(body)])
             })
             .collect();
         Some(Block::Div(
             Box::new(Attr {
-                id: "citations".to_string(),
+                id: "citations".to_string().into(),
                 classes: Vec::new(),
                 attributes: Vec::new(),
             }),
@@ -2836,7 +2855,7 @@ impl Parser<'_> {
         Some((
             Inline::Span(
                 Box::new(Attr {
-                    id,
+                    id: id.into(),
                     classes: Vec::new(),
                     attributes: Vec::new(),
                 }),
@@ -3005,7 +3024,7 @@ impl Parser<'_> {
             return Some((
                 vec![Inline::Code(
                     Box::default(),
-                    normalize_inline_literal(&content),
+                    normalize_inline_literal(&content).into(),
                 )],
                 false,
                 end,
@@ -3065,12 +3084,12 @@ impl Parser<'_> {
             "strong" => Inline::Strong(self.inlines_no_trim(content)),
             "subscript" | "sub" => Inline::Subscript(self.inlines_no_trim(content)),
             "superscript" | "sup" => Inline::Superscript(self.inlines_no_trim(content)),
-            "math" => Inline::Math(MathType::InlineMath, content.to_string()),
+            "math" => Inline::Math(MathType::InlineMath, content.to_string().into()),
             // A raw role emits its content verbatim under the format its chain declares (empty when
             // none is given); the accumulated classes do not apply to raw inlines.
             "raw" => Inline::RawInline(
-                Format(chain.format.unwrap_or_default()),
-                content.to_string(),
+                Format(chain.format.unwrap_or_default().into()),
+                content.to_string().into(),
             ),
             // A code/literal role's content is verbatim; a chain's classes lead, then the language.
             "literal" | "code" => {
@@ -3078,7 +3097,7 @@ impl Parser<'_> {
                 if let Some(language) = chain.language {
                     classes.push(language);
                 }
-                Inline::Code(Box::new(class_attr(classes)), content.to_string())
+                Inline::Code(Box::new(class_attr(classes)), content.to_string().into())
             }
             "title-reference" | "title" | "t" => {
                 let mut classes = chain.classes;
@@ -3095,11 +3114,11 @@ impl Parser<'_> {
             // information survives a round-trip.
             other => Inline::Code(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["interpreted-text".to_string()],
-                    attributes: vec![("role".to_string(), other.to_string())],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["interpreted-text".to_string().into()],
+                    attributes: vec![("role".to_string().into(), other.to_string().into())],
                 }),
-                content.to_string(),
+                content.to_string().into(),
             ),
         }
     }
@@ -3168,8 +3187,8 @@ impl Parser<'_> {
                     Box::default(),
                     display,
                     Box::new(Target {
-                        url: format!("##SUBST##|{name}|"),
-                        title: String::new(),
+                        url: format!("##SUBST##|{name}|").into(),
+                        title: carta_ast::Text::default(),
                     }),
                 )],
                 false,
@@ -3191,8 +3210,8 @@ impl Parser<'_> {
                 Box::new(attr),
                 alt,
                 Box::new(Target {
-                    url,
-                    title: String::new(),
+                    url: url.into(),
+                    title: carta_ast::Text::default(),
                 }),
             )],
             None => {
@@ -3205,8 +3224,8 @@ impl Parser<'_> {
                         Box::default(),
                         display,
                         Box::new(Target {
-                            url: format!("##SUBST##|{name}|"),
-                            title: String::new(),
+                            url: format!("##SUBST##|{name}|").into(),
+                            title: carta_ast::Text::default(),
                         }),
                     )],
                     false,
@@ -3219,8 +3238,8 @@ impl Parser<'_> {
                 Box::default(),
                 expansion,
                 Box::new(Target {
-                    url: defer_reference(&name),
-                    title: String::new(),
+                    url: defer_reference(&name).into(),
+                    title: carta_ast::Text::default(),
                 }),
             )]
         } else {
@@ -3250,14 +3269,14 @@ impl Parser<'_> {
             let url = format!("#{label}");
             let link = Inline::Link(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["citation".to_string()],
+                    id: carta_ast::Text::default(),
+                    classes: vec!["citation".to_string().into()],
                     attributes: Vec::new(),
                 }),
-                vec![Inline::Str(format!("[{label}]"))],
+                vec![Inline::Str(format!("[{label}]").into())],
                 Box::new(Target {
-                    url,
-                    title: String::new(),
+                    url: url.into(),
+                    title: carta_ast::Text::default(),
                 }),
             );
             return Some((vec![link], false, end));
@@ -3311,8 +3330,8 @@ impl Parser<'_> {
             Box::default(),
             self.inlines(&display),
             Box::new(Target {
-                url: target,
-                title: String::new(),
+                url: target.into(),
+                title: carta_ast::Text::default(),
             }),
         )
     }
@@ -3351,10 +3370,10 @@ impl Parser<'_> {
         };
         let link = Inline::Link(
             Box::default(),
-            vec![Inline::Str(name)],
+            vec![Inline::Str(name.into())],
             Box::new(Target {
-                url,
-                title: String::new(),
+                url: url.into(),
+                title: carta_ast::Text::default(),
             }),
         );
         Some((link, after))
@@ -3451,7 +3470,7 @@ impl Parser<'_> {
             match inline {
                 Inline::Link(_, children, target) | Inline::Image(_, children, target) => {
                     if let Some(name) = target.url.strip_prefix(REF_SENTINEL) {
-                        target.url = self.lookup_url(name);
+                        target.url = self.lookup_url(name).into();
                     }
                     self.resolve_inlines(children);
                 }
@@ -3689,9 +3708,12 @@ fn code_attr(argument: &str, options: &[(String, String)]) -> Attr {
         }
     }
     Attr {
-        id,
-        classes,
-        attributes,
+        id: id.into(),
+        classes: classes.into_iter().map(Into::into).collect(),
+        attributes: attributes
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect(),
     }
 }
 
@@ -3704,16 +3726,22 @@ fn image_parts(argument: &str, options: &[(String, String)]) -> (Attr, Vec<Inlin
     let mut description = Vec::new();
     for (key, value) in options {
         match key.as_str() {
-            "alt" => description = vec![Inline::Str(value.clone())],
+            "alt" => description = vec![Inline::Str(value.clone().into())],
             "name" => id.clone_from(value),
             _ => {}
         }
     }
     (
         Attr {
-            id,
-            classes: class_list(options, "class"),
-            attributes: image_dimensions(options),
+            id: id.into(),
+            classes: class_list(options, "class")
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            attributes: image_dimensions(options)
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         },
         description,
         url,
@@ -3731,12 +3759,15 @@ fn image_classes(options: &[(String, String)]) -> Vec<String> {
 /// alignment folded in. The figure's `:name:` identifies its image, not the figure itself.
 fn figure_attr(options: &[(String, String)]) -> Attr {
     Attr {
-        id: String::new(),
+        id: carta_ast::Text::default(),
         classes: aligned_classes(
             class_list(options, "figclass"),
             class_list(options, "class"),
             &align_suffix(options),
-        ),
+        )
+        .into_iter()
+        .map(Into::into)
+        .collect(),
         attributes: Vec::new(),
     }
 }
@@ -3868,8 +3899,8 @@ fn scale_dimension(dimension: Dimension, scale: Option<(f64, bool)>) -> Dimensio
 fn class_div(classes: Vec<String>, blocks: Vec<Block>) -> Block {
     Block::Div(
         Box::new(Attr {
-            id: String::new(),
-            classes,
+            id: carta_ast::Text::default(),
+            classes: classes.into_iter().map(Into::into).collect(),
             attributes: Vec::new(),
         }),
         blocks,
@@ -3902,8 +3933,8 @@ fn normalize_inline_literal(content: &str) -> String {
 /// An attribute set carrying only classes, with no identifier or key-value attributes.
 fn class_attr(classes: Vec<String>) -> Attr {
     Attr {
-        id: String::new(),
-        classes,
+        id: carta_ast::Text::default(),
+        classes: classes.into_iter().map(Into::into).collect(),
         attributes: Vec::new(),
     }
 }
@@ -3915,11 +3946,11 @@ fn attach_targets(mut blocks: Vec<Block>, mut targets: Vec<String>) -> Vec<Block
     if let [Block::Header(_, attr, inlines)] = blocks.as_mut_slice()
         && let Some(last) = targets.pop()
     {
-        attr.id = last;
+        attr.id = last.into();
         for name in targets.into_iter().rev() {
             inlines.push(Inline::Span(
                 Box::new(Attr {
-                    id: name,
+                    id: name.into(),
                     classes: Vec::new(),
                     attributes: Vec::new(),
                 }),
@@ -3931,7 +3962,7 @@ fn attach_targets(mut blocks: Vec<Block>, mut targets: Vec<String>) -> Vec<Block
     for name in targets.into_iter().rev() {
         blocks = vec![Block::Div(
             Box::new(Attr {
-                id: name,
+                id: name.into(),
                 classes: Vec::new(),
                 attributes: Vec::new(),
             }),
@@ -3965,9 +3996,12 @@ fn options_div(name: &str, options: &[(String, String)], blocks: Vec<Block>) -> 
     classes.extend(extra);
     Block::Div(
         Box::new(Attr {
-            id,
-            classes,
-            attributes,
+            id: id.into(),
+            classes: classes.into_iter().map(Into::into).collect(),
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         }),
         blocks,
     )
@@ -4122,12 +4156,12 @@ fn push_text(out: &mut Vec<Inline>, text: &str) {
     for ch in text.chars() {
         if ch == '\n' {
             if !word.is_empty() {
-                out.push(Inline::Str(std::mem::take(&mut word)));
+                out.push(Inline::Str(std::mem::take(&mut word).into()));
             }
             out.push(Inline::SoftBreak);
         } else if ch == ' ' || ch == '\t' {
             if !word.is_empty() {
-                out.push(Inline::Str(std::mem::take(&mut word)));
+                out.push(Inline::Str(std::mem::take(&mut word).into()));
             }
             // Collapse a run of spaces to one node, but keep a leading space: callers that must not
             // begin or end with one trim their result, while interpreted-text content keeps it.
@@ -4139,7 +4173,7 @@ fn push_text(out: &mut Vec<Inline>, text: &str) {
         }
     }
     if !word.is_empty() {
-        out.push(Inline::Str(word));
+        out.push(Inline::Str(word.into()));
     }
 }
 
@@ -4375,10 +4409,10 @@ fn try_uri_autolink(chars: &[char], pos: usize) -> Option<(Inline, usize)> {
     Some((
         Inline::Link(
             Box::default(),
-            vec![Inline::Str(url.clone())],
+            vec![Inline::Str(url.clone().into())],
             Box::new(Target {
-                url: escape_uri(&url),
-                title: String::new(),
+                url: escape_uri(&url).into(),
+                title: carta_ast::Text::default(),
             }),
         ),
         end,
@@ -4429,10 +4463,10 @@ fn try_email_autolink(chars: &[char], pos: usize) -> Option<(Inline, usize)> {
     Some((
         Inline::Link(
             Box::default(),
-            vec![Inline::Str(address.clone())],
+            vec![Inline::Str(address.clone().into())],
             Box::new(Target {
-                url: format!("mailto:{address}"),
-                title: String::new(),
+                url: format!("mailto:{address}").into(),
+                title: carta_ast::Text::default(),
             }),
         ),
         end,
@@ -5290,7 +5324,7 @@ mod tests {
                         vec![Inline::Str("website".into())],
                         Box::new(Target {
                             url: "https://example.org".into(),
-                            title: String::new(),
+                            title: carta_ast::Text::default(),
                         }),
                     ))
                 );
@@ -5444,7 +5478,7 @@ mod tests {
             .attributes
             .into_iter()
             .find(|(key, _)| key == "width")
-            .map(|(_, value)| value)
+            .map(|(_, value)| value.to_string())
     }
 
     #[test]

--- a/crates/carta-writers/src/asciidoc.rs
+++ b/crates/carta-writers/src/asciidoc.rs
@@ -8,7 +8,7 @@ use std::fmt::Write as _;
 
 use carta_ast::{
     Alignment, Attr, Block, Caption, Cell, ColWidth, Document, Inline, ListAttributes,
-    ListNumberStyle, MathType, QuoteType, Row, Table, TableBody, Target, slug, to_plain_text,
+    ListNumberStyle, MathType, QuoteType, Row, Table, TableBody, Target, Text, slug, to_plain_text,
 };
 use carta_core::{Result, TocStyle, WrapMode, Writer, WriterOptions};
 
@@ -560,7 +560,7 @@ impl State {
             && !url.contains(char::is_whitespace)
             && scheme != Some("mailto");
         if bare {
-            out.push(Piece::Text(url.clone()));
+            out.push(Piece::Text(url.to_string()));
             return;
         }
         let prefix = if scheme.is_some_and(is_autolink_scheme) {
@@ -921,7 +921,7 @@ fn code_block(attr: &Attr, text: &str) -> String {
         .classes
         .iter()
         .filter(|class| class.as_str() != "numberLines")
-        .map(String::as_str)
+        .map(Text::as_str)
         .collect();
     let mut header = String::from("[source");
     if numbered {

--- a/crates/carta-writers/src/beamer.rs
+++ b/crates/carta-writers/src/beamer.rs
@@ -128,7 +128,7 @@ fn frame_options(title: Option<&FrameTitle>, fragile: bool) -> String {
     if let Some(title) = title {
         for class in &title.attr.classes {
             if FRAME_CLASSES.contains(&class.as_str()) {
-                options.push(class.clone());
+                options.push(class.to_string());
             }
         }
         if let Some((_, value)) = title.attr.attributes.iter().find(|(key, _)| key == "label") {
@@ -302,17 +302,17 @@ mod tests {
     }
 
     fn para(text: &str) -> Block {
-        Block::Para(vec![Inline::Str(text.to_owned())])
+        Block::Para(vec![Inline::Str(text.to_owned().into())])
     }
 
     fn header(level: i32, id: &str, title: &str) -> Block {
         Block::Header(
             level,
             Box::new(Attr {
-                id: id.to_owned(),
+                id: id.to_owned().into(),
                 ..Attr::default()
             }),
-            vec![Inline::Str(title.to_owned())],
+            vec![Inline::Str(title.to_owned().into())],
         )
     }
 
@@ -345,7 +345,10 @@ mod tests {
 
     #[test]
     fn code_block_marks_frame_fragile() {
-        let out = render(vec![Block::CodeBlock(Box::default(), "x\n".to_owned())]);
+        let out = render(vec![Block::CodeBlock(
+            Box::default(),
+            "x\n".to_owned().into(),
+        )]);
         assert!(out.starts_with("\\begin{frame}[fragile]"));
     }
 
@@ -353,7 +356,7 @@ mod tests {
     fn inline_code_marks_frame_fragile() {
         let out = render(vec![Block::Para(vec![Inline::Code(
             Box::default(),
-            "x".to_owned(),
+            "x".to_owned().into(),
         )])]);
         assert!(out.starts_with("\\begin{frame}[fragile]"));
     }
@@ -373,12 +376,15 @@ mod tests {
     #[test]
     fn recognized_class_becomes_frame_option() {
         let mut attr = Attr {
-            id: "six".to_owned(),
+            id: "six".to_owned().into(),
             ..Attr::default()
         };
-        attr.classes = vec!["allowframebreaks".to_owned(), "unknown".to_owned()];
+        attr.classes = vec![
+            "allowframebreaks".to_owned().into(),
+            "unknown".to_owned().into(),
+        ];
         let out = render(vec![
-            Block::Header(6, Box::new(attr), vec![Inline::Str("T".to_owned())]),
+            Block::Header(6, Box::new(attr), vec![Inline::Str("T".to_owned().into())]),
             para("y"),
         ]);
         assert!(out.starts_with("\\begin{frame}[allowframebreaks]{T}"));
@@ -392,7 +398,7 @@ mod tests {
     fn div(classes: &[&str], blocks: Vec<Block>) -> Block {
         Block::Div(
             Box::new(Attr {
-                classes: classes.iter().map(|class| (*class).to_owned()).collect(),
+                classes: classes.iter().map(|class| (*class).into()).collect(),
                 ..Attr::default()
             }),
             blocks,

--- a/crates/carta-writers/src/common.rs
+++ b/crates/carta-writers/src/common.rs
@@ -924,8 +924,8 @@ pub(crate) fn normalize_image_attr(attr: &Attr) -> Attr {
     for (key, value) in &attr.attributes {
         match key.as_str() {
             "width" | "height" => {}
-            "style" => base_style = Some(value.clone()),
-            _ => rest.push((key.clone(), value.clone())),
+            "style" => base_style = Some(value.to_string()),
+            _ => rest.push((key.to_string(), value.to_string())),
         }
     }
 
@@ -941,7 +941,10 @@ pub(crate) fn normalize_image_attr(attr: &Attr) -> Attr {
     Attr {
         id: attr.id.clone(),
         classes: attr.classes.clone(),
-        attributes,
+        attributes: attributes
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect(),
     }
 }
 
@@ -1568,7 +1571,7 @@ pub(crate) fn html_attr_tokens(attr: &Attr) -> Vec<String> {
     }
     for (key, value) in &attr.attributes {
         let name = if is_known_attribute(key) {
-            key.clone()
+            key.to_string()
         } else {
             format!("data-{key}")
         };
@@ -2452,7 +2455,7 @@ mod tests {
         };
         assert_eq!(
             normalize_image_attr(&pixels).attributes,
-            vec![("width".to_owned(), "200".to_owned())]
+            vec![("width".into(), "200".into())]
         );
         let percent = Attr {
             attributes: vec![("width".into(), "50%".into())],
@@ -2460,7 +2463,7 @@ mod tests {
         };
         assert_eq!(
             normalize_image_attr(&percent).attributes,
-            vec![("style".to_owned(), "width:50.0%".to_owned())]
+            vec![("style".into(), "width:50.0%".into())]
         );
     }
 
@@ -2481,10 +2484,10 @@ mod tests {
         assert_eq!(
             normalize_image_attr(&attr).attributes,
             vec![
-                ("style".to_owned(), "width:50.0%".to_owned()),
-                ("data-a".to_owned(), "1".to_owned()),
-                ("loading".to_owned(), "lazy".to_owned()),
-                ("height".to_owned(), "200".to_owned()),
+                ("style".into(), "width:50.0%".into()),
+                ("data-a".into(), "1".into()),
+                ("loading".into(), "lazy".into()),
+                ("height".into(), "200".into()),
             ]
         );
     }
@@ -2503,8 +2506,8 @@ mod tests {
         assert_eq!(
             normalize_image_attr(&attr).attributes,
             vec![
-                ("width".to_owned(), "200".to_owned()),
-                ("height".to_owned(), "100".to_owned()),
+                ("width".into(), "200".into()),
+                ("height".into(), "100".into()),
             ]
         );
         let both_style = Attr {
@@ -2516,7 +2519,7 @@ mod tests {
         };
         assert_eq!(
             normalize_image_attr(&both_style).attributes,
-            vec![("style".to_owned(), "width:50.0%;height:5cm".to_owned())]
+            vec![("style".into(), "width:50.0%;height:5cm".into())]
         );
     }
 
@@ -2532,7 +2535,7 @@ mod tests {
         };
         assert_eq!(
             normalize_image_attr(&attr).attributes,
-            vec![("style".to_owned(), "color:red;width:50.0%".to_owned())]
+            vec![("style".into(), "color:red;width:50.0%".into())]
         );
         // A source style with no dimensions still moves ahead of the remaining pairs.
         let style_only = Attr {
@@ -2546,9 +2549,9 @@ mod tests {
         assert_eq!(
             normalize_image_attr(&style_only).attributes,
             vec![
-                ("style".to_owned(), "color:red".to_owned()),
-                ("data-a".to_owned(), "1".to_owned()),
-                ("data-b".to_owned(), "2".to_owned()),
+                ("style".into(), "color:red".into()),
+                ("data-a".into(), "1".into()),
+                ("data-b".into(), "2".into()),
             ]
         );
     }
@@ -2568,9 +2571,6 @@ mod tests {
         assert_eq!(normalized.id, "x");
         assert_eq!(normalized.classes, vec!["c".to_owned()]);
         // The unparsable width is dropped; the pixel height survives.
-        assert_eq!(
-            normalized.attributes,
-            vec![("height".to_owned(), "100".to_owned())]
-        );
+        assert_eq!(normalized.attributes, vec![("height".into(), "100".into())]);
     }
 }

--- a/crates/carta-writers/src/commonmark.rs
+++ b/crates/carta-writers/src/commonmark.rs
@@ -390,7 +390,7 @@ impl State {
                     MathType::DisplayMath => ("$$", tex),
                     MathType::InlineMath => ("$", tex.trim()),
                 };
-                let fallback = Inline::Str(format!("{delim}{body}{delim}"));
+                let fallback = Inline::Str(format!("{delim}{body}{delim}").into());
                 self.inline(&fallback, out, false);
             }
         }
@@ -708,7 +708,7 @@ fn push_html(out: &mut Vec<Piece>, html: &str, breakable: bool) {
 /// The `(url "title")` destination tail of a link or image, with the title omitted when empty.
 fn destination(target: &Target) -> String {
     if target.title.is_empty() {
-        target.url.clone()
+        target.url.to_string()
     } else {
         format!("{} \"{}\"", target.url, target.title)
     }
@@ -946,7 +946,7 @@ mod tests {
     }
 
     fn str_inlines(text: &str) -> Vec<Inline> {
-        vec![Inline::Str(text.to_owned())]
+        vec![Inline::Str(text.to_owned().into())]
     }
 
     fn plain_item(text: &str) -> Vec<Block> {
@@ -983,7 +983,7 @@ mod tests {
     fn autolink_for_uri_and_mailto() {
         let uri = Target {
             url: "http://example.com".into(),
-            title: String::new(),
+            title: String::new().into(),
         };
         assert_eq!(
             autolink(&str_inlines("http://example.com"), &uri),
@@ -991,7 +991,7 @@ mod tests {
         );
         let mail = Target {
             url: "mailto:a@b.com".into(),
-            title: String::new(),
+            title: String::new().into(),
         };
         assert_eq!(
             autolink(&str_inlines("a@b.com"), &mail),
@@ -999,7 +999,7 @@ mod tests {
         );
         let plain = Target {
             url: "http://other".into(),
-            title: String::new(),
+            title: String::new().into(),
         };
         assert_eq!(autolink(&str_inlines("text"), &plain), None);
     }
@@ -1049,7 +1049,7 @@ mod tests {
             str_inlines("http://example.com"),
             Box::new(Target {
                 url: "http://example.com".into(),
-                title: String::new(),
+                title: String::new().into(),
             }),
         );
         assert_eq!(render(vec![para(vec![link])]), "<http://example.com>");
@@ -1179,8 +1179,8 @@ mod tests {
         let div = Block::Div(
             Box::new(Attr {
                 attributes: vec![
-                    ("data-one".into(), a.clone()),
-                    ("data-two".into(), b.clone()),
+                    ("data-one".into(), a.clone().into()),
+                    ("data-two".into(), b.clone().into()),
                 ],
                 ..Attr::default()
             }),
@@ -1205,8 +1205,8 @@ mod tests {
             }),
             vec![],
             Box::new(Target {
-                url: url.clone(),
-                title: String::new(),
+                url: url.clone().into(),
+                title: String::new().into(),
             }),
         );
         assert_eq!(
@@ -1261,7 +1261,7 @@ mod tests {
             "``` rust\nfn x(){}\n```"
         );
         assert_eq!(
-            render(vec![Block::CodeBlock(Box::new(attr), String::new())]),
+            render(vec![Block::CodeBlock(Box::new(attr), String::new().into())]),
             "``` rust\n```"
         );
     }
@@ -1350,7 +1350,7 @@ mod tests {
         assert_eq!(
             destination(&Target {
                 url: "/p".into(),
-                title: String::new()
+                title: String::new().into()
             }),
             "/p"
         );
@@ -1361,16 +1361,16 @@ mod tests {
             }),
             "/p \"T\""
         );
-        assert_eq!(title_attr(&String::new()), "");
-        assert_eq!(title_attr(&"T".to_owned()), " title=\"T\"");
+        assert_eq!(title_attr(&carta_ast::Text::default()), "");
+        assert_eq!(title_attr(&"T".into()), " title=\"T\"");
     }
 
     fn inline_math(tex: &str) -> Inline {
-        Inline::Math(MathType::InlineMath, tex.to_owned())
+        Inline::Math(MathType::InlineMath, tex.to_owned().into())
     }
 
     fn display_math(tex: &str) -> Inline {
-        Inline::Math(MathType::DisplayMath, tex.to_owned())
+        Inline::Math(MathType::DisplayMath, tex.to_owned().into())
     }
 
     #[test]
@@ -1503,7 +1503,7 @@ mod tests {
             str_inlines("alt"),
             Box::new(Target {
                 url: "pic.png".into(),
-                title: String::new(),
+                title: String::new().into(),
             }),
         );
         assert_eq!(
@@ -1519,7 +1519,7 @@ mod tests {
             str_inlines("alt"),
             Box::new(Target {
                 url: "pic.png".into(),
-                title: String::new(),
+                title: String::new().into(),
             }),
         );
         assert_eq!(render(vec![para(vec![image])]), "![alt](pic.png)");
@@ -1528,13 +1528,16 @@ mod tests {
     fn dimensioned_image(attributes: Vec<(String, String)>) -> Inline {
         Inline::Image(
             Box::new(Attr {
-                attributes,
+                attributes: attributes
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect(),
                 ..Attr::default()
             }),
             str_inlines("alt"),
             Box::new(Target {
                 url: "pic.png".into(),
-                title: String::new(),
+                title: String::new().into(),
             }),
         )
     }

--- a/crates/carta-writers/src/dokuwiki.rs
+++ b/crates/carta-writers/src/dokuwiki.rs
@@ -371,7 +371,7 @@ fn bare_inline(inline: &Inline) -> String {
 fn link(inlines: &[Inline], target: &Target, wrap: WrapMode) -> String {
     let plain = to_plain_text(inlines);
     if plain == target.url && !target.url.contains(' ') {
-        return target.url.clone();
+        return target.url.to_string();
     }
     if target.url.starts_with("mailto:") && !inlines.is_empty() && is_all_text(inlines) {
         return format!("<{plain}>");
@@ -399,7 +399,7 @@ fn image(attr: &Attr, inlines: &[Inline], target: &Target, wrap: WrapMode) -> St
     let caption = if target.title.is_empty() {
         inlines_to_markup(inlines, wrap)
     } else {
-        target.title.clone()
+        target.title.to_string()
     };
     if caption.is_empty() {
         format!("{{{{{head}}}}}")

--- a/crates/carta-writers/src/html.rs
+++ b/crates/carta-writers/src/html.rs
@@ -128,7 +128,8 @@ impl SlideRenderer {
     /// titleless slide passes an empty `attr`, yielding the class words alone.
     #[must_use]
     pub(crate) fn section_open(attr: &Attr, class_words: &[&str]) -> String {
-        let mut classes: Vec<String> = class_words.iter().map(|word| (*word).to_owned()).collect();
+        let mut classes: Vec<carta_ast::Text> =
+            class_words.iter().map(|word| (*word).into()).collect();
         classes.extend(attr.classes.iter().cloned());
         let mut tag = String::from("<section");
         tag.push_str(&render_id(&attr.id));
@@ -144,7 +145,7 @@ impl SlideRenderer {
     pub(crate) fn title(&mut self, level: i32, attr: &Attr, inlines: &[Inline]) -> String {
         let tag = header_tag(level);
         let titleless = Attr {
-            id: String::new(),
+            id: carta_ast::Text::default(),
             classes: attr.classes.clone(),
             attributes: attr.attributes.clone(),
         };
@@ -1199,7 +1200,7 @@ fn cell_attr(attr: &Attr, align_style: Option<&str>) -> String {
             merged = true;
         } else {
             let name = if is_known_attribute(key) {
-                key.clone()
+                key.to_string()
             } else {
                 format!("data-{key}")
             };
@@ -1251,7 +1252,7 @@ fn render_keyvals(attributes: &[(Text, Text)], flavor: Flavor) -> String {
         }
         let name = match flavor {
             Flavor::Html5 | Flavor::Slides if !is_known_attribute(key) => format!("data-{key}"),
-            _ => key.clone(),
+            _ => key.to_string(),
         };
         let _ = write!(out, "{BREAK}{name}=\"{}\"", escape_attr(value));
     }

--- a/crates/carta-writers/src/ipynb.rs
+++ b/crates/carta-writers/src/ipynb.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 use std::iter::Peekable;
 use std::str::Chars;
 
-use carta_ast::{Attr, Block, Document, Format, Inline, MetaValue, to_plain_text};
+use carta_ast::{Attr, Block, Document, Format, Inline, MetaValue, Text, to_plain_text};
 use carta_core::{Error, Extension, Extensions, Result, Writer, WriterOptions};
 
 use crate::markdown::MarkdownWriter;
@@ -152,7 +152,7 @@ fn code_cell(attr: &Attr, content: &[Block], counter: &mut usize) -> Result<Json
     for block in content {
         match block {
             Block::CodeBlock(_, text) if !found_source => {
-                source.clone_from(text);
+                source = text.to_string();
                 found_source = true;
             }
             Block::Div(output_attr, inner) if has_class(output_attr, "output") => {
@@ -184,7 +184,7 @@ fn raw_cell(attr: &Attr, content: &[Block], counter: &mut usize) -> Json {
     let mut metadata = Vec::new();
     for block in content {
         if let Block::RawBlock(Format(format), text) = block {
-            source.clone_from(text);
+            source = text.to_string();
             metadata.push(("raw_mimetype".to_owned(), Json::Str(format_to_mime(format))));
             break;
         }
@@ -200,13 +200,12 @@ fn raw_cell(attr: &Attr, content: &[Block], counter: &mut usize) -> Json {
 
 /// Reconstructs an output object from an `output` div. The output kind is the div's second class.
 fn output_object(attr: &Attr, content: &[Block]) -> Result<Json> {
-    let output = match attr.classes.get(1).map(String::as_str) {
+    let output = match attr.classes.get(1).map(Text::as_str) {
         Some("stream") => {
             let name = attr
                 .classes
                 .get(2)
-                .cloned()
-                .unwrap_or_else(|| "stdout".to_owned());
+                .map_or_else(|| "stdout".to_owned(), ToString::to_string);
             Json::Object(vec![
                 ("output_type".to_owned(), Json::Str("stream".to_owned())),
                 ("name".to_owned(), Json::Str(name)),
@@ -292,7 +291,7 @@ fn data_bundle(content: &[Block]) -> Result<Json> {
 fn first_verbatim(content: &[Block]) -> String {
     for block in content {
         if let Block::CodeBlock(_, text) = block {
-            return text.clone();
+            return text.to_string();
         }
     }
     String::new()
@@ -308,25 +307,25 @@ fn image_url(inlines: &[Inline]) -> Option<&str> {
 
 /// Builds cell metadata from a div's key/value attributes, skipping the named keys. Each value is
 /// the attribute parsed as a JSON value, or the raw text when it is not valid JSON. Keys are ordered.
-fn attribute_metadata(attributes: &[(String, String)], skip: &[&str]) -> Json {
+fn attribute_metadata(attributes: &[(Text, Text)], skip: &[&str]) -> Json {
     let mut entries: Vec<(String, Json)> = attributes
         .iter()
         .filter(|(key, _)| !skip.contains(&key.as_str()))
-        .map(|(key, value)| (key.clone(), parse_metadata_value(value)))
+        .map(|(key, value)| (key.to_string(), parse_metadata_value(value)))
         .collect();
     entries.sort_by(|left, right| left.0.cmp(&right.0));
     Json::Object(entries)
 }
 
 /// Notebook metadata: the `jupyter` map minus the version keys, or empty when there is none.
-fn notebook_metadata(meta: &BTreeMap<String, MetaValue>) -> Json {
+fn notebook_metadata(meta: &BTreeMap<Text, MetaValue>) -> Json {
     let Some(MetaValue::MetaMap(map)) = meta.get("jupyter") else {
         return Json::Object(Vec::new());
     };
     let pairs = map
         .iter()
         .filter(|(key, _)| key.as_str() != "nbformat" && key.as_str() != "nbformat_minor")
-        .map(|(key, value)| (key.clone(), meta_to_json(value)))
+        .map(|(key, value)| (key.to_string(), meta_to_json(value)))
         .collect();
     Json::Object(pairs)
 }
@@ -336,12 +335,12 @@ fn meta_to_json(value: &MetaValue) -> Json {
     match value {
         MetaValue::MetaMap(map) => Json::Object(
             map.iter()
-                .map(|(key, value)| (key.clone(), meta_to_json(value)))
+                .map(|(key, value)| (key.to_string(), meta_to_json(value)))
                 .collect(),
         ),
         MetaValue::MetaList(values) => Json::Array(values.iter().map(meta_to_json).collect()),
         MetaValue::MetaBool(flag) => Json::Bool(*flag),
-        MetaValue::MetaString(text) => Json::Str(text.clone()),
+        MetaValue::MetaString(text) => Json::Str(text.to_string()),
         MetaValue::MetaInlines(inlines) => Json::Str(to_plain_text(inlines)),
         MetaValue::MetaBlocks(blocks) => Json::Str(meta_blocks_text(blocks)),
     }
@@ -355,7 +354,7 @@ fn meta_blocks_text(blocks: &[Block]) -> String {
             Block::Para(inlines) | Block::Plain(inlines) | Block::Header(_, _, inlines) => {
                 to_plain_text(inlines)
             }
-            Block::CodeBlock(_, text) | Block::RawBlock(_, text) => text.clone(),
+            Block::CodeBlock(_, text) | Block::RawBlock(_, text) => text.to_string(),
             _ => String::new(),
         })
         .collect::<Vec<_>>()
@@ -715,7 +714,7 @@ mod tests {
     use carta_ast::Inline;
 
     fn para(text: &str) -> Block {
-        Block::Para(vec![Inline::Str(text.to_owned())])
+        Block::Para(vec![Inline::Str(text.to_owned().into())])
     }
 
     fn write(blocks: Vec<Block>) -> String {
@@ -741,7 +740,11 @@ mod tests {
     #[test]
     fn loose_blocks_become_one_markdown_cell() {
         let notebook = write(vec![
-            Block::Header(1, Box::default(), vec![Inline::Str("Title".to_owned())]),
+            Block::Header(
+                1,
+                Box::default(),
+                vec![Inline::Str("Title".to_owned().into())],
+            ),
             para("Body."),
         ]);
         assert!(notebook.contains("\"cell_type\": \"markdown\""));
@@ -771,11 +774,14 @@ mod tests {
     fn cell_div_selects_kind_and_keeps_id() {
         let notebook = write(vec![Block::Div(
             Box::new(Attr {
-                id: "given".to_owned(),
-                classes: vec!["cell".to_owned(), "code".to_owned()],
-                attributes: vec![("execution_count".to_owned(), "7".to_owned())],
+                id: "given".to_owned().into(),
+                classes: vec!["cell".to_owned().into(), "code".to_owned().into()],
+                attributes: vec![("execution_count".to_owned().into(), "7".to_owned().into())],
             }),
-            vec![Block::CodeBlock(Box::default(), "print(1)".to_owned())],
+            vec![Block::CodeBlock(
+                Box::default(),
+                "print(1)".to_owned().into(),
+            )],
         )]);
         assert!(notebook.contains("\"cell_type\": \"code\""));
         assert!(notebook.contains("\"execution_count\": 7"));
@@ -788,13 +794,13 @@ mod tests {
     fn raw_cell_carries_mime_type() {
         let notebook = write(vec![Block::Div(
             Box::new(Attr {
-                id: String::new(),
-                classes: vec!["cell".to_owned(), "raw".to_owned()],
+                id: String::new().into(),
+                classes: vec!["cell".to_owned().into(), "raw".to_owned().into()],
                 attributes: Vec::new(),
             }),
             vec![Block::RawBlock(
-                Format("html".to_owned()),
-                "<b>x</b>".to_owned(),
+                Format("html".to_owned().into()),
+                "<b>x</b>".to_owned().into(),
             )],
         )]);
         assert!(notebook.contains("\"cell_type\": \"raw\""));
@@ -806,13 +812,13 @@ mod tests {
     fn raw_cell_maps_asciidoc_mime() {
         let notebook = write(vec![Block::Div(
             Box::new(Attr {
-                id: String::new(),
-                classes: vec!["cell".to_owned(), "raw".to_owned()],
+                id: String::new().into(),
+                classes: vec!["cell".to_owned().into(), "raw".to_owned().into()],
                 attributes: Vec::new(),
             }),
             vec![Block::RawBlock(
-                Format("asciidoc".to_owned()),
-                "[NOTE]\n====\nbody\n====".to_owned(),
+                Format("asciidoc".to_owned().into()),
+                "[NOTE]\n====\nbody\n====".to_owned().into(),
             )],
         )]);
         assert!(notebook.contains("\"cell_type\": \"raw\""));
@@ -823,34 +829,37 @@ mod tests {
     fn stream_and_error_outputs_round_trip() {
         let notebook = write(vec![Block::Div(
             Box::new(Attr {
-                id: String::new(),
-                classes: vec!["cell".to_owned(), "code".to_owned()],
+                id: String::new().into(),
+                classes: vec!["cell".to_owned().into(), "code".to_owned().into()],
                 attributes: Vec::new(),
             }),
             vec![
-                Block::CodeBlock(Box::default(), "x".to_owned()),
+                Block::CodeBlock(Box::default(), "x".to_owned().into()),
                 Block::Div(
                     Box::new(Attr {
-                        id: String::new(),
+                        id: String::new().into(),
                         classes: vec![
-                            "output".to_owned(),
-                            "stream".to_owned(),
-                            "stdout".to_owned(),
+                            "output".to_owned().into(),
+                            "stream".to_owned().into(),
+                            "stdout".to_owned().into(),
                         ],
                         attributes: Vec::new(),
                     }),
-                    vec![Block::CodeBlock(Box::default(), "hi\n".to_owned())],
+                    vec![Block::CodeBlock(Box::default(), "hi\n".to_owned().into())],
                 ),
                 Block::Div(
                     Box::new(Attr {
-                        id: String::new(),
-                        classes: vec!["output".to_owned(), "error".to_owned()],
+                        id: String::new().into(),
+                        classes: vec!["output".to_owned().into(), "error".to_owned().into()],
                         attributes: vec![
-                            ("ename".to_owned(), "ValueError".to_owned()),
-                            ("evalue".to_owned(), "bad".to_owned()),
+                            ("ename".to_owned().into(), "ValueError".to_owned().into()),
+                            ("evalue".to_owned().into(), "bad".to_owned().into()),
                         ],
                     }),
-                    vec![Block::CodeBlock(Box::default(), "trace\n".to_owned())],
+                    vec![Block::CodeBlock(
+                        Box::default(),
+                        "trace\n".to_owned().into(),
+                    )],
                 ),
             ],
         )]);
@@ -866,24 +875,27 @@ mod tests {
         let document = Document {
             blocks: vec![Block::Div(
                 Box::new(Attr {
-                    id: String::new(),
-                    classes: vec!["cell".to_owned(), "code".to_owned()],
+                    id: String::new().into(),
+                    classes: vec!["cell".to_owned().into(), "code".to_owned().into()],
                     attributes: Vec::new(),
                 }),
                 vec![
-                    Block::CodeBlock(Box::default(), "plot()".to_owned()),
+                    Block::CodeBlock(Box::default(), "plot()".to_owned().into()),
                     Block::Div(
                         Box::new(Attr {
-                            id: String::new(),
-                            classes: vec!["output".to_owned(), "display_data".to_owned()],
+                            id: String::new().into(),
+                            classes: vec![
+                                "output".to_owned().into(),
+                                "display_data".to_owned().into(),
+                            ],
                             attributes: Vec::new(),
                         }),
                         vec![Block::Para(vec![Inline::Image(
                             Box::default(),
                             Vec::new(),
                             Box::new(carta_ast::Target {
-                                url: "plot.png".to_owned(),
-                                title: String::new(),
+                                url: "plot.png".to_owned().into(),
+                                title: String::new().into(),
                             }),
                         )])],
                     ),
@@ -903,10 +915,10 @@ mod tests {
     #[test]
     fn metadata_attribute_values_are_typed() {
         let attributes = vec![
-            ("collapsed".to_owned(), "true".to_owned()),
-            ("count".to_owned(), "5".to_owned()),
-            ("name".to_owned(), "hello".to_owned()),
-            ("tags".to_owned(), "[\"a\",\"b\"]".to_owned()),
+            ("collapsed".to_owned().into(), "true".to_owned().into()),
+            ("count".to_owned().into(), "5".to_owned().into()),
+            ("name".to_owned().into(), "hello".to_owned().into()),
+            ("tags".to_owned().into(), "[\"a\",\"b\"]".to_owned().into()),
         ];
         let Json::Object(entries) = attribute_metadata(&attributes, &[]) else {
             panic!("expected object");
@@ -922,14 +934,17 @@ mod tests {
     #[test]
     fn notebook_metadata_drops_version_keys() {
         let mut jupyter = BTreeMap::new();
-        jupyter.insert("nbformat".to_owned(), MetaValue::MetaString("4".to_owned()));
         jupyter.insert(
-            "nbformat_minor".to_owned(),
-            MetaValue::MetaString("5".to_owned()),
+            "nbformat".to_owned().into(),
+            MetaValue::MetaString("4".to_owned().into()),
         );
-        jupyter.insert("kept".to_owned(), MetaValue::MetaBool(true));
+        jupyter.insert(
+            "nbformat_minor".to_owned().into(),
+            MetaValue::MetaString("5".to_owned().into()),
+        );
+        jupyter.insert("kept".to_owned().into(), MetaValue::MetaBool(true));
         let mut meta = BTreeMap::new();
-        meta.insert("jupyter".to_owned(), MetaValue::MetaMap(jupyter));
+        meta.insert("jupyter".to_owned().into(), MetaValue::MetaMap(jupyter));
 
         let Json::Object(pairs) = notebook_metadata(&meta) else {
             panic!("expected object");

--- a/crates/carta-writers/src/jira.rs
+++ b/crates/carta-writers/src/jira.rs
@@ -346,7 +346,7 @@ impl State {
             None if text.trim().is_empty() => String::new(),
             None => {
                 let delimiter = if display { "$$" } else { "$" };
-                let fallback = Inline::Str(format!("{delimiter}{text}{delimiter}"));
+                let fallback = Inline::Str(format!("{delimiter}{text}{delimiter}").into());
                 self.inline(&fallback, left, right)
             }
         };
@@ -935,7 +935,7 @@ mod tests {
     }
 
     fn math(kind: MathType, tex: &str) -> Inline {
-        Inline::Math(kind, tex.to_owned())
+        Inline::Math(kind, tex.to_owned().into())
     }
 
     fn inline(tex: &str) -> String {
@@ -947,7 +947,7 @@ mod tests {
     }
 
     fn str_inline(text: &str) -> Inline {
-        Inline::Str(text.to_owned())
+        Inline::Str(text.to_owned().into())
     }
 
     #[test]
@@ -1322,7 +1322,7 @@ mod tests {
     fn code(value: &str) -> String {
         render(vec![para(vec![Inline::Code(
             Box::default(),
-            value.to_owned(),
+            value.to_owned().into(),
         )])])
     }
 

--- a/crates/carta-writers/src/latex.rs
+++ b/crates/carta-writers/src/latex.rs
@@ -1554,7 +1554,7 @@ fn push_inline(
         }
         Inline::RawInline(format, text) => {
             if is_latex_format(&format.0) {
-                out.push(Piece::Text(text.clone()));
+                out.push(Piece::Text(text.to_string()));
             }
         }
         Inline::Link(attr, inlines, target) => {
@@ -1958,7 +1958,7 @@ mod tests {
     }
 
     fn str_inlines(text: &str) -> Vec<Inline> {
-        vec![Inline::Str(text.to_owned())]
+        vec![Inline::Str(text.to_owned().into())]
     }
 
     fn render_columns(blocks: Vec<Block>, columns: usize) -> String {
@@ -1975,7 +1975,7 @@ mod tests {
         let words: Vec<Inline> =
             "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi"
                 .split(' ')
-                .flat_map(|word| [Inline::Str(word.to_owned()), Inline::Space])
+                .flat_map(|word| [Inline::Str(word.to_owned().into()), Inline::Space])
                 .collect();
         vec![Block::Para(words)]
     }
@@ -2243,7 +2243,7 @@ mod tests {
             str_inlines("alt"),
             Box::new(Target {
                 url: "img.png".into(),
-                title: String::new(),
+                title: String::new().into(),
             }),
         );
         let out = render(vec![Block::Para(vec![image])]);

--- a/crates/carta-writers/src/man.rs
+++ b/crates/carta-writers/src/man.rs
@@ -491,7 +491,7 @@ impl State {
     fn image(&mut self, out: &mut Vec<Fragment>, font: Font, alt: &[Inline], target: &Target) {
         push_text(out, "[IMAGE: ");
         let caption: Vec<Inline> = if alt.is_empty() {
-            vec![Inline::Str("image".to_owned().into())]
+            vec![Inline::Str("image".into())]
         } else {
             alt.to_vec()
         };

--- a/crates/carta-writers/src/man.rs
+++ b/crates/carta-writers/src/man.rs
@@ -491,7 +491,7 @@ impl State {
     fn image(&mut self, out: &mut Vec<Fragment>, font: Font, alt: &[Inline], target: &Target) {
         push_text(out, "[IMAGE: ");
         let caption: Vec<Inline> = if alt.is_empty() {
-            vec![Inline::Str("image".to_owned())]
+            vec![Inline::Str("image".to_owned().into())]
         } else {
             alt.to_vec()
         };
@@ -990,7 +990,7 @@ mod tests {
     }
 
     fn s(text: &str) -> Inline {
-        Inline::Str(text.to_owned())
+        Inline::Str(text.to_owned().into())
     }
 
     #[test]
@@ -1161,7 +1161,7 @@ mod tests {
                 vec![],
                 Box::new(Target {
                     url: "i.png".into(),
-                    title: String::new(),
+                    title: String::new().into(),
                 }),
             )])]),
             ".PP\n[IMAGE: image]"
@@ -1297,11 +1297,11 @@ mod tests {
     }
 
     fn inline_math(tex: &str) -> Inline {
-        Inline::Math(MathType::InlineMath, tex.to_owned())
+        Inline::Math(MathType::InlineMath, tex.to_owned().into())
     }
 
     fn display_math(tex: &str) -> Inline {
-        Inline::Math(MathType::DisplayMath, tex.to_owned())
+        Inline::Math(MathType::DisplayMath, tex.to_owned().into())
     }
 
     #[test]

--- a/crates/carta-writers/src/markdown.rs
+++ b/crates/carta-writers/src/markdown.rs
@@ -916,7 +916,7 @@ impl State {
         if !alt_text.is_empty() && alt_text != carta_ast::to_plain_text(&caption_inlines) {
             image_attr
                 .attributes
-                .insert(0, ("alt".to_owned(), alt_text));
+                .insert(0, ("alt".to_owned().into(), alt_text.into()));
         }
         // If the image itself would fall back to an HTML `<img>`, the shorthand cannot carry it; the
         // caller renders the whole figure as an HTML `<figure>` instead.
@@ -1552,7 +1552,7 @@ impl State {
                     MathType::DisplayMath => ("$$", tex),
                     MathType::InlineMath => ("$", tex.trim()),
                 };
-                let fallback = Inline::Str(format!("{delim}{body}{delim}"));
+                let fallback = Inline::Str(format!("{delim}{body}{delim}").into());
                 self.inline(&fallback, out);
             }
         }
@@ -2114,7 +2114,7 @@ fn longest_backtick_run(text: &str) -> usize {
 
 fn destination(target: &Target) -> String {
     if target.title.is_empty() {
-        target.url.clone()
+        target.url.to_string()
     } else {
         format!("{} \"{}\"", target.url, escape_title(&target.title))
     }
@@ -2128,7 +2128,7 @@ fn autolink(inlines: &[Inline], target: &Target) -> Option<String> {
     let [Inline::Str(text)] = inlines else {
         return None;
     };
-    if &target.url == text && is_uri(text) {
+    if target.url == *text && is_uri(text) {
         return Some(format!("<{text}>"));
     }
     if target.url == format!("mailto:{text}") {
@@ -2239,14 +2239,14 @@ fn attr_body(attr: &Attr) -> String {
 
 fn underline_attr() -> Attr {
     Attr {
-        classes: vec!["underline".to_owned()],
+        classes: vec!["underline".to_owned().into()],
         ..Attr::default()
     }
 }
 
 fn smallcaps_attr() -> Attr {
     Attr {
-        classes: vec!["smallcaps".to_owned()],
+        classes: vec!["smallcaps".to_owned().into()],
         ..Attr::default()
     }
 }
@@ -2493,7 +2493,7 @@ mod tests {
             let words: Vec<Inline> =
                 "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu"
                     .split(' ')
-                    .flat_map(|word| [Inline::Str(word.to_owned()), Inline::Space])
+                    .flat_map(|word| [Inline::Str(word.to_owned().into()), Inline::Space])
                     .collect();
             vec![Block::Para(words)]
         }
@@ -2538,8 +2538,8 @@ mod tests {
         fn raw_attribute_fence_outgrows_a_backtick_run_in_the_body() {
             let document = Document {
                 blocks: vec![Block::RawBlock(
-                    Format("dot".to_owned()),
-                    "```\ngraph {}\n```".to_owned(),
+                    Format("dot".to_owned().into()),
+                    "```\ngraph {}\n```".to_owned().into(),
                 )],
                 ..Document::default()
             };
@@ -2557,7 +2557,7 @@ mod tests {
         use crate::markdown::MarkdownWriter;
 
         fn s(text: &str) -> Inline {
-            Inline::Str(text.to_owned())
+            Inline::Str(text.to_owned().into())
         }
 
         fn render(blocks: Vec<Block>) -> String {
@@ -2688,7 +2688,7 @@ mod tests {
                 render_with(
                     vec![Block::Para(vec![Inline::Math(
                         MathType::InlineMath,
-                        "x^2".to_owned()
+                        "x^2".to_owned().into()
                     )])],
                     single
                 ),
@@ -2698,7 +2698,7 @@ mod tests {
                 render_with(
                     vec![Block::Para(vec![Inline::Math(
                         MathType::DisplayMath,
-                        "x^2".to_owned()
+                        "x^2".to_owned().into()
                     )])],
                     single
                 ),
@@ -2714,7 +2714,7 @@ mod tests {
                 render_with(
                     vec![Block::Para(vec![Inline::Math(
                         MathType::InlineMath,
-                        "x^2".to_owned()
+                        "x^2".to_owned().into()
                     )])],
                     double
                 ),
@@ -2730,7 +2730,7 @@ mod tests {
                     vec![Block::Para(vec![
                         s("before"),
                         Inline::Space,
-                        Inline::Math(MathType::DisplayMath, "x^2".to_owned()),
+                        Inline::Math(MathType::DisplayMath, "x^2".to_owned().into()),
                         Inline::Space,
                         s("after"),
                     ])],

--- a/crates/carta-writers/src/markdown.rs
+++ b/crates/carta-writers/src/markdown.rs
@@ -916,7 +916,7 @@ impl State {
         if !alt_text.is_empty() && alt_text != carta_ast::to_plain_text(&caption_inlines) {
             image_attr
                 .attributes
-                .insert(0, ("alt".to_owned().into(), alt_text.into()));
+                .insert(0, ("alt".into(), alt_text.into()));
         }
         // If the image itself would fall back to an HTML `<img>`, the shorthand cannot carry it; the
         // caller renders the whole figure as an HTML `<figure>` instead.
@@ -2239,14 +2239,14 @@ fn attr_body(attr: &Attr) -> String {
 
 fn underline_attr() -> Attr {
     Attr {
-        classes: vec!["underline".to_owned().into()],
+        classes: vec!["underline".into()],
         ..Attr::default()
     }
 }
 
 fn smallcaps_attr() -> Attr {
     Attr {
-        classes: vec!["smallcaps".to_owned().into()],
+        classes: vec!["smallcaps".into()],
         ..Attr::default()
     }
 }

--- a/crates/carta-writers/src/math/inlines.rs
+++ b/crates/carta-writers/src/math/inlines.rs
@@ -282,7 +282,7 @@ fn render_script(group: &[Atom], style: Style) -> Option<Vec<Inline>> {
         && atom.sup.is_none()
         && atom.siblings.is_empty()
     {
-        return Some(vec![Inline::Str(prime_glyph(*count))]);
+        return Some(vec![Inline::Str(prime_glyph(*count).into())]);
     }
     let mut inlines = lower_styled(group, style)?;
     // A script whose sole content is a bare named function drops that function's trailing thin space:
@@ -347,12 +347,7 @@ fn render_nucleus(body: &Body, style: Style) -> Option<(Vec<Inline>, Class, bool
         Body::Char('#' | '&' | '%') => None,
         Body::Char(c) => render_char(*c, style),
         // The `:=` digraph prints as the two literal characters and takes relation spacing as a unit.
-        Body::ColonEq => Some((
-            vec![Inline::Str(":=".to_string())],
-            Class::Rel,
-            false,
-            false,
-        )),
+        Body::ColonEq => Some((vec![Inline::Str(":=".into())], Class::Rel, false, false)),
         Body::Number(digits) => render_number(digits, style),
         Body::Command(name) => render_command(name, style),
         Body::Group(inner) => {
@@ -382,7 +377,7 @@ fn render_nucleus(body: &Body, style: Style) -> Option<(Vec<Inline>, Class, bool
             };
             let glyph = delim.map_or("", |d| delim_glyph(d, side));
             Some((
-                vec![Inline::Str(glyph.to_string())],
+                vec![Inline::Str(glyph.to_string().into())],
                 Class::Ord,
                 false,
                 false,
@@ -419,7 +414,7 @@ fn render_negated(base: &str) -> Option<(Vec<Inline>, Class, bool, bool)> {
     }
     if let Some(glyph) = symbols::negated_relation(base) {
         return Some((
-            vec![Inline::Str(glyph.to_string())],
+            vec![Inline::Str(glyph.to_string().into())],
             Class::Rel,
             false,
             false,
@@ -429,7 +424,7 @@ fn render_negated(base: &str) -> Option<(Vec<Inline>, Class, bool, bool)> {
         NegatedBase::Relation(glyph) => {
             let mut struck = glyph;
             struck.push('\u{0338}');
-            Some((vec![Inline::Str(struck)], Class::Rel, false, false))
+            Some((vec![Inline::Str(struck.into())], Class::Rel, false, false))
         }
         NegatedBase::Italic(glyph) => {
             let mut struck = glyph;
@@ -439,7 +434,7 @@ fn render_negated(base: &str) -> Option<(Vec<Inline>, Class, bool, bool)> {
         NegatedBase::Upright(glyph) => {
             let mut struck = glyph;
             struck.push('\u{0338}');
-            Some((vec![Inline::Str(struck)], Class::Ord, false, false))
+            Some((vec![Inline::Str(struck.into())], Class::Ord, false, false))
         }
     }
 }
@@ -511,10 +506,10 @@ fn render_mod(kind: ModKind, arg: Option<&[Atom]>) -> Option<(Vec<Inline>, Class
         ModKind::Mod => "\u{2000}mod\u{2006}\u{00A0}",
         ModKind::Pod => "\u{00A0}(",
     };
-    let mut inlines = vec![Inline::Str(prefix.to_string())];
+    let mut inlines = vec![Inline::Str(prefix.to_string().into())];
     if let Some(arg) = arg {
         inlines.extend(lower(arg)?);
-        inlines.push(Inline::Str(")".to_string()));
+        inlines.push(Inline::Str(")".into()));
     }
     Some((merge_adjacent_str(inlines), Class::Ord, false, false))
 }
@@ -574,7 +569,9 @@ fn render_text(name: &str, content: &[TextPiece]) -> Option<(Vec<Inline>, Class,
     for piece in content {
         match piece {
             TextPiece::Run(run) => inlines.extend(wrap_text_run(name, run)?),
-            TextPiece::Space(space) => inlines.push(Inline::Str(space.codepoint().to_string())),
+            TextPiece::Space(space) => {
+                inlines.push(Inline::Str(space.codepoint().to_string().into()));
+            }
             // A `$…$` segment is math, rendered unaffected by the wrapper's own formatting.
             TextPiece::Math(atoms) => inlines.extend(lower(atoms)?),
         }
@@ -587,13 +584,13 @@ fn render_text(name: &str, content: &[TextPiece]) -> Option<(Vec<Inline>, Class,
 
 /// Wrap one literal run of text in the wrapper's formatting.
 fn wrap_text_run(name: &str, run: &str) -> Option<Vec<Inline>> {
-    let text = Inline::Str(run.to_string());
+    let text = Inline::Str(run.to_string().into());
     let wrapped = match name {
         "text" | "textrm" | "textsf" | "mbox" | "operatorname" => vec![text],
         "textbf" => vec![Inline::Strong(vec![text])],
         "textit" => vec![Inline::Emph(vec![text])],
         // Typewriter text renders as a code span over the run.
-        "texttt" => vec![Inline::Code(Box::default(), run.to_string())],
+        "texttt" => vec![Inline::Code(Box::default(), run.to_string().into())],
         _ => return None,
     };
     Some(wrapped)
@@ -646,9 +643,9 @@ fn render_char(c: char, style: Style) -> Option<(Vec<Inline>, Class, bool, bool)
     // or punctuation glyph keeps its spacing; the substituting styles already mapped a letter/digit
     // above and fall through here for a symbol, which keeps its plain glyph and class.
     let inlines = match style {
-        Style::Monospace => vec![Inline::Code(Box::default(), text)],
+        Style::Monospace => vec![Inline::Code(Box::default(), text.into())],
         _ if c.is_alphabetic() && !style.is_upright() => vec![italic(text)],
-        _ => vec![Inline::Str(text)],
+        _ => vec![Inline::Str(text.into())],
     };
     Some((inlines, class, is_limit, false))
 }
@@ -693,14 +690,14 @@ fn char_glyph(c: char) -> (String, Class, bool) {
 #[allow(clippy::unnecessary_wraps)]
 fn render_number(digits: &str, style: Style) -> Option<(Vec<Inline>, Class, bool, bool)> {
     let inlines = match style {
-        Style::Monospace => vec![Inline::Code(Box::default(), digits.to_string())],
-        Style::Substitute(alphabet) => vec![Inline::Str(substitute_run(digits, alphabet))],
+        Style::Monospace => vec![Inline::Code(Box::default(), digits.to_string().into())],
+        Style::Substitute(alphabet) => vec![Inline::Str(substitute_run(digits, alphabet).into())],
         Style::SubstituteBold(alphabet) => {
-            vec![Inline::Strong(vec![Inline::Str(substitute_run(
-                digits, alphabet,
-            ))])]
+            vec![Inline::Strong(vec![Inline::Str(
+                substitute_run(digits, alphabet).into(),
+            )])]
         }
-        _ => vec![Inline::Str(digits.to_string())],
+        _ => vec![Inline::Str(digits.to_string().into())],
     };
     Some((inlines, Class::Ord, false, false))
 }
@@ -711,12 +708,12 @@ fn render_number(digits: &str, style: Style) -> Option<(Vec<Inline>, Class, bool
 /// style's wrapper. Returns the fully-wrapped inline run for that one character.
 fn style_glyph(c: char, style: Style) -> Option<Vec<Inline>> {
     match style {
-        Style::Substitute(alphabet) => Some(vec![Inline::Str(substitute_char(c, alphabet))]),
+        Style::Substitute(alphabet) => Some(vec![Inline::Str(substitute_char(c, alphabet).into())]),
         Style::SubstituteBold(alphabet) => Some(vec![Inline::Strong(vec![Inline::Str(
-            substitute_char(c, alphabet),
+            substitute_char(c, alphabet).into(),
         )])]),
         // Monospace renders the character as its own code span, whatever the character.
-        Style::Monospace => Some(vec![Inline::Code(Box::default(), c.to_string())]),
+        Style::Monospace => Some(vec![Inline::Code(Box::default(), c.to_string().into())]),
         _ => None,
     }
 }
@@ -745,7 +742,12 @@ fn substitute_char(c: char, alphabet: Alphabet) -> String {
 
 fn render_command(name: &str, style: Style) -> Option<(Vec<Inline>, Class, bool, bool)> {
     if let Some(s) = symbols::spacing(name) {
-        return Some((vec![Inline::Str(s.to_string())], Class::Ord, false, false));
+        return Some((
+            vec![Inline::Str(s.to_string().into())],
+            Class::Ord,
+            false,
+            false,
+        ));
     }
     if let Some((letter, is_var)) = symbols::greek(name) {
         return Some((
@@ -781,7 +783,7 @@ fn style_single_glyph(text: &str, italic_default: bool, style: Style) -> Vec<Inl
     if italic_default && !style.is_upright() {
         italic_run(text)
     } else {
-        vec![Inline::Str(text.to_string())]
+        vec![Inline::Str(text.to_string().into())]
     }
 }
 
@@ -790,14 +792,14 @@ fn style_single_glyph(text: &str, italic_default: bool, style: Style) -> Vec<Inl
 /// every other style keeps the run whole and upright.
 fn style_text_glyph(text: &str, style: Style) -> Vec<Inline> {
     match style {
-        Style::Monospace => vec![Inline::Code(Box::default(), text.to_string())],
-        Style::Substitute(alphabet) => vec![Inline::Str(substitute_run(text, alphabet))],
+        Style::Monospace => vec![Inline::Code(Box::default(), text.to_string().into())],
+        Style::Substitute(alphabet) => vec![Inline::Str(substitute_run(text, alphabet).into())],
         Style::SubstituteBold(alphabet) => {
-            vec![Inline::Strong(vec![Inline::Str(substitute_run(
-                text, alphabet,
-            ))])]
+            vec![Inline::Strong(vec![Inline::Str(
+                substitute_run(text, alphabet).into(),
+            )])]
         }
-        _ => vec![Inline::Str(text.to_string())],
+        _ => vec![Inline::Str(text.to_string().into())],
     }
 }
 
@@ -930,13 +932,13 @@ fn upright_inner(arg: &[Atom]) -> Option<Vec<Inline>> {
             return None;
         }
         match &atom.body {
-            Body::Char(c) => out.push(Inline::Str(c.to_string())),
-            Body::Number(digits) => out.push(Inline::Str(digits.clone())),
+            Body::Char(c) => out.push(Inline::Str(c.to_string().into())),
+            Body::Number(digits) => out.push(Inline::Str(digits.clone().into())),
             Body::Command(name) => {
                 if let Some((letter, _)) = symbols::greek(name) {
-                    out.push(Inline::Str(letter.to_string()));
+                    out.push(Inline::Str(letter.to_string().into()));
                 } else if let Some(sym) = symbols::symbol(name) {
-                    out.push(Inline::Str(sym.text.to_string()));
+                    out.push(Inline::Str(sym.text.to_string().into()));
                 } else {
                     return None;
                 }
@@ -966,7 +968,7 @@ fn flatten_emph(inlines: Vec<Inline>) -> Vec<Inline> {
 }
 
 fn italic(text: String) -> Inline {
-    Inline::Emph(vec![Inline::Str(text)])
+    Inline::Emph(vec![Inline::Str(text.into())])
 }
 
 /// The flat prime glyph string for a run of `count` apostrophes. A run of one to four marks is a
@@ -992,17 +994,17 @@ fn prime_glyph(count: u8) -> String {
 /// the remaining `count - 4` marks into a superscript, which itself decomposes the same way.
 fn prime_nucleus(count: u8) -> Vec<Inline> {
     if count <= 4 {
-        return vec![Inline::Str(prime_glyph(count))];
+        return vec![Inline::Str(prime_glyph(count).into())];
     }
     vec![
-        Inline::Str("\u{2057}".to_string()),
-        Inline::Superscript(vec![Inline::Str(prime_glyph(count - 4))]),
+        Inline::Str("\u{2057}".into()),
+        Inline::Superscript(vec![Inline::Str(prime_glyph(count - 4).into())]),
     ]
 }
 
 fn push_str(out: &mut Vec<Inline>, text: &str) {
     if !text.is_empty() {
-        out.push(Inline::Str(text.to_string()));
+        out.push(Inline::Str(text.to_string().into()));
     }
 }
 

--- a/crates/carta-writers/src/math/inlines.rs
+++ b/crates/carta-writers/src/math/inlines.rs
@@ -9,7 +9,7 @@
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
-use carta_ast::Inline;
+use carta_ast::{Inline, ToCompactString};
 
 use super::parse::{Atom, Body, Delim, ModKind, ScriptKind, TextPiece};
 use super::symbols::{self, Alphabet, Class, is_limit_glyph};
@@ -376,12 +376,7 @@ fn render_nucleus(body: &Body, style: Style) -> Option<(Vec<Inline>, Class, bool
                 DelimSide::Close
             };
             let glyph = delim.map_or("", |d| delim_glyph(d, side));
-            Some((
-                vec![Inline::Str(glyph.to_string().into())],
-                Class::Ord,
-                false,
-                false,
-            ))
+            Some((vec![Inline::Str(glyph.into())], Class::Ord, false, false))
         }
         Body::Mod(kind, arg) => render_mod(*kind, arg.as_deref()),
         Body::Negated(base) => render_negated(base),
@@ -413,12 +408,7 @@ fn render_negated(base: &str) -> Option<(Vec<Inline>, Class, bool, bool)> {
         return None;
     }
     if let Some(glyph) = symbols::negated_relation(base) {
-        return Some((
-            vec![Inline::Str(glyph.to_string().into())],
-            Class::Rel,
-            false,
-            false,
-        ));
+        return Some((vec![Inline::Str(glyph.into())], Class::Rel, false, false));
     }
     match negated_base(base)? {
         NegatedBase::Relation(glyph) => {
@@ -506,7 +496,7 @@ fn render_mod(kind: ModKind, arg: Option<&[Atom]>) -> Option<(Vec<Inline>, Class
         ModKind::Mod => "\u{2000}mod\u{2006}\u{00A0}",
         ModKind::Pod => "\u{00A0}(",
     };
-    let mut inlines = vec![Inline::Str(prefix.to_string().into())];
+    let mut inlines = vec![Inline::Str(prefix.into())];
     if let Some(arg) = arg {
         inlines.extend(lower(arg)?);
         inlines.push(Inline::Str(")".into()));
@@ -570,7 +560,7 @@ fn render_text(name: &str, content: &[TextPiece]) -> Option<(Vec<Inline>, Class,
         match piece {
             TextPiece::Run(run) => inlines.extend(wrap_text_run(name, run)?),
             TextPiece::Space(space) => {
-                inlines.push(Inline::Str(space.codepoint().to_string().into()));
+                inlines.push(Inline::Str(space.codepoint().to_compact_string()));
             }
             // A `$…$` segment is math, rendered unaffected by the wrapper's own formatting.
             TextPiece::Math(atoms) => inlines.extend(lower(atoms)?),
@@ -584,13 +574,13 @@ fn render_text(name: &str, content: &[TextPiece]) -> Option<(Vec<Inline>, Class,
 
 /// Wrap one literal run of text in the wrapper's formatting.
 fn wrap_text_run(name: &str, run: &str) -> Option<Vec<Inline>> {
-    let text = Inline::Str(run.to_string().into());
+    let text = Inline::Str(run.into());
     let wrapped = match name {
         "text" | "textrm" | "textsf" | "mbox" | "operatorname" => vec![text],
         "textbf" => vec![Inline::Strong(vec![text])],
         "textit" => vec![Inline::Emph(vec![text])],
         // Typewriter text renders as a code span over the run.
-        "texttt" => vec![Inline::Code(Box::default(), run.to_string().into())],
+        "texttt" => vec![Inline::Code(Box::default(), run.into())],
         _ => return None,
     };
     Some(wrapped)
@@ -690,14 +680,14 @@ fn char_glyph(c: char) -> (String, Class, bool) {
 #[allow(clippy::unnecessary_wraps)]
 fn render_number(digits: &str, style: Style) -> Option<(Vec<Inline>, Class, bool, bool)> {
     let inlines = match style {
-        Style::Monospace => vec![Inline::Code(Box::default(), digits.to_string().into())],
+        Style::Monospace => vec![Inline::Code(Box::default(), digits.into())],
         Style::Substitute(alphabet) => vec![Inline::Str(substitute_run(digits, alphabet).into())],
         Style::SubstituteBold(alphabet) => {
             vec![Inline::Strong(vec![Inline::Str(
                 substitute_run(digits, alphabet).into(),
             )])]
         }
-        _ => vec![Inline::Str(digits.to_string().into())],
+        _ => vec![Inline::Str(digits.into())],
     };
     Some((inlines, Class::Ord, false, false))
 }
@@ -713,7 +703,7 @@ fn style_glyph(c: char, style: Style) -> Option<Vec<Inline>> {
             substitute_char(c, alphabet).into(),
         )])]),
         // Monospace renders the character as its own code span, whatever the character.
-        Style::Monospace => Some(vec![Inline::Code(Box::default(), c.to_string().into())]),
+        Style::Monospace => Some(vec![Inline::Code(Box::default(), c.to_compact_string())]),
         _ => None,
     }
 }
@@ -742,12 +732,7 @@ fn substitute_char(c: char, alphabet: Alphabet) -> String {
 
 fn render_command(name: &str, style: Style) -> Option<(Vec<Inline>, Class, bool, bool)> {
     if let Some(s) = symbols::spacing(name) {
-        return Some((
-            vec![Inline::Str(s.to_string().into())],
-            Class::Ord,
-            false,
-            false,
-        ));
+        return Some((vec![Inline::Str(s.into())], Class::Ord, false, false));
     }
     if let Some((letter, is_var)) = symbols::greek(name) {
         return Some((
@@ -783,7 +768,7 @@ fn style_single_glyph(text: &str, italic_default: bool, style: Style) -> Vec<Inl
     if italic_default && !style.is_upright() {
         italic_run(text)
     } else {
-        vec![Inline::Str(text.to_string().into())]
+        vec![Inline::Str(text.into())]
     }
 }
 
@@ -792,14 +777,14 @@ fn style_single_glyph(text: &str, italic_default: bool, style: Style) -> Vec<Inl
 /// every other style keeps the run whole and upright.
 fn style_text_glyph(text: &str, style: Style) -> Vec<Inline> {
     match style {
-        Style::Monospace => vec![Inline::Code(Box::default(), text.to_string().into())],
+        Style::Monospace => vec![Inline::Code(Box::default(), text.into())],
         Style::Substitute(alphabet) => vec![Inline::Str(substitute_run(text, alphabet).into())],
         Style::SubstituteBold(alphabet) => {
             vec![Inline::Strong(vec![Inline::Str(
                 substitute_run(text, alphabet).into(),
             )])]
         }
-        _ => vec![Inline::Str(text.to_string().into())],
+        _ => vec![Inline::Str(text.into())],
     }
 }
 
@@ -932,13 +917,13 @@ fn upright_inner(arg: &[Atom]) -> Option<Vec<Inline>> {
             return None;
         }
         match &atom.body {
-            Body::Char(c) => out.push(Inline::Str(c.to_string().into())),
+            Body::Char(c) => out.push(Inline::Str(c.to_compact_string())),
             Body::Number(digits) => out.push(Inline::Str(digits.clone().into())),
             Body::Command(name) => {
                 if let Some((letter, _)) = symbols::greek(name) {
-                    out.push(Inline::Str(letter.to_string().into()));
+                    out.push(Inline::Str(letter.into()));
                 } else if let Some(sym) = symbols::symbol(name) {
-                    out.push(Inline::Str(sym.text.to_string().into()));
+                    out.push(Inline::Str(sym.text.into()));
                 } else {
                     return None;
                 }
@@ -1004,7 +989,7 @@ fn prime_nucleus(count: u8) -> Vec<Inline> {
 
 fn push_str(out: &mut Vec<Inline>, text: &str) {
     if !text.is_empty() {
-        out.push(Inline::Str(text.to_string().into()));
+        out.push(Inline::Str(text.into()));
     }
 }
 

--- a/crates/carta-writers/src/math/tests.rs
+++ b/crates/carta-writers/src/math/tests.rs
@@ -7,7 +7,7 @@ fn typst_labeled(tex: &str) -> Option<(String, Option<String>)> {
 }
 
 fn str_inline(s: &str) -> Inline {
-    Inline::Str(s.to_string())
+    Inline::Str(s.to_string().into())
 }
 
 fn emph(inner: Vec<Inline>) -> Inline {
@@ -147,8 +147,8 @@ fn monospace_text_becomes_per_character_code() {
     assert_eq!(
         to_inlines("\\mathtt{ab}"),
         Some(vec![
-            Inline::Code(Box::default(), "a".to_string()),
-            Inline::Code(Box::default(), "b".to_string()),
+            Inline::Code(Box::default(), "a".to_string().into()),
+            Inline::Code(Box::default(), "b".to_string().into()),
         ])
     );
 }
@@ -1090,9 +1090,9 @@ fn monospace_keeps_a_digit_run_as_one_code_span() {
     assert_eq!(
         to_inlines("\\mathtt{1a23}"),
         Some(vec![
-            Inline::Code(Box::default(), "1".to_string()),
-            Inline::Code(Box::default(), "a".to_string()),
-            Inline::Code(Box::default(), "23".to_string()),
+            Inline::Code(Box::default(), "1".to_string().into()),
+            Inline::Code(Box::default(), "a".to_string().into()),
+            Inline::Code(Box::default(), "23".to_string().into()),
         ])
     );
 }
@@ -2423,7 +2423,7 @@ fn text_escape_preserves_the_wrapper_formatting() {
     );
     assert_eq!(
         to_inlines("\\texttt{a\\%b}"),
-        Some(vec![Inline::Code(Box::default(), "a%b".to_string())])
+        Some(vec![Inline::Code(Box::default(), "a%b".to_string().into())])
     );
 }
 
@@ -2810,19 +2810,19 @@ fn monospace_wraps_each_glyph_but_keeps_a_number_whole() {
     assert_eq!(
         to_inlines("\\mathtt{abc}"),
         Some(vec![
-            Inline::Code(Box::default(), "a".to_string()),
-            Inline::Code(Box::default(), "b".to_string()),
-            Inline::Code(Box::default(), "c".to_string()),
+            Inline::Code(Box::default(), "a".to_string().into()),
+            Inline::Code(Box::default(), "b".to_string().into()),
+            Inline::Code(Box::default(), "c".to_string().into()),
         ])
     );
     assert_eq!(
         to_inlines("\\mathtt{12}"),
-        Some(vec![Inline::Code(Box::default(), "12".to_string())])
+        Some(vec![Inline::Code(Box::default(), "12".to_string().into())])
     );
     // A monospaced operator is still code-wrapped, keeping its ordinary glyph.
     assert_eq!(
         to_inlines("\\mathtt{+}"),
-        Some(vec![Inline::Code(Box::default(), "+".to_string())])
+        Some(vec![Inline::Code(Box::default(), "+".to_string().into())])
     );
 }
 

--- a/crates/carta-writers/src/mediawiki.rs
+++ b/crates/carta-writers/src/mediawiki.rs
@@ -162,7 +162,7 @@ impl State {
     fn figure(&mut self, attr: &Attr, blocks: &[Block]) -> String {
         let merged = Attr {
             id: attr.id.clone(),
-            classes: std::iter::once("figure".to_owned())
+            classes: std::iter::once(carta_ast::Text::from("figure"))
                 .chain(attr.classes.iter().cloned())
                 .collect(),
             attributes: attr.attributes.clone(),
@@ -279,7 +279,7 @@ impl State {
         // The table's own attributes render on the `{|` line, with `wikitable` always the first
         // class.
         let mut table_attr = table.attr.clone();
-        table_attr.classes.insert(0, "wikitable".to_owned());
+        table_attr.classes.insert(0, "wikitable".into());
         let mut out = format!("{{|{}", render_html_attr(&table_attr));
         if !table.caption.long.is_empty() {
             let caption = self.blocks(&table.caption.long);
@@ -365,7 +365,7 @@ impl State {
         }
         for (key, value) in &cell.attr.attributes {
             let name = if is_known_attribute(key) {
-                key.clone()
+                key.to_string()
             } else {
                 format!("data-{key}")
             };
@@ -506,7 +506,7 @@ impl State {
         if is_external_uri(&target.url) {
             if is_percent_escaped_uri(&target.url, false) && label_matches_url(&plain, &target.url)
             {
-                target.url.clone()
+                target.url.to_string()
             } else if plain != target.url {
                 format!("[{} {label}]", target.url)
             } else if label == target.url {
@@ -548,7 +548,7 @@ impl State {
         } else {
             // The caption is the alternate text, falling back to the title.
             let caption = if alt.is_empty() {
-                target.title.clone()
+                target.title.to_string()
             } else {
                 alt
             };

--- a/crates/carta-writers/src/org.rs
+++ b/crates/carta-writers/src/org.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 
 use carta_ast::{
     Attr, Block, Caption, Cell, Citation, CitationMode, Document, Format, Inline, ListAttributes,
-    ListNumberDelim, MathType, QuoteType, Row, Table, Target, to_plain_text,
+    ListNumberDelim, MathType, QuoteType, Row, Table, Target, Text, to_plain_text,
 };
 use carta_core::{Extension, Result, WrapMode, Writer, WriterOptions};
 
@@ -200,7 +200,7 @@ impl State {
             && let Some(Inline::Str(text)) = inlines.first_mut()
         {
             let rest: String = text.chars().skip(1).collect();
-            *text = format!("{marker}{rest}");
+            *text = format!("{marker}{rest}").into();
         }
         Cow::Owned(blocks)
     }
@@ -407,7 +407,7 @@ impl State {
         }
         match special_div(&attr.classes) {
             Some(index) => {
-                let name = attr.classes.get(index).map_or("", String::as_str);
+                let name = attr.classes.get(index).map_or("", |class| class.as_str());
                 let extra: Vec<&str> = attr
                     .classes
                     .iter()
@@ -544,7 +544,7 @@ impl State {
             }
             Inline::RawInline(format, text) => {
                 if is_raw_org(format) {
-                    out.push(Piece::Text(text.clone()));
+                    out.push(Piece::Text(text.to_string()));
                 }
             }
             Inline::Link(_, label, target) => out.push(Piece::Text(self.link(label, target))),
@@ -712,14 +712,14 @@ fn fuse_term(term: &[Inline], blocks: &mut Vec<Block>) {
     if let Some(Block::Plain(inlines) | Block::Para(inlines)) = blocks.first_mut() {
         let mut fused = term.to_vec();
         fused.push(Inline::Space);
-        fused.push(Inline::Str("::".to_string()));
+        fused.push(Inline::Str("::".into()));
         fused.push(Inline::Space);
         fused.append(inlines);
         *inlines = fused;
     } else {
         let mut lead = term.to_vec();
         lead.push(Inline::Space);
-        lead.push(Inline::Str("::".to_string()));
+        lead.push(Inline::Str("::".into()));
         blocks.insert(0, Block::Plain(lead));
     }
 }
@@ -812,17 +812,17 @@ fn is_raw_org(format: &Format) -> bool {
 /// The index of the first class naming a special Org block, matched case-insensitively.
 /// The drawer name of a `Div` marked as a drawer: the first class other than the `drawer` marker,
 /// or `None` when the div is not a drawer or carries no name.
-fn drawer_name(classes: &[String]) -> Option<&str> {
+fn drawer_name(classes: &[Text]) -> Option<&str> {
     if !classes.iter().any(|class| class == "drawer") {
         return None;
     }
     classes
         .iter()
-        .map(String::as_str)
+        .map(Text::as_str)
         .find(|&class| class != "drawer")
 }
 
-fn special_div(classes: &[String]) -> Option<usize> {
+fn special_div(classes: &[Text]) -> Option<usize> {
     const SPECIAL: [&str; 7] = [
         "center",
         "quote",
@@ -840,7 +840,7 @@ fn special_div(classes: &[String]) -> Option<usize> {
 
 /// The `#+attr_html:` line for a special block's remaining classes and key/value attributes, or
 /// `None` when it carries neither.
-fn attr_html_line(extra: &[&str], attributes: &[(String, String)]) -> Option<String> {
+fn attr_html_line(extra: &[&str], attributes: &[(Text, Text)]) -> Option<String> {
     if extra.is_empty() && attributes.is_empty() {
         return None;
     }

--- a/crates/carta-writers/src/plain.rs
+++ b/crates/carta-writers/src/plain.rs
@@ -622,9 +622,9 @@ impl State {
             Inline::Str(text) => out.push(Piece::Text(if self.smart {
                 unsmarten(text)
             } else {
-                text.clone()
+                text.to_string()
             })),
-            Inline::Code(_, text) => out.push(Piece::Text(text.clone())),
+            Inline::Code(_, text) => out.push(Piece::Text(text.to_string())),
             Inline::Emph(inlines)
             | Inline::Strong(inlines)
             | Inline::Underline(inlines)
@@ -637,7 +637,7 @@ impl State {
                     && is_uri(&target.url)
                     && label_matches_url(text, &target.url)
                 {
-                    out.push(Piece::Text(target.url.clone()));
+                    out.push(Piece::Text(target.url.to_string()));
                 } else {
                     self.extend_pieces(inlines, out);
                 }
@@ -682,7 +682,7 @@ impl State {
             Inline::Math(kind, tex) => self.math(kind, tex, out),
             Inline::RawInline(format, text) => {
                 if is_plain_format(format) {
-                    out.push(Piece::Text(text.clone()));
+                    out.push(Piece::Text(text.to_string()));
                 }
             }
             Inline::Image(_, inlines, target) => {
@@ -973,7 +973,7 @@ mod tests {
     fn long_paragraph() -> Vec<Block> {
         let words: Vec<Inline> = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda"
             .split(' ')
-            .flat_map(|word| [Inline::Str(word.to_owned()), Inline::Space])
+            .flat_map(|word| [Inline::Str(word.to_owned().into()), Inline::Space])
             .collect();
         vec![Block::Para(words)]
     }
@@ -999,7 +999,7 @@ mod tests {
     }
 
     fn math_para(kind: MathType, tex: &str) -> Block {
-        Block::Para(vec![Inline::Math(kind, tex.to_owned())])
+        Block::Para(vec![Inline::Math(kind, tex.to_owned().into())])
     }
 
     fn inline(tex: &str) -> String {
@@ -1098,9 +1098,9 @@ mod tests {
     #[test]
     fn math_flows_inside_surrounding_text() {
         let blocks = vec![Block::Para(vec![
-            Inline::Str("value".to_owned()),
+            Inline::Str("value".to_owned().into()),
             Inline::Space,
-            Inline::Math(MathType::InlineMath, "E = mc^2".to_owned()),
+            Inline::Math(MathType::InlineMath, "E = mc^2".to_owned().into()),
         ])];
         assert_eq!(render(blocks), "value E\u{2004}=\u{2004}mc\u{b2}");
     }
@@ -1108,12 +1108,12 @@ mod tests {
     /// Render a single subscript/superscript run from a plain string of inner text.
     fn sub(text: &str) -> String {
         render(vec![Block::Para(vec![Inline::Subscript(vec![
-            Inline::Str(text.to_owned()),
+            Inline::Str(text.to_owned().into()),
         ])])])
     }
     fn sup(text: &str) -> String {
         render(vec![Block::Para(vec![Inline::Superscript(vec![
-            Inline::Str(text.to_owned()),
+            Inline::Str(text.to_owned().into()),
         ])])])
     }
 
@@ -1191,12 +1191,12 @@ mod tests {
         // Content that is not plain text or a space has no subscript form, so a convertible run is
         // rendered with superscript glyphs.
         let flipped = render(vec![Block::Para(vec![Inline::Subscript(vec![
-            Inline::Emph(vec![Inline::Str("2".to_owned())]),
+            Inline::Emph(vec![Inline::Str("2".to_owned().into())]),
         ])])]);
         assert_eq!(flipped, "\u{00b2}");
         // A formatted but otherwise unmappable run still falls back.
         let fallback = render(vec![Block::Para(vec![Inline::Subscript(vec![
-            Inline::Emph(vec![Inline::Str("a".to_owned())]),
+            Inline::Emph(vec![Inline::Str("a".to_owned().into())]),
         ])])]);
         assert_eq!(fallback, "_(a)");
     }

--- a/crates/carta-writers/src/revealjs.rs
+++ b/crates/carta-writers/src/revealjs.rs
@@ -264,15 +264,15 @@ mod tests {
         Block::Header(
             level,
             Box::new(Attr {
-                id: id.to_owned(),
+                id: id.to_owned().into(),
                 ..Attr::default()
             }),
-            vec![Inline::Str(title.to_owned())],
+            vec![Inline::Str(title.to_owned().into())],
         )
     }
 
     fn para(text: &str) -> Block {
-        Block::Para(vec![Inline::Str(text.to_owned())])
+        Block::Para(vec![Inline::Str(text.to_owned().into())])
     }
 
     #[test]
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn footnotes_collect_into_a_trailing_section() {
         let out = render(vec![Block::Para(vec![
-            Inline::Str("x".to_owned()),
+            Inline::Str("x".to_owned().into()),
             Inline::Note(vec![para("note")]),
         ])]);
         assert!(out.contains("href=\"#/fn1\""));

--- a/crates/carta-writers/src/rst.rs
+++ b/crates/carta-writers/src/rst.rs
@@ -8,8 +8,8 @@
 
 use carta_ast::{
     Attr, Block, Caption, ColWidth, Document, Format, Inline, ListAttributes, ListNumberDelim,
-    ListNumberStyle, MathType, MetaValue, QuoteType, Row, Table, Target, single_block_inlines,
-    slug, to_plain_text,
+    ListNumberStyle, MathType, MetaValue, QuoteType, Row, Table, Target, Text,
+    single_block_inlines, slug, to_plain_text,
 };
 use carta_core::{Extension, Result, TocStyle, WrapMode, Writer, WriterOptions};
 
@@ -318,7 +318,7 @@ impl State {
                         pieces.push(Piece::Text(text));
                     }
                 }
-                pieces.push(Piece::Math(tex.clone()));
+                pieces.push(Piece::Math(tex.to_string()));
                 start = index + 1;
             }
         }
@@ -490,7 +490,7 @@ impl State {
             // The directive's alternate text is the image's, falling back to its title.
             let alt_text = to_plain_text(alt);
             let alt_text = if alt_text.is_empty() {
-                target.title.clone()
+                target.title.to_string()
             } else {
                 alt_text
             };
@@ -652,7 +652,7 @@ impl State {
             Inline::Math(_, tex) => out.push(word(format!(":math:`{tex}`"), true)),
             Inline::RawInline(format, text) => {
                 if format.0.eq_ignore_ascii_case("rst") {
-                    out.push(word(text.clone(), false));
+                    out.push(word(text.to_string(), false));
                 } else if format.0.eq_ignore_ascii_case("latex")
                     || format.0.eq_ignore_ascii_case("tex")
                 {
@@ -800,7 +800,7 @@ impl State {
             return;
         }
         if label_matches_url(&plain, &target.url) && is_standalone_uri(&target.url) {
-            out.push(word(target.url.clone(), true));
+            out.push(word(target.url.to_string(), true));
             return;
         }
         if !self.tokens_nested(label, true).iter().any(is_word_token) {
@@ -1787,14 +1787,14 @@ fn is_bare_title(attr: &Attr) -> bool {
     attr.id.is_empty()
         && attr.attributes.is_empty()
         && attr.classes.len() == 1
-        && attr.classes.first().map(String::as_str) == Some("title")
+        && attr.classes.first().map(Text::as_str) == Some("title")
 }
 
 /// The language argument of a code block: its first class that is not the line-numbering flag.
 fn code_language(attr: &Attr) -> Option<&str> {
     attr.classes
         .iter()
-        .map(String::as_str)
+        .map(Text::as_str)
         .find(|class| *class != "numberLines")
 }
 

--- a/crates/carta-writers/src/slides.rs
+++ b/crates/carta-writers/src/slides.rs
@@ -187,15 +187,15 @@ mod tests {
         Block::Header(
             level,
             Box::new(Attr {
-                id: id.to_owned(),
+                id: id.to_owned().into(),
                 ..Attr::default()
             }),
-            vec![Inline::Str(id.to_owned())],
+            vec![Inline::Str(id.to_owned().into())],
         )
     }
 
     fn para(text: &str) -> Block {
-        Block::Para(vec![Inline::Str(text.to_owned())])
+        Block::Para(vec![Inline::Str(text.to_owned().into())])
     }
 
     #[test]

--- a/crates/carta-writers/src/typst.rs
+++ b/crates/carta-writers/src/typst.rs
@@ -1232,7 +1232,7 @@ mod tests {
     }
 
     fn str_inline(text: &str) -> Inline {
-        Inline::Str(text.to_owned())
+        Inline::Str(text.to_owned().into())
     }
 
     #[test]
@@ -1437,7 +1437,7 @@ mod tests {
                 vec![str_inline("alt")],
                 Box::new(Target {
                     url: "i.png".into(),
-                    title: String::new(),
+                    title: String::new().into(),
                 }),
             )])]),
             "#box(image(\"i.png\", width: 2.08333in, alt: \"alt\"))"

--- a/crates/carta/src/main.rs
+++ b/crates/carta/src/main.rs
@@ -268,7 +268,7 @@ fn parse_metadata(specs: &[String]) -> BTreeMap<String, MetaValue> {
         let (key, value) = match spec.split_once([':', '=']) {
             Some((key, "true")) => (key, MetaValue::MetaBool(true)),
             Some((key, "false")) => (key, MetaValue::MetaBool(false)),
-            Some((key, value)) => (key, MetaValue::MetaString(value.to_owned())),
+            Some((key, value)) => (key, MetaValue::MetaString(value.into())),
             None => (spec.as_str(), MetaValue::MetaBool(true)),
         };
         let next = match map.remove(key) {
@@ -402,9 +402,9 @@ mod tests {
                 .map(|s| (*s).to_owned())
                 .collect::<Vec<_>>(),
         );
-        assert_eq!(map["a"], MetaValue::MetaString("val".to_owned()));
+        assert_eq!(map["a"], MetaValue::MetaString("val".into()));
         assert_eq!(map["b"], MetaValue::MetaBool(true));
-        assert_eq!(map["c"], MetaValue::MetaString("x=y".to_owned()));
+        assert_eq!(map["c"], MetaValue::MetaString("x=y".into()));
     }
 
     #[test]
@@ -417,10 +417,10 @@ mod tests {
         );
         assert_eq!(map["a"], MetaValue::MetaBool(true));
         assert_eq!(map["b"], MetaValue::MetaBool(false));
-        assert_eq!(map["c"], MetaValue::MetaString("text".to_owned()));
+        assert_eq!(map["c"], MetaValue::MetaString("text".into()));
         assert_eq!(map["d"], MetaValue::MetaBool(true));
         // Only lowercase `true`/`false` are booleans; anything else stays a string.
-        assert_eq!(map["e"], MetaValue::MetaString("True".to_owned()));
+        assert_eq!(map["e"], MetaValue::MetaString("True".into()));
     }
 
     #[test]
@@ -430,8 +430,8 @@ mod tests {
         assert_eq!(
             two["k"],
             MetaValue::MetaList(vec![
-                MetaValue::MetaString("first".to_owned()),
-                MetaValue::MetaString("second".to_owned()),
+                MetaValue::MetaString("first".into()),
+                MetaValue::MetaString("second".into()),
             ])
         );
         // Further occurrences append; a bare first occurrence keeps its boolean element.
@@ -440,8 +440,8 @@ mod tests {
             mixed["k"],
             MetaValue::MetaList(vec![
                 MetaValue::MetaBool(true),
-                MetaValue::MetaString("a".to_owned()),
-                MetaValue::MetaString("b".to_owned()),
+                MetaValue::MetaString("a".into()),
+                MetaValue::MetaString("b".into()),
             ])
         );
     }

--- a/crates/carta/src/standalone.rs
+++ b/crates/carta/src/standalone.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use carta_ast::{
-    Document, Inline, MetaValue, single_block_inlines, to_plain_inlines, to_plain_text,
+    Document, Inline, MetaValue, Text, single_block_inlines, to_plain_inlines, to_plain_text,
 };
 use carta_core::sections::build_toc;
 use carta_core::template::{Template, Value};
@@ -23,12 +23,16 @@ pub(crate) fn merge_metadata(document: &mut Document, options: &WriterOptions) {
     if options.metadata_defaults.is_empty() && options.metadata.is_empty() {
         return;
     }
-    let mut merged = options.metadata_defaults.clone();
+    let mut merged: BTreeMap<Text, MetaValue> = options
+        .metadata_defaults
+        .iter()
+        .map(|(key, value)| (Text::from(key.as_str()), value.clone()))
+        .collect();
     for (key, value) in std::mem::take(&mut document.meta) {
         merged.insert(key, value);
     }
     for (key, value) in &options.metadata {
-        merged.insert(key.clone(), value.clone());
+        merged.insert(Text::from(key.as_str()), value.clone());
     }
     document.meta = merged;
 }
@@ -114,8 +118,8 @@ fn build_context(
         } else {
             value_to_json(&meta_to_value(value, writer, options, json_mode)?)
         };
-        meta_json.insert(key.clone(), json);
-        context.insert(key.clone(), context_value);
+        meta_json.insert(key.to_string(), json);
+        context.insert(key.to_string(), context_value);
     }
     context.insert(
         "meta-json".to_owned(),
@@ -213,7 +217,7 @@ fn meta_to_value(
         MetaValue::MetaMap(map) => {
             let mut entries = BTreeMap::new();
             for (key, item) in map {
-                entries.insert(key.clone(), meta_to_value(item, writer, options, mode)?);
+                entries.insert(key.to_string(), meta_to_value(item, writer, options, mode)?);
             }
             Value::Map(entries)
         }
@@ -267,7 +271,7 @@ fn insert_identity_vars(
                     .source_name
                     .clone()
                     .filter(|name| !name.is_empty())
-                    .map(|name| vec![Inline::Str(name)])
+                    .map(|name| vec![Inline::Str(name.into())])
             } else {
                 Some(title)
             };
@@ -360,7 +364,7 @@ fn insert_output_vars(
 fn plain_meta(document: &Document, key: &str) -> String {
     match document.meta.get(key) {
         Some(MetaValue::MetaInlines(inlines)) => to_plain_text(inlines),
-        Some(MetaValue::MetaString(text)) => text.clone(),
+        Some(MetaValue::MetaString(text)) => text.to_string(),
         Some(MetaValue::MetaBlocks(blocks)) => to_plain_text(single_block_inlines(blocks)),
         _ => String::new(),
     }
@@ -385,7 +389,7 @@ fn author_plain_inlines(document: &Document) -> Vec<Vec<Inline>> {
     fn plain_one(value: &MetaValue) -> (String, Vec<Inline>) {
         match value {
             MetaValue::MetaInlines(inlines) => (to_plain_text(inlines), to_plain_inlines(inlines)),
-            MetaValue::MetaString(text) => (text.clone(), vec![Inline::Str(text.clone())]),
+            MetaValue::MetaString(text) => (text.to_string(), vec![Inline::Str(text.clone())]),
             MetaValue::MetaBlocks(blocks) => {
                 let inlines = single_block_inlines(blocks);
                 (to_plain_text(inlines), to_plain_inlines(inlines))

--- a/crates/carta/tests/native_roundtrip.rs
+++ b/crates/carta/tests/native_roundtrip.rs
@@ -41,16 +41,16 @@ fn document(blocks: Vec<Block>) -> Document {
 }
 
 fn str_inline(text: &str) -> Inline {
-    Inline::Str(text.to_owned())
+    Inline::Str(text.into())
 }
 
 fn attr(id: &str, classes: &[&str], attributes: &[(&str, &str)]) -> Attr {
     Attr {
-        id: id.to_owned(),
-        classes: classes.iter().map(|c| (*c).to_owned()).collect(),
+        id: id.into(),
+        classes: classes.iter().map(|c| (*c).into()).collect(),
         attributes: attributes
             .iter()
-            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .map(|(k, v)| ((*k).into(), (*v).into()))
             .collect(),
     }
 }
@@ -87,27 +87,27 @@ fn document_corpus() -> Vec<Document> {
         document(vec![Block::Para(vec![
             Inline::Code(
                 Box::new(attr("i", &["lang"], &[("k", "v")])),
-                "x = 1".to_owned(),
+                "x = 1".into(),
             ),
-            Inline::Math(MathType::InlineMath, "a^2".to_owned()),
-            Inline::Math(MathType::DisplayMath, "b".to_owned()),
-            Inline::RawInline(Format("html".to_owned()), "<b>".to_owned()),
+            Inline::Math(MathType::InlineMath, "a^2".into()),
+            Inline::Math(MathType::DisplayMath, "b".into()),
+            Inline::RawInline(Format("html".into()), "<b>".into()),
         ])]),
         document(vec![Block::Para(vec![
             Inline::Link(
                 Box::new(attr("l", &["c"], &[])),
                 vec![str_inline("t")],
                 Box::new(Target {
-                    url: "http://x".to_owned(),
-                    title: "ti".to_owned(),
+                    url: "http://x".into(),
+                    title: "ti".into(),
                 }),
             ),
             Inline::Image(
                 Box::default(),
                 vec![str_inline("alt")],
                 Box::new(Target {
-                    url: "p.png".to_owned(),
-                    title: String::new(),
+                    url: "p.png".into(),
+                    title: "".into(),
                 }),
             ),
             Inline::Span(Box::new(attr("s", &["c"], &[])), vec![str_inline("inner")]),
@@ -116,7 +116,7 @@ fn document_corpus() -> Vec<Document> {
         document(vec![Block::Para(vec![Inline::Cite(
             vec![
                 Citation {
-                    id: "k".to_owned(),
+                    id: "k".into(),
                     prefix: vec![str_inline("see")],
                     suffix: vec![str_inline("p5")],
                     mode: CitationMode::NormalCitation,
@@ -124,7 +124,7 @@ fn document_corpus() -> Vec<Document> {
                     hash: 0,
                 },
                 Citation {
-                    id: "j".to_owned(),
+                    id: "j".into(),
                     prefix: vec![],
                     suffix: vec![],
                     mode: CitationMode::AuthorInText,
@@ -132,7 +132,7 @@ fn document_corpus() -> Vec<Document> {
                     hash: 0,
                 },
                 Citation {
-                    id: "h".to_owned(),
+                    id: "h".into(),
                     prefix: vec![],
                     suffix: vec![],
                     mode: CitationMode::SuppressAuthor,
@@ -144,8 +144,8 @@ fn document_corpus() -> Vec<Document> {
         )])]),
         document(vec![
             Block::LineBlock(vec![vec![str_inline("one")], vec![str_inline("two")]]),
-            Block::CodeBlock(Box::new(attr("", &["rust"], &[])), "let x = 1;".to_owned()),
-            Block::RawBlock(Format("html".to_owned()), "<div>".to_owned()),
+            Block::CodeBlock(Box::new(attr("", &["rust"], &[])), "let x = 1;".into()),
+            Block::RawBlock(Format("html".into()), "<div>".into()),
             Block::BlockQuote(vec![Block::Para(vec![str_inline("q")])]),
             Block::HorizontalRule,
         ]),
@@ -231,8 +231,8 @@ fn document_corpus() -> Vec<Document> {
                     Box::default(),
                     vec![str_inline("alt")],
                     Box::new(Target {
-                        url: "p.png".to_owned(),
-                        title: String::new(),
+                        url: "p.png".into(),
+                        title: "".into(),
                     }),
                 )])],
             ),

--- a/crates/carta/tests/standalone.rs
+++ b/crates/carta/tests/standalone.rs
@@ -46,18 +46,12 @@ fn options() -> WriterOptions {
         ("vm".to_owned(), "from-V-vm".to_owned()),
     ];
     options.metadata = BTreeMap::from([
-        (
-            "mover".to_owned(),
-            MetaValue::MetaString("from-M".to_owned()),
-        ),
-        (
-            "vm".to_owned(),
-            MetaValue::MetaString("from-M-vm".to_owned()),
-        ),
+        ("mover".to_owned(), MetaValue::MetaString("from-M".into())),
+        ("vm".to_owned(), MetaValue::MetaString("from-M-vm".into())),
     ]);
     options.metadata_defaults = BTreeMap::from([(
         "deflt".to_owned(),
-        MetaValue::MetaString("default-val".to_owned()),
+        MetaValue::MetaString("default-val".into()),
     )]);
     options
 }


### PR DESCRIPTION
## Summary

Readers emit one `Inline::Str` per word, each a separately heap-allocated `String`; swapping the `Text` alias to an inline-capable small string (24 bytes stored inline, same footprint and serialization as `String`) keeps word-sized payloads — words, ids, classes, targets — off the heap entirely. Output stays byte-identical, peak RSS on the 1 MB commonmark→json conversion drops ~5–9%, at the cost of +226 KiB release binary size.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.