### PR TITLE
feat: media bag for embedded resources (connected to ipynb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This tracks carta's status of all formats pandoc supports. See [`STATUS.md`](doc
 | OpenDocument Text (`odt`) | ❌ | ❌ |
 | OpenDocument (`opendocument`) | ➖ | ❌ |
 | EPUB (`epub`, `epub2`, `epub3`) | ❌ | ❌ |
-| Jupyter Notebook (`ipynb`) | ✅ | 🚧 |
+| Jupyter Notebook (`ipynb`) | ✅ | ✅ |
 | FictionBook2 (`fb2`) | ❌ | ❌ |
 | InDesign ICML (`icml`) | ➖ | ❌ |
 | Rich Text Format (`rtf`) | ❌ | ❌ |
@@ -197,6 +197,9 @@ carta -f commonmark -t html -s --toc --number-sections input.md -o output.html
 
 # render HTML math with MathJax (or --katex)
 carta -f commonmark -t html -s --mathjax input.md -o output.html
+
+# extract a notebook's embedded images to files, rewriting the references
+carta -f ipynb -t markdown --extract-media=media notebook.ipynb -o notebook.md
 
 # discover what this build supports
 carta --list-input-formats

--- a/corpus/text/ipynb/attachment-order.ipynb
+++ b/corpus/text/ipynb/attachment-order.ipynb
@@ -1,0 +1,33 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "order",
+      "metadata": {},
+      "attachments": {
+        "beta.png": {
+          "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        },
+        "alpha.png": {
+          "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+        }
+      },
+      "source": [
+        "Two attachments, referenced out of key order:\n",
+        "\n",
+        "![beta](attachment:beta.png)\n",
+        "\n",
+        "![alpha](attachment:alpha.png)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/crates/carta-core/src/lib.rs
+++ b/crates/carta-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 use std::fmt;
 use std::io;
+use std::sync::Arc;
 
 use carta_ast::{Block, Document, Inline};
 
@@ -122,6 +123,11 @@ pub struct WriterOptions {
     /// Format extensions to enable.
     pub extensions: Extensions,
 
+    /// The embedded resources the document references by name but does not carry inline. A writer
+    /// that re-embeds resource bytes — a notebook re-encoding its image outputs — reads them from
+    /// here; most writers ignore it. Shared cheaply, so cloning the options does not copy the bytes.
+    pub media: Arc<MediaBag>,
+
     /// How paragraphs are laid out: reflowed to the fill column, never wrapped, or with the source's
     /// own line breaks preserved.
     pub wrap: WrapMode,
@@ -191,6 +197,17 @@ pub struct WriterOptions {
 /// Parses input text in some source format into the document model.
 pub trait Reader {
     fn read(&self, input: &str, options: &ReaderOptions) -> Result<Document>;
+
+    /// Reads `input` into a document together with the embedded resources it references. The default
+    /// carries no resources; a container format — a notebook with image outputs — overrides this to
+    /// decode those bytes into the returned [`MediaBag`], and implements [`read`](Reader::read) by
+    /// discarding the bag.
+    ///
+    /// # Errors
+    /// Propagates any error from parsing the input.
+    fn read_media(&self, input: &str, options: &ReaderOptions) -> Result<(Document, MediaBag)> {
+        Ok((self.read(input, options)?, MediaBag::new()))
+    }
 }
 
 /// Which plain-text identity variables a writer's standalone template draws on. The document's
@@ -342,6 +359,15 @@ pub trait Writer {
 /// [`Reader`], for formats whose wire form is not text — zip containers and the like.
 pub trait BytesReader {
     fn read(&self, input: &[u8], options: &ReaderOptions) -> Result<Document>;
+
+    /// Reads `input` into a document together with the embedded resources it references. The
+    /// byte-shaped counterpart of [`Reader::read_media`]; the default carries no resources.
+    ///
+    /// # Errors
+    /// Propagates any error from parsing the input.
+    fn read_media(&self, input: &[u8], options: &ReaderOptions) -> Result<(Document, MediaBag)> {
+        Ok((self.read(input, options)?, MediaBag::new()))
+    }
 }
 
 /// Renders the document model into some target format's bytes. The byte-shaped counterpart of
@@ -388,6 +414,24 @@ impl AnyReader {
         match self {
             AnyReader::Text(reader) => reader.read(std::str::from_utf8(input)?, options),
             AnyReader::Bytes(reader) => reader.read(input, options),
+        }
+    }
+
+    /// Reads `input` into a document together with the embedded resources it references. A text
+    /// reader decodes the bytes as UTF-8 first; a byte reader takes the raw slice. A reader that
+    /// carries no resources returns an empty [`MediaBag`].
+    ///
+    /// # Errors
+    /// [`Error::InvalidUtf8`] if a text reader is handed input that is not valid UTF-8, plus any
+    /// error the underlying reader returns.
+    pub fn read_media(
+        &self,
+        input: &[u8],
+        options: &ReaderOptions,
+    ) -> Result<(Document, MediaBag)> {
+        match self {
+            AnyReader::Text(reader) => reader.read_media(std::str::from_utf8(input)?, options),
+            AnyReader::Bytes(reader) => reader.read_media(input, options),
         }
     }
 }
@@ -480,5 +524,14 @@ mod tests {
                 .read(&[0xff, 0xfe], &ReaderOptions::default())
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn default_read_media_carries_no_resources() {
+        let reader = AnyReader::Text(Box::new(EmptyTextReader));
+        let (_, media) = reader
+            .read_media(b"anything", &ReaderOptions::default())
+            .expect("read succeeds");
+        assert!(media.is_empty());
     }
 }

--- a/crates/carta-core/src/lib.rs
+++ b/crates/carta-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod media;
 pub mod sections;
 #[cfg(feature = "template")]
 pub mod template;
+pub mod walk;
 
 pub use extensions::{Extension, Extensions, presets};
 pub use media::{MediaBag, MediaItem};

--- a/crates/carta-core/src/lib.rs
+++ b/crates/carta-core/src/lib.rs
@@ -10,11 +10,13 @@ use std::io;
 use carta_ast::{Block, Document, Inline};
 
 pub mod extensions;
+pub mod media;
 pub mod sections;
 #[cfg(feature = "template")]
 pub mod template;
 
 pub use extensions::{Extension, Extensions, presets};
+pub use media::{MediaBag, MediaItem};
 
 /// The error type returned across the conversion pipeline.
 #[derive(Debug, thiserror::Error)]

--- a/crates/carta-core/src/media/base64.rs
+++ b/crates/carta-core/src/media/base64.rs
@@ -141,14 +141,16 @@ mod tests {
     #[test]
     fn mime_form_wraps_at_76_with_trailing_newline() {
         // 300 bytes -> 400 base64 chars -> five 76-char lines plus a 20-char line, each newline-ended.
-        let data: Vec<u8> = (0..300).map(|index| (index % 251) as u8).collect();
+        let data: Vec<u8> = (0..300u32)
+            .map(|index| u8::try_from(index % 251).unwrap_or(0))
+            .collect();
         let wrapped = encode_mime(&data);
         let lines: Vec<&str> = wrapped.split('\n').collect();
         // A trailing newline means split leaves an empty final element.
         assert_eq!(lines.last(), Some(&""));
         assert_eq!(lines.len(), 7);
-        assert!(lines[..5].iter().all(|line| line.len() == 76));
-        assert_eq!(lines[5].len(), 20);
+        assert!(lines.iter().take(5).all(|line| line.len() == 76));
+        assert_eq!(lines.get(5).map(|line| line.len()), Some(20));
         // The concatenation of the lines decodes back to the input.
         assert_eq!(decode(&wrapped), Some(data));
     }

--- a/crates/carta-core/src/media/base64.rs
+++ b/crates/carta-core/src/media/base64.rs
@@ -1,0 +1,160 @@
+//! Standard base64, the encoding embedded resources travel in inside text container formats.
+
+const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// The line width binary payloads are wrapped to inside a notebook's JSON.
+const LINE_WIDTH: usize = 76;
+
+/// The standard base64 symbol for a 6-bit value; the mask keeps the index within the alphabet.
+fn symbol(value: u32) -> char {
+    ALPHABET
+        .get((value & 0x3f) as usize)
+        .map_or('A', |&byte| byte as char)
+}
+
+/// Encodes bytes as standard base64 with `=` padding and no line breaks.
+#[must_use]
+pub fn encode(data: &[u8]) -> String {
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let (b0, b1, b2, len) = match chunk {
+            [b0, b1, b2] => (*b0, *b1, *b2, 3),
+            [b0, b1] => (*b0, *b1, 0, 2),
+            [b0] => (*b0, 0, 0, 1),
+            _ => continue,
+        };
+        let triple = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+        out.push(symbol(triple >> 18));
+        out.push(symbol(triple >> 12));
+        out.push(if len > 1 { symbol(triple >> 6) } else { '=' });
+        out.push(if len > 2 { symbol(triple) } else { '=' });
+    }
+    out
+}
+
+/// Encodes bytes as base64 wrapped to 76-character lines, each line — including the last —
+/// terminated by a newline. This is the line-broken form a notebook stores binary payloads in. Empty
+/// input yields an empty string (no lone newline).
+#[must_use]
+pub fn encode_mime(data: &[u8]) -> String {
+    if data.is_empty() {
+        return String::new();
+    }
+    let raw = encode(data);
+    let mut out = String::with_capacity(raw.len() + raw.len() / LINE_WIDTH + 1);
+    for (index, byte) in raw.bytes().enumerate() {
+        if index != 0 && index % LINE_WIDTH == 0 {
+            out.push('\n');
+        }
+        out.push(byte as char);
+    }
+    out.push('\n');
+    out
+}
+
+/// Decodes standard base64, ignoring inner whitespace. Returns `None` when the input — once
+/// whitespace is removed — is not well-formed: a length that is not a multiple of four, a symbol
+/// outside the alphabet, or padding that does not fall at the very end of the final quartet.
+#[must_use]
+pub fn decode(input: &str) -> Option<Vec<u8>> {
+    let symbols: Vec<u8> = input
+        .bytes()
+        .filter(|byte| !byte.is_ascii_whitespace())
+        .collect();
+    if symbols.is_empty() {
+        return Some(Vec::new());
+    }
+    if !symbols.len().is_multiple_of(4) {
+        return None;
+    }
+    let group_count = symbols.len() / 4;
+    let mut out = Vec::with_capacity(group_count * 3);
+    for (index, chunk) in symbols.chunks_exact(4).enumerate() {
+        let last = index + 1 == group_count;
+        let &[a, b, c, d] = chunk else { return None };
+        let v0 = sextet(a)?;
+        let v1 = sextet(b)?;
+        out.push((v0 << 2) | (v1 >> 4));
+        if c == b'=' {
+            if !last || d != b'=' {
+                return None;
+            }
+            continue;
+        }
+        let v2 = sextet(c)?;
+        out.push(((v1 & 0x0f) << 4) | (v2 >> 2));
+        if d == b'=' {
+            if !last {
+                return None;
+            }
+            continue;
+        }
+        let v3 = sextet(d)?;
+        out.push(((v2 & 0x03) << 6) | v3);
+    }
+    Some(out)
+}
+
+/// The 6-bit value of one standard base64 alphabet symbol, or `None` for any other byte.
+fn sextet(byte: u8) -> Option<u8> {
+    match byte {
+        b'A'..=b'Z' => Some(byte - b'A'),
+        b'a'..=b'z' => Some(byte - b'a' + 26),
+        b'0'..=b'9' => Some(byte - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode, encode, encode_mime};
+
+    #[test]
+    fn decodes_and_ignores_whitespace() {
+        assert_eq!(decode("aGVsbG8="), Some(b"hello".to_vec()));
+        assert_eq!(decode("aGVs\nbG8="), Some(b"hello".to_vec()));
+        assert_eq!(decode(""), Some(Vec::new()));
+        // A length that is not a multiple of four, a non-alphabet byte, and misplaced padding each
+        // fail to decode rather than silently dropping or truncating input.
+        assert_eq!(decode("QQ"), None);
+        assert_eq!(decode("aGVsbG8@"), None);
+        assert_eq!(decode("a=VsbG8="), None);
+    }
+
+    #[test]
+    fn encodes_with_padding() {
+        assert_eq!(encode(b""), "");
+        assert_eq!(encode(b"f"), "Zg==");
+        assert_eq!(encode(b"fo"), "Zm8=");
+        assert_eq!(encode(b"foo"), "Zm9v");
+        assert_eq!(encode(b"hello"), "aGVsbG8=");
+    }
+
+    #[test]
+    fn encode_decode_round_trips_all_byte_values() {
+        let data: Vec<u8> = (0..=255).collect();
+        assert_eq!(decode(&encode(&data)), Some(data));
+    }
+
+    #[test]
+    fn mime_form_wraps_at_76_with_trailing_newline() {
+        // 300 bytes -> 400 base64 chars -> five 76-char lines plus a 20-char line, each newline-ended.
+        let data: Vec<u8> = (0..300).map(|index| (index % 251) as u8).collect();
+        let wrapped = encode_mime(&data);
+        let lines: Vec<&str> = wrapped.split('\n').collect();
+        // A trailing newline means split leaves an empty final element.
+        assert_eq!(lines.last(), Some(&""));
+        assert_eq!(lines.len(), 7);
+        assert!(lines[..5].iter().all(|line| line.len() == 76));
+        assert_eq!(lines[5].len(), 20);
+        // The concatenation of the lines decodes back to the input.
+        assert_eq!(decode(&wrapped), Some(data));
+    }
+
+    #[test]
+    fn mime_form_of_empty_is_empty() {
+        assert_eq!(encode_mime(b""), "");
+    }
+}

--- a/crates/carta-core/src/media/mod.rs
+++ b/crates/carta-core/src/media/mod.rs
@@ -15,6 +15,8 @@ pub use base64::{
 };
 pub use sha1::hex as sha1_hex;
 
+use crate::walk;
+use carta_ast::Block;
 use std::collections::BTreeMap;
 
 /// One entry in a [`MediaBag`]: a resource's bytes together with its MIME type, when the source
@@ -109,9 +111,32 @@ pub fn content_addressed_name(mime: &str, bytes: &[u8]) -> String {
     format!("{}.{}", sha1_hex(bytes), extension_for_mime(mime))
 }
 
+/// The path a resource named `name` occupies when a document's media is extracted under `dir`: the
+/// directory and the name joined with `/`. A reference rewritten to this path resolves to the file
+/// the extraction writes out.
+#[must_use]
+pub fn extracted_path(dir: &str, name: &str) -> String {
+    format!("{}/{}", dir.trim_end_matches('/'), name)
+}
+
+/// Rewrites every image reference in `blocks` that names an entry of `media` to the path it occupies
+/// once extracted under `dir` (see [`extracted_path`]), turning an embedded resource into an external
+/// file reference. A reference to anything the bag does not hold is left untouched.
+pub fn rewrite_extracted_references(blocks: &mut [Block], media: &MediaBag, dir: &str) {
+    walk::for_each_image_target(blocks, &mut |target| {
+        if media.contains(target.url.as_str()) {
+            target.url = extracted_path(dir, target.url.as_str()).into();
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{MediaBag, content_addressed_name, extension_for_mime};
+    use super::{
+        MediaBag, content_addressed_name, extension_for_mime, extracted_path,
+        rewrite_extracted_references,
+    };
+    use carta_ast::{Block, Inline, Target};
 
     #[test]
     fn extension_falls_back_to_subtype_without_suffix() {
@@ -128,7 +153,7 @@ mod tests {
     fn content_addressed_name_is_stable_for_equal_bytes() {
         let name = content_addressed_name("image/png", b"the same bytes");
         assert_eq!(name, content_addressed_name("image/png", b"the same bytes"));
-        assert!(name.ends_with(".png"));
+        assert_eq!(name.rsplit('.').next(), Some("png"));
         assert_eq!(name.len(), 40 + 1 + 3);
     }
 
@@ -145,6 +170,49 @@ mod tests {
             bag.get("a.png").map(|item| item.bytes.clone()),
             Some(vec![2])
         );
+    }
+
+    #[test]
+    fn extracted_path_joins_with_a_single_slash() {
+        assert_eq!(extracted_path("media", "a.png"), "media/a.png");
+        assert_eq!(extracted_path("assets/img", "a.png"), "assets/img/a.png");
+        // A trailing slash on the directory does not double up.
+        assert_eq!(extracted_path("media/", "a.png"), "media/a.png");
+    }
+
+    #[test]
+    fn rewrite_points_bag_references_at_their_extracted_paths() {
+        let mut bag = MediaBag::new();
+        bag.insert("a.png", Some("image/png".to_owned()), vec![1]);
+        let mut blocks = vec![
+            Block::Para(vec![image("a.png")]),
+            // A reference the bag does not hold is left as it is.
+            Block::Para(vec![image("https://example.com/b.png")]),
+        ];
+        rewrite_extracted_references(&mut blocks, &bag, "media");
+        let urls: Vec<&str> = blocks.iter().map(image_url).collect();
+        assert_eq!(urls, ["media/a.png", "https://example.com/b.png"]);
+    }
+
+    fn image(url: &str) -> Inline {
+        Inline::Image(
+            Box::default(),
+            Vec::new(),
+            Box::new(Target {
+                url: url.into(),
+                title: carta_ast::Text::default(),
+            }),
+        )
+    }
+
+    fn image_url(block: &Block) -> &str {
+        let Block::Para(inlines) = block else {
+            panic!("expected para");
+        };
+        let Some(Inline::Image(_, _, target)) = inlines.first() else {
+            panic!("expected image");
+        };
+        target.url.as_str()
     }
 
     #[test]

--- a/crates/carta-core/src/media/mod.rs
+++ b/crates/carta-core/src/media/mod.rs
@@ -1,0 +1,160 @@
+//! The media bag: a document's embedded resources — images and other binary payloads — carried
+//! alongside the syntax tree rather than inside it.
+//!
+//! A container format (a notebook today; a word-processor or e-book package later) references its
+//! resources by name while storing their bytes out of band. Keeping those bytes out of the syntax
+//! tree mirrors that split: a reader fills a [`MediaBag`] as it decodes, a writer consumes it to
+//! re-embed the bytes, and the extract step writes them out as files and rewrites the references to
+//! point at them. The tree stays a pure model of structure; the bytes travel next to it.
+
+mod base64;
+mod sha1;
+
+pub use base64::{
+    decode as base64_decode, encode as base64_encode, encode_mime as base64_encode_mime,
+};
+pub use sha1::hex as sha1_hex;
+
+use std::collections::BTreeMap;
+
+/// One entry in a [`MediaBag`]: a resource's bytes together with its MIME type, when the source
+/// recorded one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaItem {
+    /// The resource's MIME type, when known.
+    pub mime: Option<String>,
+    /// The resource's raw bytes.
+    pub bytes: Vec<u8>,
+}
+
+/// A document's embedded resources, keyed by the name the document references each one under.
+///
+/// Entries are held in sorted order, so iteration — and any file extraction or re-embedding derived
+/// from it — is byte-reproducible across runs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MediaBag {
+    items: BTreeMap<String, MediaItem>,
+}
+
+impl MediaBag {
+    /// An empty bag.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records `bytes` under `name`, replacing any existing entry with that name.
+    pub fn insert(&mut self, name: impl Into<String>, mime: Option<String>, bytes: Vec<u8>) {
+        self.items.insert(name.into(), MediaItem { mime, bytes });
+    }
+
+    /// The entry recorded under `name`, if any.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&MediaItem> {
+        self.items.get(name)
+    }
+
+    /// Whether an entry is recorded under `name`.
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        self.items.contains_key(name)
+    }
+
+    /// The entries in name order, as `(name, item)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &MediaItem)> {
+        self.items.iter().map(|(name, item)| (name.as_str(), item))
+    }
+
+    /// The name of every entry, in sorted order.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.items.keys().map(String::as_str)
+    }
+
+    /// The number of entries.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Whether the bag holds no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+/// The conventional file extension (without a leading dot) for an image-like MIME type. An
+/// unrecognized type falls back to its subtype with any structured-syntax suffix removed, so
+/// `image/svg+xml` yields `svg`.
+#[must_use]
+pub fn extension_for_mime(mime: &str) -> &str {
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/svg+xml" => "svg",
+        "application/pdf" => "pdf",
+        other => other
+            .rsplit('/')
+            .next()
+            .and_then(|subtype| subtype.split('+').next())
+            .unwrap_or(other),
+    }
+}
+
+/// A content-addressed name for a resource: the SHA-1 of its bytes, then a dot, then the extension
+/// its MIME type implies. Identical bytes therefore always resolve to the same name.
+#[must_use]
+pub fn content_addressed_name(mime: &str, bytes: &[u8]) -> String {
+    format!("{}.{}", sha1_hex(bytes), extension_for_mime(mime))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MediaBag, content_addressed_name, extension_for_mime};
+
+    #[test]
+    fn extension_falls_back_to_subtype_without_suffix() {
+        assert_eq!(extension_for_mime("image/png"), "png");
+        assert_eq!(extension_for_mime("image/jpeg"), "jpg");
+        assert_eq!(extension_for_mime("image/svg+xml"), "svg");
+        assert_eq!(extension_for_mime("application/pdf"), "pdf");
+        assert_eq!(extension_for_mime("image/webp"), "webp");
+        // The structured-syntax suffix is dropped just as it is for svg+xml.
+        assert_eq!(extension_for_mime("application/geo+json"), "geo");
+    }
+
+    #[test]
+    fn content_addressed_name_is_stable_for_equal_bytes() {
+        let name = content_addressed_name("image/png", b"the same bytes");
+        assert_eq!(name, content_addressed_name("image/png", b"the same bytes"));
+        assert!(name.ends_with(".png"));
+        assert_eq!(name.len(), 40 + 1 + 3);
+    }
+
+    #[test]
+    fn bag_keeps_entries_in_name_order() {
+        let mut bag = MediaBag::new();
+        bag.insert("z.png", Some("image/png".to_owned()), vec![1]);
+        bag.insert("a.png", None, vec![2]);
+        let names: Vec<&str> = bag.names().collect();
+        assert_eq!(names, ["a.png", "z.png"]);
+        assert_eq!(bag.len(), 2);
+        assert!(bag.contains("a.png"));
+        assert_eq!(
+            bag.get("a.png").map(|item| item.bytes.clone()),
+            Some(vec![2])
+        );
+    }
+
+    #[test]
+    fn insert_replaces_an_existing_name() {
+        let mut bag = MediaBag::new();
+        bag.insert("x", None, vec![1]);
+        bag.insert("x", Some("image/png".to_owned()), vec![2, 3]);
+        assert_eq!(bag.len(), 1);
+        let item = bag.get("x").expect("entry present");
+        assert_eq!(item.bytes, vec![2, 3]);
+        assert_eq!(item.mime.as_deref(), Some("image/png"));
+    }
+}

--- a/crates/carta-core/src/media/sha1.rs
+++ b/crates/carta-core/src/media/sha1.rs
@@ -1,0 +1,88 @@
+//! SHA-1 digest, used to give an embedded resource a content-addressed name.
+
+/// The SHA-1 digest of `data` as a 40-character lowercase hex string.
+#[allow(
+    clippy::indexing_slicing,
+    clippy::cast_possible_truncation,
+    clippy::many_single_char_names,
+    reason = "the schedule and chunk indices are bounded by the fixed 80-word/64-byte block sizes; \
+              the casts isolate the intended low bits; the single-letter names are the digest's own \
+              working-variable notation"
+)]
+#[must_use]
+pub fn hex(data: &[u8]) -> String {
+    const HEX: [u8; 16] = *b"0123456789abcdef";
+    let mut h: [u32; 5] = [
+        0x6745_2301,
+        0xEFCD_AB89,
+        0x98BA_DCFE,
+        0x1032_5476,
+        0xC3D2_E1F0,
+    ];
+    let bit_len = (data.len() as u64).wrapping_mul(8);
+    let mut message = data.to_vec();
+    message.push(0x80);
+    while message.len() % 64 != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+
+    for block in message.chunks_exact(64) {
+        let mut w = [0u32; 80];
+        for (index, word) in block.chunks_exact(4).enumerate() {
+            w[index] = u32::from_be_bytes(word.try_into().unwrap_or([0; 4]));
+        }
+        for index in 16..80 {
+            w[index] = (w[index - 3] ^ w[index - 8] ^ w[index - 14] ^ w[index - 16]).rotate_left(1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e] = h;
+        for (index, &word) in w.iter().enumerate() {
+            let (f, k) = match index {
+                0..=19 => ((b & c) | ((!b) & d), 0x5A82_7999u32),
+                20..=39 => (b ^ c ^ d, 0x6ED9_EBA1),
+                40..=59 => ((b & c) | (b & d) | (c & d), 0x8F1B_BCDC),
+                _ => (b ^ c ^ d, 0xCA62_C1D6),
+            };
+            let temp = a
+                .rotate_left(5)
+                .wrapping_add(f)
+                .wrapping_add(e)
+                .wrapping_add(k)
+                .wrapping_add(word);
+            e = d;
+            d = c;
+            c = b.rotate_left(30);
+            b = a;
+            a = temp;
+        }
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+    }
+
+    let mut out = String::with_capacity(40);
+    for word in h {
+        for byte in word.to_be_bytes() {
+            out.push(HEX[usize::from(byte >> 4)] as char);
+            out.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hex;
+
+    #[test]
+    fn matches_known_vectors() {
+        assert_eq!(hex(b""), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+        assert_eq!(hex(b"abc"), "a9993e364706816aba3e25717850c26c9cd0d89d");
+        assert_eq!(
+            hex(b"The quick brown fox jumps over the lazy dog"),
+            "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+        );
+    }
+}

--- a/crates/carta-core/src/walk.rs
+++ b/crates/carta-core/src/walk.rs
@@ -132,7 +132,7 @@ mod tests {
             Block::Para(vec![image("a")]),
             Block::BulletList(vec![vec![Block::Plain(vec![image("b")])]]),
             Block::BlockQuote(vec![Block::Div(
-                Box::new(Attr::default()),
+                Box::<Attr>::default(),
                 vec![Block::Para(vec![Inline::Note(vec![Block::Para(vec![
                     image("c"),
                 ])])])],
@@ -145,10 +145,10 @@ mod tests {
         });
         assert_eq!(seen, ["a", "b", "c"]);
         // The mutation is threaded back into the tree.
-        let Block::Para(inlines) = &blocks[0] else {
+        let Some(Block::Para(inlines)) = blocks.first() else {
             panic!("expected para");
         };
-        let Inline::Image(_, _, target) = &inlines[0] else {
+        let Some(Inline::Image(_, _, target)) = inlines.first() else {
             panic!("expected image");
         };
         assert_eq!(target.url.as_str(), "seen:a");

--- a/crates/carta-core/src/walk.rs
+++ b/crates/carta-core/src/walk.rs
@@ -1,0 +1,156 @@
+//! Mutable traversals over the document model.
+//!
+//! [`for_each_image_target`] visits every image target in a block sequence, descending through all
+//! nested inline and block content in document order. Rewriting a container format's inline resource
+//! references — a notebook's `attachment:` links on the way in, its file names on the way out, and an
+//! extraction step's on-disk paths — is the same walk with a different callback, so the traversal
+//! lives here once rather than in each reader and writer.
+
+use carta_ast::{Block, Caption, Inline, Table, Target};
+
+/// Applies `visit` to every image target throughout `blocks`, descending into every nested inline and
+/// block sequence — list items, table cells, notes, captions, and the rest — in document order.
+pub fn for_each_image_target(blocks: &mut [Block], visit: &mut dyn FnMut(&mut Target)) {
+    for block in blocks {
+        visit_block(block, visit);
+    }
+}
+
+fn visit_block(block: &mut Block, visit: &mut dyn FnMut(&mut Target)) {
+    match block {
+        Block::Plain(inlines) | Block::Para(inlines) | Block::Header(_, _, inlines) => {
+            visit_inlines(inlines, visit);
+        }
+        Block::LineBlock(lines) => {
+            for line in lines {
+                visit_inlines(line, visit);
+            }
+        }
+        Block::BlockQuote(inner) | Block::Div(_, inner) => {
+            for_each_image_target(inner, visit);
+        }
+        Block::OrderedList(_, items) | Block::BulletList(items) => {
+            for item in items {
+                for_each_image_target(item, visit);
+            }
+        }
+        Block::DefinitionList(items) => {
+            for (term, definitions) in items {
+                visit_inlines(term, visit);
+                for definition in definitions {
+                    for_each_image_target(definition, visit);
+                }
+            }
+        }
+        Block::Figure(_, caption, inner) => {
+            visit_caption(caption, visit);
+            for_each_image_target(inner, visit);
+        }
+        Block::Table(table) => visit_table(table, visit),
+        Block::CodeBlock(..) | Block::RawBlock(..) | Block::HorizontalRule => {}
+    }
+}
+
+fn visit_table(table: &mut Table, visit: &mut dyn FnMut(&mut Target)) {
+    visit_caption(&mut table.caption, visit);
+    let row_groups = std::iter::once(&mut table.head.rows)
+        .chain(table.bodies.iter_mut().flat_map(|body| {
+            std::iter::once(&mut body.head).chain(std::iter::once(&mut body.body))
+        }))
+        .chain(std::iter::once(&mut table.foot.rows));
+    for rows in row_groups {
+        for row in rows {
+            for cell in &mut row.cells {
+                for_each_image_target(&mut cell.content, visit);
+            }
+        }
+    }
+}
+
+fn visit_caption(caption: &mut Caption, visit: &mut dyn FnMut(&mut Target)) {
+    if let Some(short) = &mut caption.short {
+        visit_inlines(short, visit);
+    }
+    for_each_image_target(&mut caption.long, visit);
+}
+
+fn visit_inlines(inlines: &mut [Inline], visit: &mut dyn FnMut(&mut Target)) {
+    for inline in inlines {
+        match inline {
+            Inline::Image(_, alt, target) => {
+                visit(target);
+                visit_inlines(alt, visit);
+            }
+            Inline::Link(_, children, _)
+            | Inline::Emph(children)
+            | Inline::Underline(children)
+            | Inline::Strong(children)
+            | Inline::Strikeout(children)
+            | Inline::Superscript(children)
+            | Inline::Subscript(children)
+            | Inline::SmallCaps(children)
+            | Inline::Quoted(_, children)
+            | Inline::Span(_, children) => visit_inlines(children, visit),
+            Inline::Cite(citations, children) => {
+                for citation in citations {
+                    visit_inlines(&mut citation.prefix, visit);
+                    visit_inlines(&mut citation.suffix, visit);
+                }
+                visit_inlines(children, visit);
+            }
+            Inline::Note(blocks) => for_each_image_target(blocks, visit),
+            Inline::Str(_)
+            | Inline::Code(..)
+            | Inline::Space
+            | Inline::SoftBreak
+            | Inline::LineBreak
+            | Inline::Math(..)
+            | Inline::RawInline(..) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::for_each_image_target;
+    use carta_ast::{Attr, Block, Inline, Target};
+
+    fn image(url: &str) -> Inline {
+        Inline::Image(
+            Box::default(),
+            Vec::new(),
+            Box::new(Target {
+                url: url.into(),
+                title: carta_ast::Text::default(),
+            }),
+        )
+    }
+
+    #[test]
+    fn visits_images_nested_in_containers() {
+        let mut blocks = vec![
+            Block::Para(vec![image("a")]),
+            Block::BulletList(vec![vec![Block::Plain(vec![image("b")])]]),
+            Block::BlockQuote(vec![Block::Div(
+                Box::new(Attr::default()),
+                vec![Block::Para(vec![Inline::Note(vec![Block::Para(vec![
+                    image("c"),
+                ])])])],
+            )]),
+        ];
+        let mut seen = Vec::new();
+        for_each_image_target(&mut blocks, &mut |target| {
+            seen.push(target.url.to_string());
+            target.url = format!("seen:{}", target.url).into();
+        });
+        assert_eq!(seen, ["a", "b", "c"]);
+        // The mutation is threaded back into the tree.
+        let Block::Para(inlines) = &blocks[0] else {
+            panic!("expected para");
+        };
+        let Inline::Image(_, _, target) = &inlines[0] else {
+            panic!("expected image");
+        };
+        assert_eq!(target.url.as_str(), "seen:a");
+    }
+}

--- a/crates/carta-readers/src/ipynb.rs
+++ b/crates/carta-readers/src/ipynb.rs
@@ -375,7 +375,12 @@ fn markdown_cell_blocks(
         .get("id")
         .map(|id| format!("{}-", id.as_str().unwrap_or_default()));
     capture_attachments(cell, prefix.as_deref(), media);
-    strip_attachment_blocks(&mut blocks, prefix.as_deref());
+    let prefix = prefix.as_deref().unwrap_or_default();
+    carta_core::walk::for_each_image_target(&mut blocks, &mut |target| {
+        if let Some(bare) = target.url.strip_prefix("attachment:") {
+            target.url = format!("{prefix}{bare}").into();
+        }
+    });
     Ok(blocks)
 }
 
@@ -702,111 +707,6 @@ fn strip_ansi(text: &str) -> String {
         }
     }
     out
-}
-
-/// Rewrite `attachment:` image references to their cell-scoped names throughout a block sequence.
-/// `prefix` is the cell's name prefix (`<id>-`), or `None` for a cell without an `id`.
-fn strip_attachment_blocks(blocks: &mut [Block], prefix: Option<&str>) {
-    for block in blocks {
-        match block {
-            Block::Plain(inlines) | Block::Para(inlines) | Block::Header(_, _, inlines) => {
-                strip_attachment_inlines(inlines, prefix);
-            }
-            Block::LineBlock(lines) => {
-                for line in lines {
-                    strip_attachment_inlines(line, prefix);
-                }
-            }
-            Block::BlockQuote(inner) | Block::Div(_, inner) => {
-                strip_attachment_blocks(inner, prefix);
-            }
-            Block::OrderedList(_, items) | Block::BulletList(items) => {
-                for item in items {
-                    strip_attachment_blocks(item, prefix);
-                }
-            }
-            Block::DefinitionList(items) => {
-                for (term, definitions) in items {
-                    strip_attachment_inlines(term, prefix);
-                    for definition in definitions {
-                        strip_attachment_blocks(definition, prefix);
-                    }
-                }
-            }
-            Block::Figure(_, caption, inner) => {
-                strip_attachment_caption(caption, prefix);
-                strip_attachment_blocks(inner, prefix);
-            }
-            Block::Table(table) => strip_attachment_table(table, prefix),
-            Block::CodeBlock(..) | Block::RawBlock(..) | Block::HorizontalRule => {}
-        }
-    }
-}
-
-/// Rewrite `attachment:` image references throughout a table's caption and cells.
-fn strip_attachment_table(table: &mut carta_ast::Table, prefix: Option<&str>) {
-    strip_attachment_caption(&mut table.caption, prefix);
-    let row_groups = std::iter::once(&mut table.head.rows)
-        .chain(table.bodies.iter_mut().flat_map(|body| {
-            std::iter::once(&mut body.head).chain(std::iter::once(&mut body.body))
-        }))
-        .chain(std::iter::once(&mut table.foot.rows));
-    for rows in row_groups {
-        for row in rows {
-            for cell in &mut row.cells {
-                strip_attachment_blocks(&mut cell.content, prefix);
-            }
-        }
-    }
-}
-
-fn strip_attachment_caption(caption: &mut carta_ast::Caption, prefix: Option<&str>) {
-    if let Some(short) = &mut caption.short {
-        strip_attachment_inlines(short, prefix);
-    }
-    strip_attachment_blocks(&mut caption.long, prefix);
-}
-
-/// Rewrite `attachment:` image references to their cell-scoped names throughout an inline sequence.
-fn strip_attachment_inlines(inlines: &mut [Inline], prefix: Option<&str>) {
-    for inline in inlines {
-        match inline {
-            Inline::Image(_, alt, target) => {
-                if let Some(bare) = target.url.strip_prefix("attachment:") {
-                    target.url = match prefix {
-                        Some(prefix) => format!("{prefix}{bare}").into(),
-                        None => bare.into(),
-                    };
-                }
-                strip_attachment_inlines(alt, prefix);
-            }
-            Inline::Emph(children)
-            | Inline::Underline(children)
-            | Inline::Strong(children)
-            | Inline::Strikeout(children)
-            | Inline::Superscript(children)
-            | Inline::Subscript(children)
-            | Inline::SmallCaps(children)
-            | Inline::Quoted(_, children)
-            | Inline::Link(_, children, _)
-            | Inline::Span(_, children) => strip_attachment_inlines(children, prefix),
-            Inline::Cite(citations, children) => {
-                for citation in citations {
-                    strip_attachment_inlines(&mut citation.prefix, prefix);
-                    strip_attachment_inlines(&mut citation.suffix, prefix);
-                }
-                strip_attachment_inlines(children, prefix);
-            }
-            Inline::Note(blocks) => strip_attachment_blocks(blocks, prefix),
-            Inline::Str(_)
-            | Inline::Code(..)
-            | Inline::Space
-            | Inline::SoftBreak
-            | Inline::LineBreak
-            | Inline::Math(..)
-            | Inline::RawInline(..) => {}
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/carta-readers/src/ipynb.rs
+++ b/crates/carta-readers/src/ipynb.rs
@@ -18,16 +18,18 @@
 //!   `raw_mimetype` metadata, falling back to its `format` metadata.
 //!
 //! Notebook-level metadata is exposed under a single `jupyter` metadata key, with the `nbformat`
-//! and `nbformat_minor` versions folded in. Image payloads in the outputs are referenced by a
-//! content-addressed file name (the SHA-1 of the decoded bytes); the bytes themselves are not
-//! retained in the tree.
+//! and `nbformat_minor` versions folded in. An output's image payload is referenced by a
+//! content-addressed file name (the SHA-1 of the decoded bytes) and a markdown cell's attachment by
+//! a cell-scoped name; in both cases the bytes are lifted out of the tree into the media bag, which
+//! [`IpynbReader::read_media`] returns alongside the document.
 
 use std::collections::BTreeMap;
 
 use carta_ast::{
     ApiVersion, Attr, Block, Document, Format, Inline, MetaValue, Target, ToCompactString,
 };
-use carta_core::{Error, Reader, ReaderOptions, Result};
+use carta_core::media::{base64_decode, content_addressed_name};
+use carta_core::{Error, MediaBag, Reader, ReaderOptions, Result};
 use serde_json::Value;
 
 use crate::commonmark::CommonmarkReader;
@@ -38,6 +40,11 @@ pub struct IpynbReader;
 
 impl Reader for IpynbReader {
     fn read(&self, input: &str, options: &ReaderOptions) -> Result<Document> {
+        self.read_media(input, options)
+            .map(|(document, _)| document)
+    }
+
+    fn read_media(&self, input: &str, options: &ReaderOptions) -> Result<(Document, MediaBag)> {
         let notebook: Value = serde_json::from_str(input)?;
         let nbformat = notebook
             .get("nbformat")
@@ -55,19 +62,21 @@ impl Reader for IpynbReader {
         let language = notebook_language(&notebook);
         let meta = build_meta(&notebook, nbformat, nbformat_minor);
 
+        let mut media = MediaBag::new();
         let mut blocks = Vec::new();
         if let Some(Value::Array(cells)) = notebook.get("cells") {
             for cell in cells {
-                if let Some(block) = cell_to_block(cell, &language, options)? {
+                if let Some(block) = cell_to_block(cell, &language, options, &mut media)? {
                     blocks.push(block);
                 }
             }
         }
-        Ok(Document {
+        let document = Document {
             api_version: ApiVersion::default(),
             meta: meta.into_iter().map(|(k, v)| (k.into(), v)).collect(),
             blocks,
-        })
+        };
+        Ok((document, media))
     }
 }
 
@@ -270,15 +279,22 @@ fn json_write(value: &Value, out: &mut String) {
     }
 }
 
-/// Convert one cell into its `Div`, or `None` for an unrecognized cell kind.
-fn cell_to_block(cell: &Value, language: &str, options: &ReaderOptions) -> Result<Option<Block>> {
+/// Convert one cell into its `Div`, or `None` for an unrecognized cell kind. Any image bytes the
+/// cell carries — a code cell's image outputs, a markdown cell's attachments — are lifted into
+/// `media`.
+fn cell_to_block(
+    cell: &Value,
+    language: &str,
+    options: &ReaderOptions,
+    media: &mut MediaBag,
+) -> Result<Option<Block>> {
     let Some(kind) = cell.get("cell_type").and_then(Value::as_str) else {
         return Ok(None);
     };
     let attr = cell_attr(cell, kind);
     let block = match kind {
-        "markdown" => Block::Div(Box::new(attr), markdown_cell_blocks(cell, options)?),
-        "code" => Block::Div(Box::new(attr), code_cell_blocks(cell, language)),
+        "markdown" => Block::Div(Box::new(attr), markdown_cell_blocks(cell, options, media)?),
+        "code" => Block::Div(Box::new(attr), code_cell_blocks(cell, language, media)),
         "raw" => Block::Div(Box::new(attr), vec![raw_cell_block(cell)]),
         _ => return Ok(None),
     };
@@ -340,7 +356,11 @@ fn is_integer_literal(text: &str) -> bool {
 /// A markdown cell's blocks: its source parsed as Markdown with the reader's extensions, then with
 /// `attachment:` image references rewritten to the cell-scoped name `<cell id>-<reference>`. A cell
 /// that carries no `id` field leaves the bare reference in place.
-fn markdown_cell_blocks(cell: &Value, options: &ReaderOptions) -> Result<Vec<Block>> {
+fn markdown_cell_blocks(
+    cell: &Value,
+    options: &ReaderOptions,
+    media: &mut MediaBag,
+) -> Result<Vec<Block>> {
     let source = multiline_text(cell.get("source"));
     let mut markdown_options = ReaderOptions::default();
     markdown_options.extensions = options.extensions;
@@ -354,13 +374,42 @@ fn markdown_cell_blocks(cell: &Value, options: &ReaderOptions) -> Result<Vec<Blo
     let prefix = cell
         .get("id")
         .map(|id| format!("{}-", id.as_str().unwrap_or_default()));
+    capture_attachments(cell, prefix.as_deref(), media);
     strip_attachment_blocks(&mut blocks, prefix.as_deref());
     Ok(blocks)
 }
 
+/// Lift a markdown cell's inline attachments into the media bag. Each entry in the cell's
+/// `attachments` object maps a reference name to a MIME→payload bundle; its bytes are stored under
+/// the cell-scoped name (`<prefix><reference>`) the `attachment:` references resolve to, so a later
+/// extract or re-embed step finds them. The bundle's image representation is preferred; failing that,
+/// its first entry in key order is taken.
+fn capture_attachments(cell: &Value, prefix: Option<&str>, media: &mut MediaBag) {
+    let Some(Value::Object(attachments)) = cell.get("attachments") else {
+        return;
+    };
+    for (reference, bundle) in attachments {
+        let Value::Object(by_mime) = bundle else {
+            continue;
+        };
+        let chosen = by_mime
+            .iter()
+            .find(|(mime, _)| is_image_like(mime))
+            .or_else(|| by_mime.iter().next());
+        let Some((mime, payload)) = chosen else {
+            continue;
+        };
+        let name = match prefix {
+            Some(prefix) => format!("{prefix}{reference}"),
+            None => reference.clone(),
+        };
+        media.insert(name, Some(mime.clone()), decode_payload(mime, payload));
+    }
+}
+
 /// A code cell's blocks: a `CodeBlock` of its source tagged with the kernel language, then one
 /// block per renderable output.
-fn code_cell_blocks(cell: &Value, language: &str) -> Vec<Block> {
+fn code_cell_blocks(cell: &Value, language: &str, media: &mut MediaBag) -> Vec<Block> {
     let source = multiline_text(cell.get("source"));
     let source_attr = Attr {
         id: carta_ast::Text::default(),
@@ -370,7 +419,7 @@ fn code_cell_blocks(cell: &Value, language: &str) -> Vec<Block> {
     let mut blocks = vec![Block::CodeBlock(Box::new(source_attr), source.into())];
     if let Some(Value::Array(outputs)) = cell.get("outputs") {
         for output in outputs {
-            if let Some(block) = output_to_block(output) {
+            if let Some(block) = output_to_block(output, media) {
                 blocks.push(block);
             }
         }
@@ -392,12 +441,13 @@ fn raw_cell_block(cell: &Value) -> Block {
     Block::RawBlock(Format(format.into()), source.into())
 }
 
-/// Convert one execution output into its `Div`, or `None` for an unrecognized output kind.
-fn output_to_block(output: &Value) -> Option<Block> {
+/// Convert one execution output into its `Div`, or `None` for an unrecognized output kind. An image
+/// output's bytes are lifted into `media`.
+fn output_to_block(output: &Value, media: &mut MediaBag) -> Option<Block> {
     match output.get("output_type").and_then(Value::as_str)? {
         "stream" => Some(stream_output(output)),
-        "execute_result" => Some(result_output(output, true)),
-        "display_data" => Some(result_output(output, false)),
+        "execute_result" => Some(result_output(output, true, media)),
+        "display_data" => Some(result_output(output, false, media)),
         "error" => Some(error_output(output)),
         _ => None,
     }
@@ -424,7 +474,7 @@ fn stream_output(output: &Value) -> Block {
 
 /// An `execute_result` or `display_data` output: the richest renderable bundle from its `data`,
 /// inside a `Div`. A result carries its `execution_count` as an attribute.
-fn result_output(output: &Value, is_result: bool) -> Block {
+fn result_output(output: &Value, is_result: bool, media: &mut MediaBag) -> Block {
     let kind = if is_result {
         "execute_result"
     } else {
@@ -444,7 +494,7 @@ fn result_output(output: &Value, is_result: bool) -> Block {
     };
     Block::Div(
         Box::new(attr),
-        data_to_blocks(output.get("data"), output.get("metadata")),
+        data_to_blocks(output.get("data"), output.get("metadata"), media),
     )
 }
 
@@ -495,12 +545,16 @@ fn error_output(output: &Value) -> Block {
 /// any `+json` structured-syntax type — then plain text, HTML, LaTeX, and Markdown are tried in that
 /// order. Among several JSON representations the lowest MIME name is taken. An empty or absent bundle
 /// yields no blocks.
-fn data_to_blocks(data: Option<&Value>, metadata: Option<&Value>) -> Vec<Block> {
+fn data_to_blocks(
+    data: Option<&Value>,
+    metadata: Option<&Value>,
+    media: &mut MediaBag,
+) -> Vec<Block> {
     let Some(Value::Object(data)) = data else {
         return Vec::new();
     };
     if let Some((mime, value)) = data.iter().find(|(mime, _)| is_image_like(mime)) {
-        return vec![image_block(mime, value, metadata)];
+        return vec![image_block(mime, value, metadata, media)];
     }
     if let Some((mime, value)) = data.iter().find(|(mime, _)| is_json_like(mime)) {
         return vec![non_image_block(mime, value)];
@@ -543,17 +597,12 @@ fn non_image_block(mime: &str, value: &Value) -> Block {
 }
 
 /// A `Para` holding a single image whose URL is the content-addressed file name of the decoded
-/// payload. SVG is stored as its source text; every other type is base64-decoded to bytes, falling
-/// back to the raw source bytes when the payload is not well-formed base64. Any entry the output's
+/// payload, whose bytes are lifted into `media` under that same name. Any entry the output's
 /// `metadata` records under the chosen MIME type becomes an attribute on the image.
-fn image_block(mime: &str, value: &Value, metadata: Option<&Value>) -> Block {
-    let payload = multiline_text(Some(value));
-    let bytes = if mime == "image/svg+xml" {
-        payload.into_bytes()
-    } else {
-        base64_decode(&payload).unwrap_or_else(|| payload.into_bytes())
-    };
-    let name = format!("{}.{}", sha1_hex(&bytes), extension_for_mime(mime));
+fn image_block(mime: &str, value: &Value, metadata: Option<&Value>, media: &mut MediaBag) -> Block {
+    let bytes = decode_payload(mime, value);
+    let name = content_addressed_name(mime, &bytes);
+    media.insert(name.clone(), Some(mime.to_owned()), bytes);
     Block::Para(vec![Inline::Image(
         Box::new(image_attr(mime, metadata)),
         Vec::new(),
@@ -562,6 +611,18 @@ fn image_block(mime: &str, value: &Value, metadata: Option<&Value>) -> Block {
             title: carta_ast::Text::default(),
         }),
     )])
+}
+
+/// The raw bytes of an image payload. An SVG representation is its own UTF-8 source; every other type
+/// is base64-decoded, falling back to the raw source bytes when the payload is not well-formed
+/// base64.
+fn decode_payload(mime: &str, value: &Value) -> Vec<u8> {
+    let payload = multiline_text(Some(value));
+    if mime == "image/svg+xml" {
+        payload.into_bytes()
+    } else {
+        base64_decode(&payload).unwrap_or_else(|| payload.into_bytes())
+    }
 }
 
 /// The image attributes drawn from an output's `metadata`: every key under the entry named for the
@@ -595,23 +656,6 @@ fn is_image_like(mime: &str) -> bool {
 /// structured-syntax suffix is `+json` (for example `application/geo+json`).
 fn is_json_like(mime: &str) -> bool {
     mime == "application/json" || mime.ends_with("+json")
-}
-
-/// The file extension for an image-like MIME type.
-fn extension_for_mime(mime: &str) -> &str {
-    match mime {
-        "image/png" => "png",
-        "image/jpeg" => "jpg",
-        "image/gif" => "gif",
-        "image/svg+xml" => "svg",
-        "application/pdf" => "pdf",
-        // An unrecognized image type falls back to its subtype, dropping any structured suffix.
-        other => other
-            .rsplit('/')
-            .next()
-            .and_then(|subtype| subtype.split('+').next())
-            .unwrap_or(other),
-    }
 }
 
 /// The raw-passthrough format name for a cell's `format` MIME type. A few media types map onto a
@@ -765,134 +809,10 @@ fn strip_attachment_inlines(inlines: &mut [Inline], prefix: Option<&str>) {
     }
 }
 
-/// Decode standard base64, ignoring inner whitespace. Returns `None` when the input — once
-/// whitespace is removed — is not well-formed: a length that is not a multiple of four, a symbol
-/// outside the alphabet, or padding that does not fall at the very end of the final quartet.
-fn base64_decode(input: &str) -> Option<Vec<u8>> {
-    let symbols: Vec<u8> = input
-        .bytes()
-        .filter(|byte| !byte.is_ascii_whitespace())
-        .collect();
-    if symbols.is_empty() {
-        return Some(Vec::new());
-    }
-    if !symbols.len().is_multiple_of(4) {
-        return None;
-    }
-    let group_count = symbols.len() / 4;
-    let mut out = Vec::with_capacity(group_count * 3);
-    for (index, chunk) in symbols.chunks_exact(4).enumerate() {
-        let last = index + 1 == group_count;
-        let &[a, b, c, d] = chunk else { return None };
-        let v0 = sextet(a)?;
-        let v1 = sextet(b)?;
-        out.push((v0 << 2) | (v1 >> 4));
-        if c == b'=' {
-            if !last || d != b'=' {
-                return None;
-            }
-            continue;
-        }
-        let v2 = sextet(c)?;
-        out.push(((v1 & 0x0f) << 4) | (v2 >> 2));
-        if d == b'=' {
-            if !last {
-                return None;
-            }
-            continue;
-        }
-        let v3 = sextet(d)?;
-        out.push(((v2 & 0x03) << 6) | v3);
-    }
-    Some(out)
-}
-
-/// The 6-bit value of one standard base64 alphabet symbol, or `None` for any other byte.
-fn sextet(byte: u8) -> Option<u8> {
-    match byte {
-        b'A'..=b'Z' => Some(byte - b'A'),
-        b'a'..=b'z' => Some(byte - b'a' + 26),
-        b'0'..=b'9' => Some(byte - b'0' + 52),
-        b'+' => Some(62),
-        b'/' => Some(63),
-        _ => None,
-    }
-}
-
-/// The SHA-1 digest of `data` as a 40-character lowercase hex string.
-#[allow(
-    clippy::indexing_slicing,
-    clippy::cast_possible_truncation,
-    clippy::many_single_char_names,
-    reason = "the schedule and chunk indices are bounded by the fixed 80-word/64-byte block sizes; \
-              the casts isolate the intended low bits; the single-letter names are the digest's own \
-              working-variable notation"
-)]
-fn sha1_hex(data: &[u8]) -> String {
-    const HEX: [u8; 16] = *b"0123456789abcdef";
-    let mut h: [u32; 5] = [
-        0x6745_2301,
-        0xEFCD_AB89,
-        0x98BA_DCFE,
-        0x1032_5476,
-        0xC3D2_E1F0,
-    ];
-    let bit_len = (data.len() as u64).wrapping_mul(8);
-    let mut message = data.to_vec();
-    message.push(0x80);
-    while message.len() % 64 != 56 {
-        message.push(0);
-    }
-    message.extend_from_slice(&bit_len.to_be_bytes());
-
-    for block in message.chunks_exact(64) {
-        let mut w = [0u32; 80];
-        for (index, word) in block.chunks_exact(4).enumerate() {
-            w[index] = u32::from_be_bytes(word.try_into().unwrap_or([0; 4]));
-        }
-        for index in 16..80 {
-            w[index] = (w[index - 3] ^ w[index - 8] ^ w[index - 14] ^ w[index - 16]).rotate_left(1);
-        }
-        let [mut a, mut b, mut c, mut d, mut e] = h;
-        for (index, &word) in w.iter().enumerate() {
-            let (f, k) = match index {
-                0..=19 => ((b & c) | ((!b) & d), 0x5A82_7999u32),
-                20..=39 => (b ^ c ^ d, 0x6ED9_EBA1),
-                40..=59 => ((b & c) | (b & d) | (c & d), 0x8F1B_BCDC),
-                _ => (b ^ c ^ d, 0xCA62_C1D6),
-            };
-            let temp = a
-                .rotate_left(5)
-                .wrapping_add(f)
-                .wrapping_add(e)
-                .wrapping_add(k)
-                .wrapping_add(word);
-            e = d;
-            d = c;
-            c = b.rotate_left(30);
-            b = a;
-            a = temp;
-        }
-        h[0] = h[0].wrapping_add(a);
-        h[1] = h[1].wrapping_add(b);
-        h[2] = h[2].wrapping_add(c);
-        h[3] = h[3].wrapping_add(d);
-        h[4] = h[4].wrapping_add(e);
-    }
-
-    let mut out = String::with_capacity(40);
-    for word in h {
-        for byte in word.to_be_bytes() {
-            out.push(HEX[usize::from(byte >> 4)] as char);
-            out.push(HEX[usize::from(byte & 0x0f)] as char);
-        }
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use carta_core::MediaBag;
 
     fn read(input: &str) -> Document {
         IpynbReader
@@ -906,33 +826,17 @@ mod tests {
         IpynbReader.read(input, &options).expect("notebook parses")
     }
 
+    fn read_media(input: &str) -> (Document, MediaBag) {
+        IpynbReader
+            .read_media(input, &ReaderOptions::default())
+            .expect("notebook input parses")
+    }
+
     fn jupyter(document: &Document) -> &BTreeMap<carta_ast::Text, MetaValue> {
         match document.meta.get("jupyter") {
             Some(MetaValue::MetaMap(map)) => map,
             _ => panic!("expected a jupyter metadata map"),
         }
-    }
-
-    #[test]
-    fn sha1_matches_known_vectors() {
-        assert_eq!(sha1_hex(b""), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
-        assert_eq!(sha1_hex(b"abc"), "a9993e364706816aba3e25717850c26c9cd0d89d");
-        assert_eq!(
-            sha1_hex(b"The quick brown fox jumps over the lazy dog"),
-            "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
-        );
-    }
-
-    #[test]
-    fn base64_decodes_and_ignores_whitespace() {
-        assert_eq!(base64_decode("aGVsbG8="), Some(b"hello".to_vec()));
-        assert_eq!(base64_decode("aGVs\nbG8="), Some(b"hello".to_vec()));
-        assert_eq!(base64_decode(""), Some(Vec::new()));
-        // A length that is not a multiple of four, a non-alphabet byte, and misplaced padding each
-        // fail to decode rather than silently dropping or truncating input.
-        assert_eq!(base64_decode("QQ"), None);
-        assert_eq!(base64_decode("aGVsbG8@"), None);
-        assert_eq!(base64_decode("a=VsbG8="), None);
     }
 
     #[test]
@@ -1210,6 +1114,95 @@ mod tests {
             panic!("expected an image");
         };
         assert_eq!(target.url, "1c3ba3b813e1080e9721846f23a21c09e5c3fd27.svg");
+    }
+
+    #[test]
+    fn image_output_bytes_are_lifted_into_the_media_bag() {
+        let (document, media) = read_media(
+            r#"{"cells": [{"cell_type": "code", "metadata": {}, "execution_count": 1,
+               "source": [], "outputs": [
+                 {"output_type": "display_data", "data": {"image/png": "iVBORw0KGgoAAAANSUhEUg=="},
+                  "metadata": {}}]}],
+               "metadata": {}, "nbformat": 4, "nbformat_minor": 5}"#,
+        );
+        // The tree references the image by its content-addressed name...
+        let Some(Block::Div(_, body)) = first_output(&document) else {
+            panic!("expected an output div");
+        };
+        let Some(Block::Para(inlines)) = body.first() else {
+            panic!("expected a paragraph");
+        };
+        let Some(Inline::Image(_, _, target)) = inlines.first() else {
+            panic!("expected an image");
+        };
+        let name = "22f545ac6b50163ce39bac49094c3f64e0858403.png";
+        assert_eq!(target.url, name);
+        // ...and the bag holds exactly that name, with the decoded bytes and their MIME type.
+        assert_eq!(media.len(), 1);
+        let item = media.get(name).expect("image is in the bag");
+        assert_eq!(item.mime.as_deref(), Some("image/png"));
+        assert_eq!(
+            item.bytes,
+            carta_core::media::base64_decode("iVBORw0KGgoAAAANSUhEUg==").unwrap()
+        );
+    }
+
+    #[test]
+    fn svg_output_is_stored_as_its_source_bytes() {
+        let (_, media) = read_media(
+            r#"{"cells": [{"cell_type": "code", "metadata": {}, "execution_count": 1,
+               "source": [], "outputs": [
+                 {"output_type": "display_data", "data": {"image/svg+xml": ["<svg/>"]},
+                  "metadata": {}}]}],
+               "metadata": {}, "nbformat": 4, "nbformat_minor": 5}"#,
+        );
+        let name = "1c3ba3b813e1080e9721846f23a21c09e5c3fd27.svg";
+        let item = media.get(name).expect("svg is in the bag");
+        assert_eq!(item.mime.as_deref(), Some("image/svg+xml"));
+        assert_eq!(item.bytes, b"<svg/>");
+    }
+
+    #[test]
+    fn identical_image_outputs_share_one_bag_entry() {
+        let (_, media) = read_media(
+            r#"{"cells": [{"cell_type": "code", "metadata": {}, "execution_count": 1,
+               "source": [], "outputs": [
+                 {"output_type": "display_data", "data": {"image/png": "iVBORw0KGgoAAAANSUhEUg=="},
+                  "metadata": {}},
+                 {"output_type": "display_data", "data": {"image/png": "iVBORw0KGgoAAAANSUhEUg=="},
+                  "metadata": {}}]}],
+               "metadata": {}, "nbformat": 4, "nbformat_minor": 5}"#,
+        );
+        // Content addressing means equal bytes collapse to a single entry.
+        assert_eq!(media.len(), 1);
+    }
+
+    #[test]
+    fn markdown_attachment_bytes_are_lifted_into_the_media_bag() {
+        let (_, media) = read_media(
+            r#"{"cells": [{"cell_type": "markdown", "id": "cell9", "metadata": {},
+               "attachments": {"a.png": {"image/png": "iVBORw0KGgoAAAANSUhEUg=="}},
+               "source": ["![alt](attachment:a.png)"]}],
+               "metadata": {}, "nbformat": 4, "nbformat_minor": 5}"#,
+        );
+        // The attachment is keyed by the same cell-scoped name the image reference resolves to.
+        let item = media.get("cell9-a.png").expect("attachment is in the bag");
+        assert_eq!(item.mime.as_deref(), Some("image/png"));
+        assert_eq!(
+            item.bytes,
+            carta_core::media::base64_decode("iVBORw0KGgoAAAANSUhEUg==").unwrap()
+        );
+    }
+
+    #[test]
+    fn attachment_without_a_cell_id_uses_the_bare_reference() {
+        let (_, media) = read_media(
+            r#"{"cells": [{"cell_type": "markdown", "metadata": {},
+               "attachments": {"a.png": {"image/png": "iVBORw0KGgoAAAANSUhEUg=="}},
+               "source": ["![alt](attachment:a.png)"]}],
+               "metadata": {}, "nbformat": 4, "nbformat_minor": 5}"#,
+        );
+        assert!(media.contains("a.png"));
     }
 
     #[test]

--- a/crates/carta-writers/src/ipynb.rs
+++ b/crates/carta-writers/src/ipynb.rs
@@ -22,7 +22,8 @@ use std::iter::Peekable;
 use std::str::Chars;
 
 use carta_ast::{Attr, Block, Document, Format, Inline, MetaValue, Text, to_plain_text};
-use carta_core::{Error, Extension, Extensions, Result, Writer, WriterOptions};
+use carta_core::media::base64_encode_mime;
+use carta_core::{Error, Extension, Extensions, MediaBag, Result, Writer, WriterOptions};
 
 use crate::markdown::MarkdownWriter;
 
@@ -102,7 +103,7 @@ fn typed_cell(
     counter: &mut usize,
 ) -> Result<Json> {
     if has_class(attr, "code") {
-        code_cell(attr, content, counter)
+        code_cell(attr, content, &options.media, counter)
     } else if has_class(attr, "raw") {
         Ok(raw_cell(attr, content, counter))
     } else {
@@ -110,24 +111,58 @@ fn typed_cell(
     }
 }
 
-/// A markdown cell: its blocks rendered as markdown, with the div's attributes as cell metadata.
+/// A markdown cell: its blocks rendered as markdown, with the div's attributes as cell metadata. An
+/// image whose file name the media bag holds is restored to the cell's inline-attachment form — an
+/// `attachment:` reference and an entry in the cell's `attachments` object.
 fn markdown_cell(
     blocks: &[Block],
     attr: &Attr,
     options: &WriterOptions,
     counter: &mut usize,
 ) -> Result<Json> {
-    let source = render_cell_markdown(blocks, options)?;
+    let mut blocks = blocks.to_vec();
+    let attachments = reattach_media(&mut blocks, &options.media)?;
+    let source = render_cell_markdown(&blocks, options)?;
     let id = next_id(&attr.id, &source, counter);
-    Ok(Json::Object(vec![
+    let mut fields = vec![
         ("cell_type".to_owned(), Json::Str("markdown".to_owned())),
         (
             "metadata".to_owned(),
             attribute_metadata(&attr.attributes, &[]),
         ),
         ("source".to_owned(), source_lines(&source)),
-        ("id".to_owned(), Json::Str(id)),
-    ]))
+    ];
+    if let Some(attachments) = attachments {
+        fields.push(("attachments".to_owned(), attachments));
+    }
+    fields.push(("id".to_owned(), Json::Str(id)));
+    Ok(Json::Object(fields))
+}
+
+/// Rewrites every image in a cell whose file name the bag holds into an `attachment:` reference and
+/// returns the cell's reconstructed `attachments` object, or `None` when the cell draws on no bag
+/// resources. Each attachment is keyed by the image's file name — the reference the rewritten link now
+/// points at — and carries the same MIME→payload bundle an output image would.
+fn reattach_media(blocks: &mut [Block], media: &MediaBag) -> Result<Option<Json>> {
+    let mut names: Vec<String> = Vec::new();
+    carta_core::walk::for_each_image_target(blocks, &mut |target| {
+        let name = target.url.as_str();
+        if media.contains(name) {
+            if !names.iter().any(|seen| seen == name) {
+                names.push(name.to_owned());
+            }
+            target.url = format!("attachment:{name}").into();
+        }
+    });
+    if names.is_empty() {
+        return Ok(None);
+    }
+    let mut entries = Vec::with_capacity(names.len());
+    for name in names {
+        let bundle = Json::Object(vec![image_entry(&name, media)?]);
+        entries.push((name, bundle));
+    }
+    Ok(Some(Json::Object(entries)))
 }
 
 /// A code cell: the first code block's text as source, the execution count lifted out of the
@@ -144,7 +179,12 @@ fn execution_count_json(attr: &Attr) -> Json {
     }
 }
 
-fn code_cell(attr: &Attr, content: &[Block], counter: &mut usize) -> Result<Json> {
+fn code_cell(
+    attr: &Attr,
+    content: &[Block],
+    media: &MediaBag,
+    counter: &mut usize,
+) -> Result<Json> {
     let mut source = String::new();
     let mut found_source = false;
     let mut outputs = Vec::new();
@@ -156,7 +196,7 @@ fn code_cell(attr: &Attr, content: &[Block], counter: &mut usize) -> Result<Json
                 found_source = true;
             }
             Block::Div(output_attr, inner) if has_class(output_attr, "output") => {
-                outputs.push(output_object(output_attr, inner)?);
+                outputs.push(output_object(output_attr, inner, media)?);
             }
             _ => {}
         }
@@ -199,7 +239,7 @@ fn raw_cell(attr: &Attr, content: &[Block], counter: &mut usize) -> Json {
 }
 
 /// Reconstructs an output object from an `output` div. The output kind is the div's second class.
-fn output_object(attr: &Attr, content: &[Block]) -> Result<Json> {
+fn output_object(attr: &Attr, content: &[Block], media: &MediaBag) -> Result<Json> {
     let output = match attr.classes.get(1).map(Text::as_str) {
         Some("stream") => {
             let name = attr
@@ -244,7 +284,7 @@ fn output_object(attr: &Attr, content: &[Block]) -> Result<Json> {
                 ),
                 ("execution_count".to_owned(), execution_count),
                 ("metadata".to_owned(), Json::Object(Vec::new())),
-                ("data".to_owned(), data_bundle(content)?),
+                ("data".to_owned(), data_bundle(content, media)?),
             ])
         }
         _ => Json::Object(vec![
@@ -253,7 +293,7 @@ fn output_object(attr: &Attr, content: &[Block]) -> Result<Json> {
                 Json::Str("display_data".to_owned()),
             ),
             ("metadata".to_owned(), Json::Object(Vec::new())),
-            ("data".to_owned(), data_bundle(content)?),
+            ("data".to_owned(), data_bundle(content, media)?),
         ]),
     };
     Ok(output)
@@ -261,10 +301,10 @@ fn output_object(attr: &Attr, content: &[Block]) -> Result<Json> {
 
 /// The mime bundle of a rich output: each recognized block contributes one mime entry.
 ///
-/// An image output references its payload by file name (the document model carries no embedded
-/// bytes), so it cannot be turned back into the notebook's base64 `data` entry and is reported as
-/// unrepresentable rather than written as a broken bundle.
-fn data_bundle(content: &[Block]) -> Result<Json> {
+/// An image output references its payload by file name; the bytes are drawn from the media bag and
+/// re-embedded under the image's MIME type. An image whose bytes the bag does not hold cannot be
+/// reconstructed and is reported as unrepresentable rather than written as a broken bundle.
+fn data_bundle(content: &[Block], media: &MediaBag) -> Result<Json> {
     let mut entries = Vec::new();
     for block in content {
         match block {
@@ -276,15 +316,36 @@ fn data_bundle(content: &[Block]) -> Result<Json> {
             }
             Block::Para(inlines) | Block::Plain(inlines) => {
                 if let Some(url) = image_url(inlines) {
-                    return Err(Error::Unrepresentable(format!(
-                        "an image output references the file {url:?}, whose data is not embedded in the document"
-                    )));
+                    entries.push(image_entry(url, media)?);
                 }
             }
             _ => {}
         }
     }
     Ok(Json::Object(entries))
+}
+
+/// The `data` entry for an image output: its MIME type mapped to the payload drawn from the media bag
+/// under the image's file name. A textual image (SVG) is written as a source-line array; every other
+/// type is written as a single base64 string wrapped to notebook line width. An image the bag does
+/// not hold — or one carrying no MIME type — cannot be reconstructed and is unrepresentable.
+fn image_entry(url: &str, media: &MediaBag) -> Result<(String, Json)> {
+    let item = media.get(url).ok_or_else(|| {
+        Error::Unrepresentable(format!(
+            "an image output references the file {url:?}, whose bytes are not available"
+        ))
+    })?;
+    let mime = item.mime.clone().ok_or_else(|| {
+        Error::Unrepresentable(format!(
+            "the image output {url:?} carries no MIME type, so its data bundle cannot be rebuilt"
+        ))
+    })?;
+    let data = if mime == "image/svg+xml" {
+        source_lines(&String::from_utf8_lossy(&item.bytes))
+    } else {
+        Json::Str(base64_encode_mime(&item.bytes))
+    };
+    Ok((mime, data))
 }
 
 /// The text of the first code block in a sequence, or empty when there is none.
@@ -870,9 +931,9 @@ mod tests {
         assert!(notebook.contains("\"evalue\": \"bad\""));
     }
 
-    #[test]
-    fn image_output_without_embedded_data_is_unrepresentable() {
-        let document = Document {
+    /// A one-code-cell document whose single `display_data` output is an image referencing `url`.
+    fn image_output_document(url: &str) -> Document {
+        Document {
             blocks: vec![Block::Div(
                 Box::new(Attr {
                     id: String::new().into(),
@@ -894,7 +955,7 @@ mod tests {
                             Box::default(),
                             Vec::new(),
                             Box::new(carta_ast::Target {
-                                url: "plot.png".to_owned().into(),
+                                url: url.to_owned().into(),
                                 title: String::new().into(),
                             }),
                         )])],
@@ -902,7 +963,13 @@ mod tests {
                 ],
             )],
             ..Document::default()
-        };
+        }
+    }
+
+    #[test]
+    fn image_output_without_embedded_data_is_unrepresentable() {
+        // With no media bag, the referenced bytes are unavailable, so the output cannot be rebuilt.
+        let document = image_output_document("plot.png");
         match IpynbWriter.write(&document, &WriterOptions::default()) {
             Err(Error::Unrepresentable(message)) => assert!(
                 message.contains("plot.png"),
@@ -910,6 +977,78 @@ mod tests {
             ),
             other => panic!("expected an unrepresentable error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn image_output_data_is_re_embedded_from_the_media_bag() {
+        let bytes = vec![1u8, 2, 3, 4, 5, 6, 7];
+        let mut bag = MediaBag::new();
+        bag.insert("plot.png", Some("image/png".to_owned()), bytes.clone());
+        let mut options = WriterOptions::default();
+        options.media = std::sync::Arc::new(bag);
+
+        let notebook = IpynbWriter
+            .write(&image_output_document("plot.png"), &options)
+            .expect("the image bytes are available, so the output writes");
+        // The bundle names the image's MIME type and carries the base64 of the bag's bytes.
+        assert!(notebook.contains("\"image/png\""));
+        let encoded = base64_encode_mime(&bytes);
+        assert!(
+            notebook.contains(encoded.trim_end_matches('\n')),
+            "notebook should embed the base64 payload"
+        );
+    }
+
+    #[test]
+    fn svg_output_data_is_re_embedded_as_source_lines() {
+        let mut bag = MediaBag::new();
+        bag.insert(
+            "fig.svg",
+            Some("image/svg+xml".to_owned()),
+            b"<svg/>".to_vec(),
+        );
+        let mut options = WriterOptions::default();
+        options.media = std::sync::Arc::new(bag);
+
+        let notebook = IpynbWriter
+            .write(&image_output_document("fig.svg"), &options)
+            .expect("the svg bytes are available, so the output writes");
+        assert!(notebook.contains("\"image/svg+xml\""));
+        assert!(notebook.contains("<svg/>"));
+    }
+
+    #[test]
+    fn markdown_cell_image_becomes_an_inline_attachment() {
+        let bytes = vec![9u8, 8, 7, 6];
+        let mut bag = MediaBag::new();
+        bag.insert("cell-diagram.png", Some("image/png".to_owned()), bytes);
+        let mut options = WriterOptions::default();
+        options.media = std::sync::Arc::new(bag);
+
+        // A markdown cell whose image references a bag entry by its file name.
+        let document = Document {
+            blocks: vec![Block::Div(
+                Box::new(Attr {
+                    id: "cell".to_owned().into(),
+                    classes: vec!["cell".to_owned().into(), "markdown".to_owned().into()],
+                    attributes: Vec::new(),
+                }),
+                vec![Block::Para(vec![Inline::Image(
+                    Box::default(),
+                    vec![Inline::Str("a diagram".to_owned().into())],
+                    Box::new(carta_ast::Target {
+                        url: "cell-diagram.png".to_owned().into(),
+                        title: String::new().into(),
+                    }),
+                )])],
+            )],
+            ..Document::default()
+        };
+        let notebook = IpynbWriter.write(&document, &options).expect("writes");
+        // The link is rewritten to the attachment form and the payload restored under that name.
+        assert!(notebook.contains("attachment:cell-diagram.png"));
+        assert!(notebook.contains("\"attachments\""));
+        assert!(notebook.contains("\"cell-diagram.png\""));
     }
 
     #[test]

--- a/crates/carta-writers/src/ipynb.rs
+++ b/crates/carta-writers/src/ipynb.rs
@@ -142,7 +142,8 @@ fn markdown_cell(
 /// Rewrites every image in a cell whose file name the bag holds into an `attachment:` reference and
 /// returns the cell's reconstructed `attachments` object, or `None` when the cell draws on no bag
 /// resources. Each attachment is keyed by the image's file name — the reference the rewritten link now
-/// points at — and carries the same MIME→payload bundle an output image would.
+/// points at — and carries the same MIME→payload bundle an output image would. The keys are emitted in
+/// sorted order, independent of where each reference first appears in the cell.
 fn reattach_media(blocks: &mut [Block], media: &MediaBag) -> Result<Option<Json>> {
     let mut names: Vec<String> = Vec::new();
     carta_core::walk::for_each_image_target(blocks, &mut |target| {
@@ -157,6 +158,7 @@ fn reattach_media(blocks: &mut [Block], media: &MediaBag) -> Result<Option<Json>
     if names.is_empty() {
         return Ok(None);
     }
+    names.sort();
     let mut entries = Vec::with_capacity(names.len());
     for name in names {
         let bundle = Json::Object(vec![image_entry(&name, media)?]);
@@ -283,7 +285,7 @@ fn output_object(attr: &Attr, content: &[Block], media: &MediaBag) -> Result<Jso
                     Json::Str("execute_result".to_owned()),
                 ),
                 ("execution_count".to_owned(), execution_count),
-                ("metadata".to_owned(), Json::Object(Vec::new())),
+                ("metadata".to_owned(), output_metadata(content)),
                 ("data".to_owned(), data_bundle(content, media)?),
             ])
         }
@@ -292,7 +294,7 @@ fn output_object(attr: &Attr, content: &[Block], media: &MediaBag) -> Result<Jso
                 "output_type".to_owned(),
                 Json::Str("display_data".to_owned()),
             ),
-            ("metadata".to_owned(), Json::Object(Vec::new())),
+            ("metadata".to_owned(), output_metadata(content)),
             ("data".to_owned(), data_bundle(content, media)?),
         ]),
     };
@@ -358,12 +360,33 @@ fn first_verbatim(content: &[Block]) -> String {
     String::new()
 }
 
-/// The destination of the first image among the inlines, if any.
-fn image_url(inlines: &[Inline]) -> Option<&str> {
+/// The first image inline among the inlines: its attributes and destination.
+fn first_image(inlines: &[Inline]) -> Option<(&Attr, &str)> {
     inlines.iter().find_map(|inline| match inline {
-        Inline::Image(_, _, target) => Some(target.url.as_str()),
+        Inline::Image(attr, _, target) => Some((attr.as_ref(), target.url.as_str())),
         _ => None,
     })
+}
+
+/// The destination of the first image among the inlines, if any.
+fn image_url(inlines: &[Inline]) -> Option<&str> {
+    first_image(inlines).map(|(_, url)| url)
+}
+
+/// The metadata object of a rich output, reconstructed from its image payload. An image output's
+/// per-MIME display metadata (dimensions, background hint) is carried on the image's attributes;
+/// this restores it as the output's own metadata, sorted by key. An output with no image, or an
+/// image bearing no such attributes, has empty metadata.
+fn output_metadata(content: &[Block]) -> Json {
+    for block in content {
+        if let Block::Para(inlines) | Block::Plain(inlines) = block
+            && let Some((attr, _)) = first_image(inlines)
+            && !attr.attributes.is_empty()
+        {
+            return attribute_metadata(&attr.attributes, &[]);
+        }
+    }
+    Json::Object(Vec::new())
 }
 
 /// Builds cell metadata from a div's key/value attributes, skipping the named keys. Each value is
@@ -1049,6 +1072,126 @@ mod tests {
         assert!(notebook.contains("attachment:cell-diagram.png"));
         assert!(notebook.contains("\"attachments\""));
         assert!(notebook.contains("\"cell-diagram.png\""));
+    }
+
+    #[test]
+    fn image_output_metadata_is_restored_sorted_and_typed() {
+        // An image output's display metadata rides on the image's attributes; the writer restores it
+        // as the output's own metadata object, keys sorted, numbers and strings typed as given.
+        let bytes = vec![1u8, 2, 3, 4];
+        let mut bag = MediaBag::new();
+        bag.insert("plot.png", Some("image/png".to_owned()), bytes);
+        let mut options = WriterOptions::default();
+        options.media = std::sync::Arc::new(bag);
+
+        let image = Inline::Image(
+            Box::new(Attr {
+                id: String::new().into(),
+                classes: Vec::new(),
+                attributes: vec![
+                    ("width".to_owned().into(), "320".to_owned().into()),
+                    ("height".to_owned().into(), "240".to_owned().into()),
+                    (
+                        "needs_background".to_owned().into(),
+                        "light".to_owned().into(),
+                    ),
+                ],
+            }),
+            Vec::new(),
+            Box::new(carta_ast::Target {
+                url: "plot.png".to_owned().into(),
+                title: String::new().into(),
+            }),
+        );
+        let document = Document {
+            blocks: vec![Block::Div(
+                Box::new(Attr {
+                    id: String::new().into(),
+                    classes: vec!["cell".to_owned().into(), "code".to_owned().into()],
+                    attributes: Vec::new(),
+                }),
+                vec![
+                    Block::CodeBlock(Box::default(), "plot()".to_owned().into()),
+                    Block::Div(
+                        Box::new(Attr {
+                            id: String::new().into(),
+                            classes: vec![
+                                "output".to_owned().into(),
+                                "display_data".to_owned().into(),
+                            ],
+                            attributes: Vec::new(),
+                        }),
+                        vec![Block::Para(vec![image])],
+                    ),
+                ],
+            )],
+            ..Document::default()
+        };
+
+        let notebook = IpynbWriter.write(&document, &options).expect("writes");
+        assert!(notebook.contains("\"height\": 240"));
+        assert!(notebook.contains("\"width\": 320"));
+        assert!(notebook.contains("\"needs_background\": \"light\""));
+        let height = notebook.find("\"height\"").expect("height key");
+        let background = notebook
+            .find("\"needs_background\"")
+            .expect("background key");
+        let width = notebook.find("\"width\"").expect("width key");
+        assert!(
+            height < background && background < width,
+            "metadata keys are not sorted:\n{notebook}"
+        );
+    }
+
+    #[test]
+    fn image_output_without_metadata_has_an_empty_metadata_object() {
+        let Json::Object(entries) =
+            output_metadata(&[Block::Para(vec![Inline::Str("text".to_owned().into())])])
+        else {
+            panic!("expected object");
+        };
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn cell_attachments_are_emitted_in_sorted_key_order() {
+        let bytes = vec![9u8, 8, 7, 6];
+        let mut bag = MediaBag::new();
+        bag.insert("fig-a.png", Some("image/png".to_owned()), bytes.clone());
+        bag.insert("fig-b.png", Some("image/png".to_owned()), bytes);
+        let mut options = WriterOptions::default();
+        options.media = std::sync::Arc::new(bag);
+
+        // The cell references b before a; the emitted attachments object is keyed in sorted order.
+        let reference = |name: &str| {
+            Block::Para(vec![Inline::Image(
+                Box::default(),
+                Vec::new(),
+                Box::new(carta_ast::Target {
+                    url: name.to_owned().into(),
+                    title: String::new().into(),
+                }),
+            )])
+        };
+        let document = Document {
+            blocks: vec![Block::Div(
+                Box::new(Attr {
+                    id: "fig".to_owned().into(),
+                    classes: vec!["cell".to_owned().into(), "markdown".to_owned().into()],
+                    attributes: Vec::new(),
+                }),
+                vec![reference("fig-b.png"), reference("fig-a.png")],
+            )],
+            ..Document::default()
+        };
+
+        let notebook = IpynbWriter.write(&document, &options).expect("writes");
+        let (_, attachments) = notebook
+            .split_once("\"attachments\"")
+            .expect("attachments object present");
+        let a = attachments.find("fig-a.png").expect("a key present");
+        let b = attachments.find("fig-b.png").expect("b key present");
+        assert!(a < b, "attachments are not sorted:\n{notebook}");
     }
 
     #[test]

--- a/crates/carta/src/lib.rs
+++ b/crates/carta/src/lib.rs
@@ -14,7 +14,7 @@ pub use carta_ast::Document;
 pub use carta_core::{
     AnyReader, AnyWriter, BytesReader, BytesWriter, Error, Extension, Extensions, MathMethod,
     MediaBag, MediaItem, Output, Reader, ReaderOptions, Result, TocStyle, WrapMode, Writer,
-    WriterOptions, presets,
+    WriterOptions, media, presets,
 };
 
 use std::sync::Arc;

--- a/crates/carta/src/lib.rs
+++ b/crates/carta/src/lib.rs
@@ -13,8 +13,11 @@ pub use carta_ast as ast;
 pub use carta_ast::Document;
 pub use carta_core::{
     AnyReader, AnyWriter, BytesReader, BytesWriter, Error, Extension, Extensions, MathMethod,
-    Output, Reader, ReaderOptions, Result, TocStyle, WrapMode, Writer, WriterOptions, presets,
+    MediaBag, MediaItem, Output, Reader, ReaderOptions, Result, TocStyle, WrapMode, Writer,
+    WriterOptions, presets,
 };
+
+use std::sync::Arc;
 
 mod format_spec;
 mod registry;
@@ -89,11 +92,28 @@ pub fn convert(
     reader_options: &ReaderOptions,
     writer_options: &WriterOptions,
 ) -> Result<Output> {
-    let (from_base, from_ext) = format_spec::parse_reader_format_spec(from)?;
-    let (to_base, to_ext) = parse_format_spec(to)?;
+    let (document, media) = read_document(from, input, reader_options)?;
+    render_document(to, document, media, writer_options)
+}
 
+/// Parses `input` in format `from` into the document model together with the embedded resources it
+/// references (a notebook's image outputs; empty for a format that carries none).
+///
+/// The reading half of [`convert`], exposed so a caller can inspect or transform the [`Document`] —
+/// and extract or rewrite its media — before rendering it with [`render_document`]. `from` may carry
+/// `+ext`/`-ext` toggles, merged with the extensions already in `reader_options`.
+///
+/// # Errors
+/// Propagates format-resolution errors ([`Error::UnsupportedFormat`], [`Error::FormatNotEnabled`],
+/// [`Error::UnknownExtension`]) and any reader error, including [`Error::InvalidUtf8`] when a
+/// text-shaped reader is handed input that is not valid UTF-8.
+pub fn read_document(
+    from: &str,
+    input: &[u8],
+    reader_options: &ReaderOptions,
+) -> Result<(Document, MediaBag)> {
+    let (from_base, from_ext) = format_spec::parse_reader_format_spec(from)?;
     let reader = any_reader_for(&from_base)?;
-    let writer = any_writer_for(&to_base)?;
 
     let mut reader_options = reader_options.clone();
     reader_options.extensions = from_ext.union(reader_options.extensions);
@@ -101,17 +121,39 @@ pub fn convert(
     // preceding blank line, so a bare following line continues the paragraph rather than starting a
     // new block.
     reader_options.greedy_paragraphs |= from_base.starts_with("markdown");
+
+    reader.read_media(input, &reader_options)
+}
+
+/// Renders `document` into format `to`, returning text for a text target and bytes for a byte-shaped
+/// one. `media` supplies the embedded resources a re-embedding writer (a notebook re-encoding its
+/// image outputs) draws on; pass an empty bag when the document references none.
+///
+/// The writing half of [`convert`]. `to` may carry `+ext`/`-ext` toggles, merged with the extensions
+/// already in `writer_options`.
+///
+/// # Errors
+/// Propagates format-resolution errors ([`Error::UnsupportedFormat`], [`Error::FormatNotEnabled`],
+/// [`Error::UnknownExtension`]) and any writer error encountered during rendering.
+pub fn render_document(
+    to: &str,
+    document: Document,
+    media: MediaBag,
+    writer_options: &WriterOptions,
+) -> Result<Output> {
+    let (to_base, to_ext) = parse_format_spec(to)?;
+    let writer = any_writer_for(&to_base)?;
+
     let mut writer_options = writer_options.clone();
     writer_options.extensions = to_ext.union(writer_options.extensions);
+    writer_options.media = Arc::new(media);
 
     #[cfg(feature = "standalone")]
     let document = {
-        let mut document = reader.read(input, &reader_options)?;
+        let mut document = document;
         standalone::merge_metadata(&mut document, &writer_options);
         document
     };
-    #[cfg(not(feature = "standalone"))]
-    let document = reader.read(input, &reader_options)?;
 
     // A byte-shaped writer owns its complete output: no template, standalone wrapping, or section
     // splicing decorates it.

--- a/crates/carta/src/main.rs
+++ b/crates/carta/src/main.rs
@@ -11,8 +11,11 @@ use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use carta::ast::MetaValue;
-use carta::{Error, MathMethod, Output, ReaderOptions, Result, WrapMode, WriterOptions, convert};
+use carta::ast::{Block, MetaValue};
+use carta::{
+    Error, MathMethod, MediaBag, Output, ReaderOptions, Result, WrapMode, WriterOptions, media,
+    read_document, render_document,
+};
 use clap::{ArgAction, Parser};
 
 const LIST_FLAGS: [&str; 4] = [
@@ -42,6 +45,10 @@ struct Cli {
     /// Write output to this file instead of stdout.
     #[arg(short = 'o', long = "output")]
     output: Option<PathBuf>,
+    /// Extract the input's embedded media to this directory, writing each resource as a file and
+    /// rewriting the document's references to point at the extracted files.
+    #[arg(long = "extract-media", value_name = "DIR")]
+    extract_media: Option<PathBuf>,
     /// Produce a standalone document, wrapping the body in the format's template.
     #[arg(short = 's', long = "standalone")]
     standalone: bool,
@@ -179,8 +186,32 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     // A template (default or `--template`) emits verbatim; a bare fragment gets one trailing newline.
     let verbatim = cli.standalone || cli.template.is_some();
 
-    let output = convert(from, to, &input, &ReaderOptions::default(), &writer_options)?;
+    let (mut document, resources) = read_document(from, &input, &ReaderOptions::default())?;
+    let resources = match &cli.extract_media {
+        // Extraction turns the embedded resources into external files the document points at, so the
+        // writer no longer re-embeds them: it renders against an empty bag.
+        Some(dir) => {
+            extract_media(dir, &resources, &mut document.blocks)?;
+            MediaBag::new()
+        }
+        None => resources,
+    };
+    let output = render_document(to, document, resources, &writer_options)?;
     write_output(cli.output.as_deref(), &output, verbatim)
+}
+
+/// Writes every resource in `media` to a file under `dir` (`<dir>/<name>`, creating parent
+/// directories) and rewrites the document's references to those resources to point at the files.
+fn extract_media(dir: &Path, media: &MediaBag, blocks: &mut [Block]) -> Result<()> {
+    for (name, item) in media.iter() {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, &item.bytes)?;
+    }
+    media::rewrite_extracted_references(blocks, media, &dir.to_string_lossy());
+    Ok(())
 }
 
 /// The title an HTML-family standalone document falls back to when no `title` metadata is present:

--- a/crates/carta/tests/cli.rs
+++ b/crates/carta/tests/cli.rs
@@ -264,9 +264,11 @@ fn extract_media_writes_files_and_rewrites_references() {
     );
     assert!(result.success, "stderr: {}", result.stderr);
 
-    // The document's image reference is rewritten to the extracted file's path.
+    // The document's image reference is rewritten to the extracted file's path. The reference joins
+    // the directory to the name with a forward slash on every platform (a document link is URL-style,
+    // not an OS path), so it is built with the same join the writer uses rather than `Path::join`.
     let extracted = media_dir.join(&name);
-    let extracted_ref = extracted.to_string_lossy().into_owned();
+    let extracted_ref = carta::media::extracted_path(&media_dir.to_string_lossy(), &name);
     assert!(
         result.stdout.contains(&extracted_ref),
         "stdout missing extracted path {extracted_ref}:\n{}",

--- a/crates/carta/tests/cli.rs
+++ b/crates/carta/tests/cli.rs
@@ -243,3 +243,36 @@ fn list_extensions_rejects_an_unknown_format() {
         result.stderr
     );
 }
+
+#[cfg(all(feature = "read-ipynb", feature = "write-markdown"))]
+#[test]
+fn extract_media_writes_files_and_rewrites_references() {
+    const NOTEBOOK: &str = r#"{"cells":[{"cell_type":"code","execution_count":1,"metadata":{},"outputs":[{"output_type":"display_data","data":{"image/png":"iVBORw0KGgoAAAANSUhEUg=="},"metadata":{}}],"source":["draw()"]}],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"}},"nbformat":4,"nbformat_minor":5}"#;
+
+    // The extraction directory must be absolute: the subprocess resolves it against its own working
+    // directory, not this test's temp area.
+    let media_dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("extract-media");
+    let _ = fs::remove_dir_all(&media_dir);
+
+    let bytes = carta::media::base64_decode("iVBORw0KGgoAAAANSUhEUg==").unwrap();
+    let name = carta::media::content_addressed_name("image/png", &bytes);
+
+    let extract_arg = format!("--extract-media={}", media_dir.display());
+    let result = run(
+        &["-f", "ipynb", "-t", "markdown", extract_arg.as_str()],
+        NOTEBOOK,
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+
+    // The document's image reference is rewritten to the extracted file's path.
+    let extracted = media_dir.join(&name);
+    let extracted_ref = extracted.to_string_lossy().into_owned();
+    assert!(
+        result.stdout.contains(&extracted_ref),
+        "stdout missing extracted path {extracted_ref}:\n{}",
+        result.stdout
+    );
+    // The bytes are written to that path verbatim, under the content-addressed name.
+    let written = fs::read(&extracted).expect("extracted media file");
+    assert_eq!(written, bytes);
+}

--- a/crates/carta/tests/media.rs
+++ b/crates/carta/tests/media.rs
@@ -1,0 +1,91 @@
+//! Facade integration tests for embedded-media handling: reading a notebook lifts its image bytes
+//! into the media bag under a content-addressed name, rendering back re-embeds them from the bag,
+//! and the extract transform rewrites references to on-disk paths. These run fully offline — the
+//! bytes and names are the code's own deterministic output.
+
+#![cfg(all(feature = "read-ipynb", feature = "write-ipynb"))]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use carta::media::{base64_decode, content_addressed_name, rewrite_extracted_references};
+use carta::{Output, ReaderOptions, WriterOptions, read_document, render_document};
+
+// A one-cell notebook whose code cell emits a single PNG display output.
+const NOTEBOOK_WITH_IMAGE: &str = r#"{"cells":[{"cell_type":"code","execution_count":1,"metadata":{},"outputs":[{"output_type":"display_data","data":{"image/png":"iVBORw0KGgoAAAANSUhEUg=="},"metadata":{}}],"source":["draw()"]}],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"}},"nbformat":4,"nbformat_minor":5}"#;
+
+const IMAGE_BASE64: &str = "iVBORw0KGgoAAAANSUhEUg==";
+
+#[test]
+fn reading_a_notebook_lifts_image_bytes_into_the_bag() {
+    let (_document, media) = read_document(
+        "ipynb",
+        NOTEBOOK_WITH_IMAGE.as_bytes(),
+        &ReaderOptions::default(),
+    )
+    .unwrap();
+
+    let bytes = base64_decode(IMAGE_BASE64).unwrap();
+    let name = content_addressed_name("image/png", &bytes);
+    let item = media.get(&name).expect("image is in the bag");
+    assert_eq!(item.mime.as_deref(), Some("image/png"));
+    assert_eq!(item.bytes, bytes);
+}
+
+#[test]
+fn rendering_back_to_a_notebook_re_embeds_from_the_bag() {
+    let (document, media) = read_document(
+        "ipynb",
+        NOTEBOOK_WITH_IMAGE.as_bytes(),
+        &ReaderOptions::default(),
+    )
+    .unwrap();
+
+    let Output::Text(rendered) =
+        render_document("ipynb", document, media, &WriterOptions::default()).unwrap()
+    else {
+        panic!("ipynb output is text");
+    };
+    // The output carries the image's bytes back as an embedded base64 payload.
+    assert!(
+        rendered.contains(IMAGE_BASE64),
+        "re-embedded payload missing from output:\n{rendered}"
+    );
+}
+
+// Extraction externalizes the bytes for a text target; a notebook re-embeds, so it is not the
+// extraction target here.
+#[cfg(feature = "write-markdown")]
+#[test]
+fn extraction_rewrites_references_to_the_target_directory() {
+    let (mut document, media) = read_document(
+        "ipynb",
+        NOTEBOOK_WITH_IMAGE.as_bytes(),
+        &ReaderOptions::default(),
+    )
+    .unwrap();
+
+    let bytes = base64_decode(IMAGE_BASE64).unwrap();
+    let name = content_addressed_name("image/png", &bytes);
+
+    rewrite_extracted_references(&mut document.blocks, &media, "assets/img");
+
+    // Render to a text target with an empty bag: the writer emits the rewritten external reference
+    // rather than re-embedding the bytes.
+    let Output::Text(rendered) = render_document(
+        "markdown",
+        document,
+        carta::MediaBag::new(),
+        &WriterOptions::default(),
+    )
+    .unwrap() else {
+        panic!("markdown output is text");
+    };
+    assert!(
+        rendered.contains(&format!("assets/img/{name}")),
+        "rewritten reference missing from output:\n{rendered}"
+    );
+    // With the reference now external, the bytes are no longer embedded.
+    assert!(
+        !rendered.contains(IMAGE_BASE64),
+        "bytes should not be re-embedded after extraction:\n{rendered}"
+    );
+}

--- a/crates/carta/tests/snapshots/golden_reader__ipynb__attachment-order.snap
+++ b/crates/carta/tests/snapshots/golden_reader__ipynb__attachment-order.snap
@@ -1,0 +1,5 @@
+---
+source: crates/carta/tests/golden_reader.rs
+expression: json
+---
+{"pandoc-api-version":[1,23,1,2],"meta":{"jupyter":{"t":"MetaMap","c":{"kernelspec":{"t":"MetaMap","c":{"display_name":{"t":"MetaString","c":"Python 3"},"language":{"t":"MetaString","c":"python"},"name":{"t":"MetaString","c":"python3"}}},"nbformat":{"t":"MetaString","c":"4"},"nbformat_minor":{"t":"MetaString","c":"5"}}}},"blocks":[{"t":"Div","c":[["order",["cell","markdown"],[]],[{"t":"Para","c":[{"t":"Str","c":"Two"},{"t":"Space"},{"t":"Str","c":"attachments,"},{"t":"Space"},{"t":"Str","c":"referenced"},{"t":"Space"},{"t":"Str","c":"out"},{"t":"Space"},{"t":"Str","c":"of"},{"t":"Space"},{"t":"Str","c":"key"},{"t":"Space"},{"t":"Str","c":"order:"}]},{"t":"Para","c":[{"t":"Image","c":[["",[],[]],[{"t":"Str","c":"beta"}],["order-beta.png",""]]}]},{"t":"Para","c":[{"t":"Image","c":[["",[],[]],[{"t":"Str","c":"alpha"}],["order-alpha.png",""]]}]}]]}]}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -165,6 +165,8 @@ dialect's own default extension set, so the `markdown` notes above apply to them
   (SVG and other text payloads emit as source-line arrays); `--extract-media=DIR` instead writes each
   resource to a file and rewrites the reference to point at it. An image whose bytes are absent from
   the bag is reported as unrepresentable rather than emitted as a broken bundle.
+- An image output's display metadata (dimensions, background hint) rides on the image's attributes and
+  is restored as the output's `metadata`; a cell's `attachments` are keyed in sorted order.
 - Nested metadata keys (e.g. `kernelspec`) emit in sorted order rather than the format's hash order.
 - Standalone (`-s`), TOC, and section numbering are no-ops.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -54,6 +54,8 @@ dialect's own default extension set, so the `markdown` notes above apply to them
 - Doctest blocks (`>>>`) read as ordinary paragraphs.
 
 ### `ipynb` — ✅
+- Image outputs and inline cell attachments are decoded into the media bag under a content-addressed
+  name, which the writer re-embeds or `--extract-media` writes to disk.
 - nbformat v3 (worksheets) is reported as an unsupported format rather than read.
 - Lenient where the format is strict: a stream output with no `name`, a null `execution_count`, or a
   missing top-level `nbformat` are accepted rather than rejected.
@@ -158,10 +160,11 @@ dialect's own default extension set, so the `markdown` notes above apply to them
 ### `json` — ✅
 ### `native` — ✅
 
-### `ipynb` — 🚧
-- An image output references its payload by file name (the model carries no embedded bytes), so its
-  base64 `data` bundle cannot be reconstructed — such an output is reported as unrepresentable rather
-  than emitted as a broken bundle.
+### `ipynb` — ✅
+- Image and attachment outputs re-embed their bytes from the media bag as a base64 `data` bundle
+  (SVG and other text payloads emit as source-line arrays); `--extract-media=DIR` instead writes each
+  resource to a file and rewrites the reference to point at it. An image whose bytes are absent from
+  the bag is reported as unrepresentable rather than emitted as a broken bundle.
 - Nested metadata keys (e.g. `kernelspec`) emit in sorted order rather than the format's hash order.
 - Standalone (`-s`), TOC, and section numbering are no-ops.
 

--- a/tools/conformance-suite/lib.sh
+++ b/tools/conformance-suite/lib.sh
@@ -87,6 +87,22 @@ compare_ipynb() {
   return 1
 }
 
+# Compare the media-bag-reconstructed fields of two notebook outputs: each rich output's `metadata`
+# object and each cell's `attachments` keys, in document order. Keys are compared as emitted (no
+# canonical sort), so a regression in either the metadata ordering or the attachment ordering shows
+# up. This isolates what the media bag drives on the write side — an image output's display metadata
+# and a cell's attachment table — from the cell source, minted ids, and non-image data bundles, whose
+# fidelity belongs to other surfaces. Brief diff + 1 on mismatch.
+compare_ipynb_media() {
+  local proj='[.cells[] | {output_metadata: [.outputs[]? | select(.metadata) | .metadata], attachment_keys: (.attachments // {} | keys_unsorted)}]'
+  local a="$WORK/.cmp.oracle.media.json" b="$WORK/.cmp.ox.media.json"
+  jq -c "$proj" "$1" >"$a" 2>/dev/null || { echo "oracle notebook unparsable"; return 1; }
+  jq -c "$proj" "$2" >"$b" 2>/dev/null || { echo "carta notebook unparsable"; return 1; }
+  cmp -s "$a" "$b" && return 0
+  diff "$a" "$b" | head -n 200
+  return 1
+}
+
 # Compare two files byte-for-byte, with no trailing-newline tolerance. Used where the output is
 # emitted verbatim (a filled template) and every byte — trailing newlines included — must agree.
 # Renders the diff through `cat -A` so whitespace and line ends are visible.

--- a/tools/conformance-suite/lib.sh
+++ b/tools/conformance-suite/lib.sh
@@ -106,6 +106,23 @@ compare_text() {
   return 1
 }
 
+# Compare two extracted-media directories byte-for-byte. Either side may be absent — a document that
+# carries no media extracts nothing — and both-absent counts as equal; one-absent is a mismatch.
+# Prints the differing entries (bounded) and returns 1 on any divergence.
+compare_dir() {
+  local a="$1" b="$2" a_has=0 b_has=0
+  [ -d "$a" ] && [ -n "$(ls -A "$a" 2>/dev/null)" ] && a_has=1
+  [ -d "$b" ] && [ -n "$(ls -A "$b" 2>/dev/null)" ] && b_has=1
+  [ "$a_has" = 0 ] && [ "$b_has" = 0 ] && return 0
+  if [ "$a_has" != "$b_has" ]; then
+    echo "extracted media present on one side only (oracle=$a_has carta=$b_has)"
+    return 1
+  fi
+  diff -qr "$a" "$b" >/dev/null 2>&1 && return 0
+  diff -qr "$a" "$b" 2>&1 | head -n 50
+  return 1
+}
+
 # Per-surface tally. Reset before each (surface, format) group.
 conf_reset() {
   PASS=0 FAIL=0 ERR=0 SKIP=0

--- a/tools/conformance-suite/run.sh
+++ b/tools/conformance-suite/run.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   run.sh <surface> [arg]   run one surface (reader|writer|e2e|roundtrip|commands|extensions|
-#                            templates|standalone), optional arg narrows it (a format or target)
+#                            templates|standalone|media), optional arg narrows it (a format or target)
 #   run.sh all               run every surface
 #
 # Each surface prints one `RESULT <surface> <group> pass=N fail=N err=N skip=N` line per group and
@@ -13,7 +13,7 @@
 set -uo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SURFACES="reader writer e2e roundtrip commands extensions templates standalone"
+SURFACES="reader writer e2e roundtrip commands extensions templates standalone media"
 
 run_one() {
   local surface="$1"

--- a/tools/conformance-suite/surfaces/media.sh
+++ b/tools/conformance-suite/surfaces/media.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
-# Media surface: extract a notebook's embedded resources to files and diff both the rewritten
-# document and the extracted file tree against the oracle.
+# Media surface: exercise both sides of the media bag against the oracle.
 #
-# Each corpus/text/ipynb/*.ipynb case is converted to native with --extract-media, each tool writing
-# into its own isolated working directory so the two media/ trees never collide. The comparison is
-# writer-neutral: the native AST carries the references rewritten to the extracted paths, and the
-# media/ tree carries the resource bytes and their content-addressed names — both are compared
-# byte-for-byte. A notebook that carries no media extracts nothing on either side, which agrees.
+# Group `media/ipynb` extracts a notebook's embedded resources to files and diffs both the rewritten
+# document and the extracted file tree. Each corpus/text/ipynb/*.ipynb case is converted to native
+# with --extract-media, each tool writing into its own isolated working directory so the two media/
+# trees never collide. The comparison is writer-neutral: the native AST carries the references
+# rewritten to the extracted paths, and the media/ tree carries the resource bytes and their
+# content-addressed names — both are compared byte-for-byte. A notebook that carries no media
+# extracts nothing on either side, which agrees.
+#
+# Group `media/reembed` renders each notebook back to a notebook and diffs the fields the bag drives
+# on the write side — each output's reconstructed metadata and each cell's attachment table — so the
+# re-embedding path is checked differentially, not just the extraction path.
 #
 # Usage: surfaces/media.sh
 set -uo pipefail
@@ -51,6 +56,33 @@ $detail"
   fi
 done
 report media ipynb
+tally_group
+
+# Re-embedding path: render each notebook back to a notebook and diff the media-driven fields.
+conf_reset "media-reembed"
+for input in "$dir"/*; do
+  [ -f "$input" ] || continue
+  label="media/reembed/$(basename "$input")"
+  repro="repro: \$TOOL -f ipynb -t ipynb <$input"
+  ofile="$WORK/.reembed.oracle" xfile="$WORK/.reembed.ox" efile="$WORK/.reembed.err"
+  if ! "$ORACLE" -f ipynb -t ipynb <"$input" >"$ofile" 2>/dev/null; then
+    SKIP=$((SKIP + 1))
+    continue
+  fi
+  if ! "$OX" -f ipynb -t ipynb <"$input" >"$xfile" 2>"$efile"; then
+    note_err "$label" "$repro
+$(head -n 3 "$efile")"
+    continue
+  fi
+  if detail=$(compare_ipynb_media "$ofile" "$xfile"); then
+    PASS=$((PASS + 1))
+  else
+    note_fail "$label" "$repro
+media fields differ:
+$detail"
+  fi
+done
+report media reembed
 tally_group
 
 exit "$SUITE_RC"

--- a/tools/conformance-suite/surfaces/media.sh
+++ b/tools/conformance-suite/surfaces/media.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Media surface: extract a notebook's embedded resources to files and diff both the rewritten
+# document and the extracted file tree against the oracle.
+#
+# Each corpus/text/ipynb/*.ipynb case is converted to native with --extract-media, each tool writing
+# into its own isolated working directory so the two media/ trees never collide. The comparison is
+# writer-neutral: the native AST carries the references rewritten to the extracted paths, and the
+# media/ tree carries the resource bytes and their content-addressed names — both are compared
+# byte-for-byte. A notebook that carries no media extracts nothing on either side, which agrees.
+#
+# Usage: surfaces/media.sh
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+require_tools
+
+dir="$CORPUS/text/ipynb"
+conf_reset "media-ipynb"
+for input in "$dir"/*; do
+  [ -f "$input" ] || continue
+  label="media/ipynb/$(basename "$input")"
+  work="$WORK/media/$(basename "$input")"
+  rm -rf "$work"
+  mkdir -p "$work/oracle" "$work/ox"
+  repro="repro: (cd DIR && \$TOOL -f ipynb -t native --extract-media=media <$input)"
+  # Each tool runs in its own directory and extracts to a bare `media`, so both resolve the same
+  # relative reference while writing to disjoint trees.
+  if ! ( cd "$work/oracle" && "$ORACLE" -f ipynb -t native --extract-media=media <"$input" >out.native 2>err ); then
+    SKIP=$((SKIP + 1))
+    continue
+  fi
+  if ! ( cd "$work/ox" && "$OX" -f ipynb -t native --extract-media=media <"$input" >out.native 2>err ); then
+    note_err "$label" "$repro
+$(head -n 3 "$work/ox/err")"
+    continue
+  fi
+  detail=""
+  if ! d=$(compare_text "$work/oracle/out.native" "$work/ox/out.native"); then
+    detail="native AST differs:
+$d"
+  fi
+  if ! d=$(compare_dir "$work/oracle/media" "$work/ox/media"); then
+    detail="${detail:+$detail
+}extracted media differs:
+$d"
+  fi
+  if [ -z "$detail" ]; then
+    PASS=$((PASS + 1))
+  else
+    note_fail "$label" "$repro
+$detail"
+  fi
+done
+report media ipynb
+tally_group
+
+exit "$SUITE_RC"


### PR DESCRIPTION
## Summary

Adds a media bag — a side-channel carrying resource bytes outside the AST — and connects it to the notebook reader/writer, closing the ipynb image/attachment gap: image outputs and cell attachments now round-trip, and `--extract-media=DIR` writes embedded resources to files while rewriting their references. The seam (content-addressed naming, a shared image-target tree walk, `Arc<MediaBag>` through the reader/writer contract) is format-agnostic, readying the pipeline for the binary container formats (docx, epub, …).

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196EgN9sitFCSckx1qHcJ79