### PR TITLE
perf(commonmark-reader): remember failed code-span close searches

### DIFF
--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -4670,6 +4670,27 @@ mod inline_tests {
         assert_eq!(p("`a ``b``"), vec![str("`a"), Inline::Space, code("b")]);
     }
 
+    #[test]
+    fn code_span_repeated_failures_of_one_length_skip_the_rescan() {
+        // An escape consumes the backslash plus the first backtick of a raw run, so the opener
+        // that follows is the run's suffix — its length (2 here) need not equal any raw run's
+        // length. The first length-2 opener's close search fails to end-of-input (every raw run
+        // is length 3) and is remembered; the second length-2 opener skips the rescan and emits
+        // its backticks literally, identical to what the full scan would produce.
+        assert_eq!(
+            p("\\``` x \\``` x"),
+            vec![
+                str("```"),
+                Inline::Space,
+                str("x"),
+                Inline::Space,
+                str("```"),
+                Inline::Space,
+                str("x"),
+            ]
+        );
+    }
+
     // --- Inline raw TeX and backslash math ---
 
     fn tex(source: &str) -> Inline {

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -767,6 +767,7 @@ fn parse_inlines(text: &str, refs: &RefMap, notes: RefContext, ext: Extensions) 
         ext,
         bracket_stack: Vec::new(),
         interesting: interesting_chars(ext),
+        backtick_no_close: BTreeMap::new(),
     };
     parser.run();
     let mut inlines = resolve_inline_nodes(parser.nodes, ext, notes.markdown);
@@ -812,6 +813,10 @@ struct InlineParser<'a> {
     /// For each ASCII code, whether a character can start a syntactic construct under the active
     /// extensions. Everything else is ordinary text a run scan can skip over in one step.
     interesting: [bool; 128],
+    /// Backtick run lengths for which a close search already failed, each with the position the
+    /// failed search started from. A search to end-of-input that failed from `p` also fails from
+    /// any later position, so an equal-length opener past `p` skips the scan.
+    backtick_no_close: BTreeMap<usize, usize>,
 }
 
 /// The ASCII characters that can begin an inline construct under `ext`; every other character is
@@ -1397,37 +1402,45 @@ impl InlineParser<'_> {
         let start = self.pos;
         let open = backtick_run_len(self.chars, self.pos);
         self.pos += open;
-        // Find a closing run of exactly `open` backticks.
-        let mut scan = self.pos;
-        while scan < self.chars.len() {
-            if self.chars.get(scan).copied() == Some('`') {
-                let close = backtick_run_len(self.chars, scan);
-                if close == open {
-                    let content: String = self
-                        .chars
-                        .get(self.pos..scan)
-                        .map(|s| s.iter().collect())
-                        .unwrap_or_default();
-                    self.pos = scan + close;
-                    if let Some((format, next)) = self.scan_raw_format() {
-                        self.pos = next;
-                        self.nodes.push(Node::Inline(Inline::RawInline(
-                            carta_ast::Format(format.into()),
+        // If a same-length close search already failed from at or before `start`, it fails again.
+        let already_failed = self
+            .backtick_no_close
+            .get(&open)
+            .is_some_and(|&failed_from| failed_from <= start);
+        if !already_failed {
+            // Find a closing run of exactly `open` backticks.
+            let mut scan = self.pos;
+            while scan < self.chars.len() {
+                if self.chars.get(scan).copied() == Some('`') {
+                    let close = backtick_run_len(self.chars, scan);
+                    if close == open {
+                        let content: String = self
+                            .chars
+                            .get(self.pos..scan)
+                            .map(|s| s.iter().collect())
+                            .unwrap_or_default();
+                        self.pos = scan + close;
+                        if let Some((format, next)) = self.scan_raw_format() {
+                            self.pos = next;
+                            self.nodes.push(Node::Inline(Inline::RawInline(
+                                carta_ast::Format(format.into()),
+                                normalize_code(&content, self.notes.markdown).into(),
+                            )));
+                            return;
+                        }
+                        let attr = self.take_code_attr();
+                        self.nodes.push(Node::Inline(Inline::Code(
+                            Box::new(attr),
                             normalize_code(&content, self.notes.markdown).into(),
                         )));
                         return;
                     }
-                    let attr = self.take_code_attr();
-                    self.nodes.push(Node::Inline(Inline::Code(
-                        Box::new(attr),
-                        normalize_code(&content, self.notes.markdown).into(),
-                    )));
-                    return;
+                    scan += close;
+                } else {
+                    scan += 1;
                 }
-                scan += close;
-            } else {
-                scan += 1;
             }
+            self.backtick_no_close.insert(open, start);
         }
         // No closing run: emit the opening backticks literally.
         let literal: String = self
@@ -4636,6 +4649,25 @@ mod inline_tests {
     #[test]
     fn raw_attribute_off_leaves_marker_literal() {
         assert_eq!(p("`<b>`{=html}"), vec![code("<b>"), str("{=html}")]);
+    }
+
+    #[test]
+    fn code_span_matches_equal_length_closer() {
+        assert_eq!(p("`a`"), vec![code("a")]);
+    }
+
+    #[test]
+    fn code_span_with_no_closer_stays_literal() {
+        assert_eq!(p("`a"), vec![str("`a")]);
+    }
+
+    #[test]
+    fn code_span_failed_search_does_not_mask_a_different_length_match() {
+        // The length-1 opener's close search runs to end-of-buffer and fails (no lone backtick
+        // follows), which the parser remembers for length 1. The length-2 span that comes right
+        // after must still match: the memo is keyed by run length, so a failure recorded for one
+        // length must not suppress the scan for another.
+        assert_eq!(p("`a ``b``"), vec![str("`a"), Inline::Space, code("b")]);
     }
 
     // --- Inline raw TeX and backslash math ---


### PR DESCRIPTION
## Summary

An unmatched code-span opener rescans to the end of the block for every opener of the same length, which goes quadratic when escaped backticks mint openers whose length matches no raw run. A per-parse memo of failed close searches skips the doomed rescans: 60k such openers drop from ~7.4s to ~0.01s with byte-identical output.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.
