### PR TITLE
perf(readers): resume heading-id suffix probing from the last issued suffix

### DIFF
--- a/crates/carta-readers/src/heading_ids.rs
+++ b/crates/carta-readers/src/heading_ids.rs
@@ -18,7 +18,6 @@
 //! dialect uses native disambiguation for every slug shape (so its GitHub-slug variant still maps an
 //! empty slug to `section`), while the bare `CommonMark` engine pairs the GitHub slug with count-suffix.
 
-#[cfg(any(feature = "commonmark", feature = "rst", feature = "dokuwiki"))]
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
@@ -190,6 +189,11 @@ pub(crate) struct IdRegistry {
     /// Per-base occurrence counts, used by the count-suffix strategy.
     #[cfg(any(feature = "commonmark", feature = "rst", feature = "dokuwiki"))]
     counts: BTreeMap<String, u32>,
+    /// The next suffix to try for a given `(base, separator)`, used by the increment-until-unique
+    /// strategy so a repeated collision resumes probing where the last one left off instead of
+    /// restarting at 1. A value here is only ever a lower bound: `seen` remains the source of truth,
+    /// since an explicit id can still occupy the next few candidates.
+    next_suffix: BTreeMap<(String, char), u32>,
 }
 
 impl IdRegistry {
@@ -240,10 +244,12 @@ impl IdRegistry {
         if self.seen.insert(base.clone()) {
             return base;
         }
-        let mut suffix = 1u32;
+        let key = (base.clone(), separator);
+        let mut suffix = self.next_suffix.get(&key).copied().unwrap_or(1);
         loop {
             let candidate = format!("{base}{separator}{suffix}");
             if self.seen.insert(candidate.clone()) {
+                self.next_suffix.insert(key, suffix + 1);
                 return candidate;
             }
             suffix += 1;
@@ -342,6 +348,77 @@ mod tests {
         let mut registry = IdRegistry::default();
         registry.reserve(IdScheme::Gfm, "intro");
         assert_eq!(registry.assign(IdScheme::Gfm, "Intro"), "intro");
+    }
+
+    #[test]
+    fn assign_with_separator_resumes_probing_from_the_last_issued_suffix() {
+        let mut registry = IdRegistry::default();
+        assert_eq!(
+            registry.assign_with_separator("base".to_owned(), '-'),
+            "base"
+        );
+        for suffix in 1..5 {
+            assert_eq!(
+                registry.assign_with_separator("base".to_owned(), '-'),
+                format!("base-{suffix}")
+            );
+        }
+    }
+
+    #[test]
+    fn assign_with_separator_skips_a_reserved_suffix_exactly_once() {
+        let mut registry = IdRegistry::default();
+        registry.seen.insert("base-2".to_owned());
+        assert_eq!(
+            registry.assign_with_separator("base".to_owned(), '-'),
+            "base"
+        );
+        assert_eq!(
+            registry.assign_with_separator("base".to_owned(), '-'),
+            "base-1"
+        );
+        assert_eq!(
+            registry.assign_with_separator("base".to_owned(), '-'),
+            "base-3"
+        );
+    }
+
+    #[test]
+    fn assign_with_separator_stays_consistent_when_a_reservation_lands_on_the_memo() {
+        let mut registry = IdRegistry::default();
+        assert_eq!(
+            registry.assign_with_separator("base".to_owned(), '-'),
+            "base"
+        );
+        assert_eq!(
+            registry.assign_with_separator("base".to_owned(), '-'),
+            "base-1"
+        );
+        // The memo now points at suffix 2; reserve that exact candidate before the next assignment.
+        registry.seen.insert("base-2".to_owned());
+        assert_eq!(
+            registry.assign_with_separator("base".to_owned(), '-'),
+            "base-3"
+        );
+    }
+
+    #[test]
+    fn assign_with_separator_keys_the_memo_by_separator() {
+        let mut registry = IdRegistry::default();
+        assert_eq!(
+            registry.assign_with_separator("same".to_owned(), '-'),
+            "same"
+        );
+        assert_eq!(
+            registry.assign_with_separator("same".to_owned(), '-'),
+            "same-1"
+        );
+        // The `_` separator has its own memo, so it starts probing at 1, not at the `-` memo's 2 — the
+        // bare `same` is already in `seen`, so `same_1` is the first available `_` candidate.
+        assert_eq!(
+            registry.assign_with_separator("same".to_owned(), '_'),
+            "same_1"
+        );
     }
 
     #[cfg(feature = "man")]

--- a/crates/carta-readers/src/html/convert.rs
+++ b/crates/carta-readers/src/html/convert.rs
@@ -69,6 +69,11 @@ fn text_inlines(e: &Element) -> Vec<Inline> {
 #[derive(Default)]
 pub(super) struct Converter {
     used_ids: BTreeSet<String>,
+    /// The next suffix to try for a given base, so a repeated collision resumes probing where the
+    /// last one left off instead of restarting at 1. A value here is only ever a lower bound:
+    /// `used_ids` remains the source of truth, since an explicit id can still occupy the next few
+    /// candidates.
+    next_id_suffix: BTreeMap<String, u32>,
     in_list_item: std::cell::Cell<bool>,
     /// When set, the inline finishing pass runs in code context: text becomes verbatim code, so
     /// `smart` emits curly glyphs in place of [`Inline::Quoted`] and the math forms are not scanned.
@@ -461,10 +466,11 @@ impl Converter {
         if self.used_ids.insert(base.clone()) {
             return base;
         }
-        let mut n = 1;
+        let mut n = self.next_id_suffix.get(&base).copied().unwrap_or(1);
         loop {
             let candidate = format!("{base}-{n}");
             if self.used_ids.insert(candidate.clone()) {
+                self.next_id_suffix.insert(base, n + 1);
                 return candidate;
             }
             n += 1;

--- a/crates/carta-readers/src/html/mod.rs
+++ b/crates/carta-readers/src/html/mod.rs
@@ -1013,6 +1013,21 @@ mod tests {
         assert_eq!(ids, vec![String::new()]);
     }
 
+    #[test]
+    fn repeated_headings_resume_probing_from_the_last_issued_suffix() {
+        let ids = header_ids("<h2>Same</h2><h2>Same</h2><h2>Same</h2><h2>Same</h2>", &[]);
+        assert_eq!(ids, vec!["same", "same-1", "same-2", "same-3"]);
+    }
+
+    #[test]
+    fn repeated_headings_skip_an_id_reserved_by_an_explicit_heading() {
+        let ids = header_ids(
+            "<h2 id=\"same-2\">Explicit</h2><h2>Same</h2><h2>Same</h2><h2>Same</h2>",
+            &[],
+        );
+        assert_eq!(ids, vec!["same-2", "same", "same-1", "same-3"]);
+    }
+
     #[cfg(feature = "opml")]
     #[test]
     fn inline_fragment_parses_markup_and_trims_edges() {


### PR DESCRIPTION
## Summary

Colliding heading slugs re-probed `base-1`, `base-2`, … from 1 on every collision — O(k²) over k duplicates in both the shared id registry and the HTML reader. A per-(base, separator) next-suffix memo resumes probing where the last collision stopped, with the seen-set staying authoritative so explicit-id reservations and emitted ids are byte-identical.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.
