### PR TITLE
refactor(writers): share the identical markdown-family block helpers

### DIFF
--- a/crates/carta-writers/src/commonmark.rs
+++ b/crates/carta-writers/src/commonmark.rs
@@ -8,8 +8,8 @@
 //! This format has no public specification.
 
 use carta_ast::{
-    Attr, Block, Document, Format, Inline, ListAttributes, ListNumberDelim, ListNumberStyle,
-    MathType, Target, Text,
+    Attr, Block, Document, Inline, ListAttributes, ListNumberDelim, ListNumberStyle, MathType,
+    Target, Text,
 };
 use carta_core::{Result, WrapMode, Writer, WriterOptions};
 
@@ -17,6 +17,10 @@ use crate::common::{
     FILL_COLUMN, NotesHost, Piece, append_notes, escape_attr, fill, fill_groups, indent_block,
     is_loose, is_uri, item_separator, label_matches_url, normalize_image_attr, offset_as_i32,
     ordered_marker, quote_marks, render_html_attr,
+};
+use crate::markdown_common::{
+    attr_is_empty, indent_code, is_autolink_class, is_html_format, longest_backtick_run,
+    needs_separator, offset_horizontal_rule, quote_block,
 };
 
 /// Renders a document to `CommonMark` text.
@@ -528,62 +532,12 @@ fn html_tag_pieces(tag: &str) -> Vec<Piece> {
     pieces
 }
 
-/// Whether an HTML comment must separate two consecutive blocks so the second is not absorbed into
-/// the first: two lists of the same kind would merge into one, and an indented code block following
-/// a list would read as a continuation of the final item.
-fn needs_separator(previous: &Block, current: &Block) -> bool {
-    match (previous, current) {
-        (Block::BulletList(_), Block::BulletList(_))
-        | (Block::OrderedList(..), Block::OrderedList(..)) => true,
-        (Block::BulletList(_) | Block::OrderedList(..), Block::CodeBlock(attr, _)) => {
-            attr_is_empty(attr)
-        }
-        _ => false,
-    }
-}
-
-/// A list item whose first block is a horizontal rule cannot place the rule on the marker line,
-/// where it would read as part of the marker; the rule is pushed onto its own line below an empty
-/// marker line by prefixing the rendered body with a blank line.
-fn offset_horizontal_rule(item: &[Block], body: String) -> String {
-    if matches!(item.first(), Some(Block::HorizontalRule)) {
-        format!("\n\n{body}")
-    } else {
-        body
-    }
-}
-
 /// Whether the next inline is a bare `1.` or `1)`: an ordered-list marker whose start number is one,
 /// the only ordered marker that can interrupt a paragraph. If such a token began a wrapped
 /// continuation line it would be re-read as a list, so the space before it is held non-breakable to
 /// keep it on the line with the preceding word.
 fn next_is_para_interrupting_marker(inline: Option<&Inline>) -> bool {
     matches!(inline, Some(Inline::Str(text)) if text == "1." || text == "1)")
-}
-
-/// Prefix every line of a blockquote body with `> ` (a bare `>` on an otherwise empty line).
-fn quote_block(body: &str) -> String {
-    if body.is_empty() {
-        return "> ".to_owned();
-    }
-    let mut out = String::new();
-    for (index, line) in body.split('\n').enumerate() {
-        if index > 0 {
-            out.push('\n');
-        }
-        if line.is_empty() {
-            out.push('>');
-        } else {
-            out.push_str("> ");
-            out.push_str(line);
-        }
-    }
-    out
-}
-
-/// Whether a raw node targets HTML and should pass its content through verbatim.
-fn is_html_format(format: &Format) -> bool {
-    matches!(format.0.as_str(), "html" | "html4" | "html5")
 }
 
 /// Keep an embedded HTML block a single `CommonMark` block: each blank line inside it becomes a
@@ -616,23 +570,6 @@ fn code_block(attr: &Attr, text: &str) -> String {
     }
 }
 
-/// An indented code block: every non-blank line is prefixed with four spaces, blank lines stay
-/// empty, and trailing blank lines are dropped. Empty content yields no output.
-fn indent_code(text: &str) -> String {
-    let body = text.trim_end_matches('\n');
-    let mut out = String::new();
-    for (index, line) in body.split('\n').enumerate() {
-        if index > 0 {
-            out.push('\n');
-        }
-        if !line.is_empty() {
-            out.push_str("    ");
-            out.push_str(line);
-        }
-    }
-    out
-}
-
 /// The backtick run length for a fenced code block: longer than the longest backtick run in the
 /// content, and at least three.
 fn backtick_fence_len(text: &str) -> usize {
@@ -651,20 +588,6 @@ fn code_span(text: &str) -> String {
     } else {
         format!("{fence}{text}{fence}")
     }
-}
-
-fn longest_backtick_run(text: &str) -> usize {
-    let mut longest = 0;
-    let mut current = 0;
-    for ch in text.chars() {
-        if ch == '`' {
-            current += 1;
-            longest = longest.max(current);
-        } else {
-            current = 0;
-        }
-    }
-    longest
 }
 
 /// Append a raw-HTML run to the fill pieces. When `breakable`, the spaces separating a tag's
@@ -728,18 +651,6 @@ fn autolink(inlines: &[Inline], target: &Target) -> Option<String> {
         return Some(format!("<{text}>"));
     }
     None
-}
-
-fn attr_is_empty(attr: &Attr) -> bool {
-    attr.id.is_empty() && attr.classes.is_empty() && attr.attributes.is_empty()
-}
-
-/// Whether a link's attributes consist solely of the `uri` or `email` class that marks it as an
-/// autolink: with no id and no further attributes, such a link is written in angle-bracket form.
-fn is_autolink_class(attr: &Attr) -> bool {
-    attr.id.is_empty()
-        && attr.attributes.is_empty()
-        && matches!(attr.classes.as_slice(), [class] if class == "uri" || class == "email")
 }
 
 /// The plain-text projection of an inline sequence, used for an image's `alt` attribute.
@@ -927,7 +838,7 @@ fn is_word_boundary(before: Option<char>, after: Option<char>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use carta_ast::QuoteType;
+    use carta_ast::{Format, QuoteType};
 
     fn render(blocks: Vec<Block>) -> String {
         CommonmarkWriter

--- a/crates/carta-writers/src/lib.rs
+++ b/crates/carta-writers/src/lib.rs
@@ -39,6 +39,9 @@ mod grid;
 ))]
 mod math;
 
+#[cfg(any(feature = "commonmark", feature = "markdown", feature = "gfm"))]
+mod markdown_common;
+
 #[cfg(feature = "slides")]
 mod slides;
 

--- a/crates/carta-writers/src/markdown.rs
+++ b/crates/carta-writers/src/markdown.rs
@@ -23,11 +23,15 @@ use carta_core::{Extension, Extensions, Result, WrapMode, Writer, WriterOptions,
 use crate::common::{
     FILL_COLUMN, MEASURE_WIDTH, NotesHost, Piece, TableForm, append_notes, block_inlines,
     body_rows, cell_inlines, dash_rule, display_width, escape_attr, extend_multiline_body, fill,
-    fill_offset, filled_cells, indent_block, indent_lines, is_known_scheme, is_loose,
-    is_percent_escaped_uri, is_simple_cell, item_separator, lay_row, measure_pieces, offset_as_i32,
-    ordered_marker, pad_align, pieces_nonempty, quote_marks, render_html_attr, table_form,
+    fill_offset, filled_cells, indent_block, indent_lines, is_loose, is_simple_cell, is_uri,
+    item_separator, lay_row, measure_pieces, offset_as_i32, ordered_marker, pad_align,
+    pieces_nonempty, quote_marks, render_html_attr, table_form,
 };
 use crate::grid;
+use crate::markdown_common::{
+    attr_is_empty, indent_code, is_autolink_class, is_html_format, longest_backtick_run,
+    needs_separator, offset_horizontal_rule, quote_block,
+};
 
 /// The rendering configuration shared by every entry point and exposed to sibling writers that embed
 /// markdown (the outline writer renders note text through this engine). The active [`Extensions`]
@@ -1892,48 +1896,6 @@ fn pieces_to_string(pieces: &[Piece]) -> String {
     out
 }
 
-fn needs_separator(previous: &Block, current: &Block) -> bool {
-    match (previous, current) {
-        (Block::BulletList(_), Block::BulletList(_))
-        | (Block::OrderedList(..), Block::OrderedList(..)) => true,
-        (Block::BulletList(_) | Block::OrderedList(..), Block::CodeBlock(attr, _)) => {
-            attr_is_empty(attr)
-        }
-        _ => false,
-    }
-}
-
-fn offset_horizontal_rule(item: &[Block], body: String) -> String {
-    if matches!(item.first(), Some(Block::HorizontalRule)) {
-        format!("\n\n{body}")
-    } else {
-        body
-    }
-}
-
-fn quote_block(body: &str) -> String {
-    if body.is_empty() {
-        return "> ".to_owned();
-    }
-    let mut out = String::new();
-    for (index, line) in body.split('\n').enumerate() {
-        if index > 0 {
-            out.push('\n');
-        }
-        if line.is_empty() {
-            out.push('>');
-        } else {
-            out.push_str("> ");
-            out.push_str(line);
-        }
-    }
-    out
-}
-
-fn is_html_format(format: &Format) -> bool {
-    matches!(format.0.as_str(), "html" | "html4" | "html5")
-}
-
 /// Whether a raw-format name denotes TeX, which Markdown dialects with `raw_tex` embed verbatim.
 /// `ConTeXt` and other TeX-adjacent formats are excluded — only `tex`/`latex` take the verbatim
 /// path; everything else is rendered via the `raw_attribute` fenced form.
@@ -2019,21 +1981,6 @@ fn github_code_info(attr: &Attr) -> Option<String> {
     }
 }
 
-fn indent_code(text: &str) -> String {
-    let body = text.trim_end_matches('\n');
-    let mut out = String::new();
-    for (index, line) in body.split('\n').enumerate() {
-        if index > 0 {
-            out.push('\n');
-        }
-        if !line.is_empty() {
-            out.push_str("    ");
-            out.push_str(line);
-        }
-    }
-    out
-}
-
 /// The fence length for a fenced code block built from `fence`: longer than the longest leading run
 /// of that character already in the body (so the fence cannot close early), and at least three.
 fn fence_run_len(text: &str, fence: char) -> usize {
@@ -2098,20 +2045,6 @@ fn code_span(text: &str) -> String {
     }
 }
 
-fn longest_backtick_run(text: &str) -> usize {
-    let mut longest = 0;
-    let mut current = 0;
-    for ch in text.chars() {
-        if ch == '`' {
-            current += 1;
-            longest = longest.max(current);
-        } else {
-            current = 0;
-        }
-    }
-    longest
-}
-
 fn destination(target: &Target) -> String {
     if target.title.is_empty() {
         target.url.to_string()
@@ -2135,17 +2068,6 @@ fn autolink(inlines: &[Inline], target: &Target) -> Option<String> {
         return Some(format!("<{text}>"));
     }
     None
-}
-
-fn is_uri(text: &str) -> bool {
-    let Some(colon) = text.find(':') else {
-        return false;
-    };
-    text.get(..colon).is_some_and(is_known_scheme) && is_percent_escaped_uri(text, true)
-}
-
-fn attr_is_empty(attr: &Attr) -> bool {
-    attr.id.is_empty() && attr.classes.is_empty() && attr.attributes.is_empty()
 }
 
 /// Flatten a figure caption's blocks into one inline sequence for the implicit-figure form: each
@@ -2173,12 +2095,6 @@ fn header_attr_implicit(attr: &Attr, inlines: &[Inline], auto_identifiers: bool)
         && attr.attributes.is_empty()
         && (attr.id.is_empty()
             || (auto_identifiers && attr.id == carta_ast::slug(&carta_ast::to_plain_text(inlines))))
-}
-
-fn is_autolink_class(attr: &Attr) -> bool {
-    attr.id.is_empty()
-        && attr.attributes.is_empty()
-        && matches!(attr.classes.as_slice(), [class] if class == "uri" || class == "email")
 }
 
 fn has_dimension(attr: &Attr) -> bool {

--- a/crates/carta-writers/src/markdown_common.rs
+++ b/crates/carta-writers/src/markdown_common.rs
@@ -1,0 +1,98 @@
+//! Block and inline helpers shared by the Markdown-family writer engines. Both the `CommonMark`
+//! engine and the multi-dialect Markdown engine render these constructs identically, so the layout
+//! and escaping logic lives here once.
+
+use carta_ast::{Attr, Block, Format};
+
+/// Whether an HTML comment must separate two consecutive blocks so the second is not absorbed into
+/// the first: two lists of the same kind would merge into one, and an indented code block following
+/// a list would read as a continuation of the final item.
+pub(crate) fn needs_separator(previous: &Block, current: &Block) -> bool {
+    match (previous, current) {
+        (Block::BulletList(_), Block::BulletList(_))
+        | (Block::OrderedList(..), Block::OrderedList(..)) => true,
+        (Block::BulletList(_) | Block::OrderedList(..), Block::CodeBlock(attr, _)) => {
+            attr_is_empty(attr)
+        }
+        _ => false,
+    }
+}
+
+/// A list item whose first block is a horizontal rule cannot place the rule on the marker line,
+/// where it would read as part of the marker; the rule is pushed onto its own line below an empty
+/// marker line by prefixing the rendered body with a blank line.
+pub(crate) fn offset_horizontal_rule(item: &[Block], body: String) -> String {
+    if matches!(item.first(), Some(Block::HorizontalRule)) {
+        format!("\n\n{body}")
+    } else {
+        body
+    }
+}
+
+/// Prefix every line of a blockquote body with `> ` (a bare `>` on an otherwise empty line).
+pub(crate) fn quote_block(body: &str) -> String {
+    if body.is_empty() {
+        return "> ".to_owned();
+    }
+    let mut out = String::new();
+    for (index, line) in body.split('\n').enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        if line.is_empty() {
+            out.push('>');
+        } else {
+            out.push_str("> ");
+            out.push_str(line);
+        }
+    }
+    out
+}
+
+/// Whether a raw node targets HTML and should pass its content through verbatim.
+pub(crate) fn is_html_format(format: &Format) -> bool {
+    matches!(format.0.as_str(), "html" | "html4" | "html5")
+}
+
+/// An indented code block: every non-blank line is prefixed with four spaces, blank lines stay
+/// empty, and trailing blank lines are dropped. Empty content yields no output.
+pub(crate) fn indent_code(text: &str) -> String {
+    let body = text.trim_end_matches('\n');
+    let mut out = String::new();
+    for (index, line) in body.split('\n').enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        if !line.is_empty() {
+            out.push_str("    ");
+            out.push_str(line);
+        }
+    }
+    out
+}
+
+pub(crate) fn longest_backtick_run(text: &str) -> usize {
+    let mut longest = 0;
+    let mut current = 0;
+    for ch in text.chars() {
+        if ch == '`' {
+            current += 1;
+            longest = longest.max(current);
+        } else {
+            current = 0;
+        }
+    }
+    longest
+}
+
+pub(crate) fn attr_is_empty(attr: &Attr) -> bool {
+    attr.id.is_empty() && attr.classes.is_empty() && attr.attributes.is_empty()
+}
+
+/// Whether a link's attributes consist solely of the `uri` or `email` class that marks it as an
+/// autolink: with no id and no further attributes, such a link is written in angle-bracket form.
+pub(crate) fn is_autolink_class(attr: &Attr) -> bool {
+    attr.id.is_empty()
+        && attr.attributes.is_empty()
+        && matches!(attr.classes.as_slice(), [class] if class == "uri" || class == "email")
+}


### PR DESCRIPTION
## Summary

The two Markdown-family writer engines duplicated eight block/inline helpers byte-for-byte, so every layout fix had to be made twice; they now live once in a shared `markdown_common` module, and `markdown.rs`'s private `is_uri` copy is folded into the existing `common::is_uri`.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.
