### PR TITLE
perf(commonmark-reader): migrate the inline layer to byte offsets

### DIFF
--- a/crates/carta-readers/src/commonmark/attr.rs
+++ b/crates/carta-readers/src/commonmark/attr.rs
@@ -16,47 +16,43 @@ pub(crate) enum IdPolicy {
     Last,
 }
 
+/// The character beginning at byte offset `at`, or `None` at or past the end of `text`.
+fn char_at(text: &str, at: usize) -> Option<char> {
+    text.get(at..).and_then(|rest| rest.chars().next())
+}
+
 /// Parse an attribute block at the start of `s`, which must begin with `{`. Returns the parsed
 /// [`Attr`] and the number of bytes consumed (both braces included), or `None` when `s` does not open
 /// a well-formed block (a bare-word token, or no closing brace). A repeated `#id` keeps the last.
 pub(crate) fn parse_attributes(s: &str) -> Option<(Attr, usize)> {
-    parse_attributes_with(s, IdPolicy::Last)
+    parse_attributes_bytes_with(s, 0, IdPolicy::Last)
 }
 
 /// Like [`parse_attributes`], but a repeated `#id` keeps the first.
 pub(crate) fn parse_attributes_first_id(s: &str) -> Option<(Attr, usize)> {
-    parse_attributes_with(s, IdPolicy::First)
+    parse_attributes_bytes_with(s, 0, IdPolicy::First)
 }
 
-fn parse_attributes_with(s: &str, policy: IdPolicy) -> Option<(Attr, usize)> {
-    let chars: Vec<char> = s.chars().collect();
-    let (attr, end) = parse_attributes_chars_with(&chars, 0, policy)?;
-    let consumed = chars
-        .get(..end)
-        .map_or(0, |head| head.iter().map(|ch| ch.len_utf8()).sum());
-    Some((attr, consumed))
-}
-
-/// Parse an attribute block at `chars[start..]`, which must begin with `{`. Returns the parsed
-/// [`Attr`] and the char index just past the closing brace, or `None` when the block is not
+/// Parse an attribute block at byte offset `start` in `text`, which must begin with `{`. Returns the
+/// parsed [`Attr`] and the byte offset just past the closing brace, or `None` when the block is not
 /// well-formed (a bare-word token, or no closing brace). A repeated `#id` keeps the last.
-pub(crate) fn parse_attributes_chars(chars: &[char], start: usize) -> Option<(Attr, usize)> {
-    parse_attributes_chars_with(chars, start, IdPolicy::Last)
+pub(crate) fn parse_attributes_bytes(text: &str, start: usize) -> Option<(Attr, usize)> {
+    parse_attributes_bytes_with(text, start, IdPolicy::Last)
 }
 
-fn parse_attributes_chars_with(
-    chars: &[char],
+fn parse_attributes_bytes_with(
+    text: &str,
     start: usize,
     policy: IdPolicy,
 ) -> Option<(Attr, usize)> {
-    if chars.get(start).copied() != Some('{') {
+    if char_at(text, start) != Some('{') {
         return None;
     }
     let mut index = start + 1;
     let mut attr = Attr::default();
     loop {
-        skip_ws(chars, &mut index);
-        match chars.get(index).copied() {
+        skip_ws(text, &mut index);
+        match char_at(text, index) {
             None => return None,
             Some('}') => {
                 index += 1;
@@ -64,7 +60,7 @@ fn parse_attributes_chars_with(
             }
             Some('#') => {
                 index += 1;
-                let id = read_token(chars, &mut index);
+                let id = read_token(text, &mut index);
                 if id.is_empty() {
                     return None;
                 }
@@ -74,19 +70,19 @@ fn parse_attributes_chars_with(
             }
             Some('.') => {
                 index += 1;
-                let class = read_token(chars, &mut index);
+                let class = read_token(text, &mut index);
                 if class.is_empty() {
                     return None;
                 }
                 attr.classes.push(class.into());
             }
             Some(_) => {
-                let key = read_key(chars, &mut index);
-                if key.is_empty() || chars.get(index).copied() != Some('=') {
+                let key = read_key(text, &mut index);
+                if key.is_empty() || char_at(text, index) != Some('=') {
                     return None;
                 }
                 index += 1;
-                let value = read_value(chars, &mut index);
+                let value = read_value(text, &mut index);
                 attr.attributes.push((key.into(), value.into()));
             }
         }
@@ -114,47 +110,53 @@ fn is_token_end(ch: char) -> bool {
     matches!(ch, ' ' | '\t' | '\n' | '}')
 }
 
-fn skip_ws(chars: &[char], index: &mut usize) {
-    while matches!(chars.get(*index).copied(), Some(' ' | '\t' | '\n')) {
+fn skip_ws(text: &str, index: &mut usize) {
+    while matches!(char_at(text, *index), Some(' ' | '\t' | '\n')) {
         *index += 1;
     }
 }
 
 /// Read an identifier or class token: everything up to whitespace or the closing brace.
-fn read_token(chars: &[char], index: &mut usize) -> String {
+fn read_token(text: &str, index: &mut usize) -> String {
     let mut out = String::new();
-    while let Some(&ch) = chars.get(*index).filter(|&&c| !is_token_end(c)) {
+    while let Some(ch) = char_at(text, *index) {
+        if is_token_end(ch) {
+            break;
+        }
         out.push(ch);
-        *index += 1;
+        *index += ch.len_utf8();
     }
     out
 }
 
 /// Read a key: everything up to `=`, whitespace, or the closing brace.
-fn read_key(chars: &[char], index: &mut usize) -> String {
+fn read_key(text: &str, index: &mut usize) -> String {
     let mut out = String::new();
-    while let Some(&ch) = chars.get(*index).filter(|&&c| c != '=' && !is_token_end(c)) {
+    while let Some(ch) = char_at(text, *index) {
+        if ch == '=' || is_token_end(ch) {
+            break;
+        }
         out.push(ch);
-        *index += 1;
+        *index += ch.len_utf8();
     }
     out
 }
 
 /// Read a value: a quoted string (with backslash escapes) or a bare run up to whitespace/`}`.
-fn read_value(chars: &[char], index: &mut usize) -> String {
-    match chars.get(*index).copied() {
+fn read_value(text: &str, index: &mut usize) -> String {
+    match char_at(text, *index) {
         Some(quote @ ('"' | '\'')) => {
             *index += 1;
             let mut out = String::new();
-            while let Some(&ch) = chars.get(*index) {
+            while let Some(ch) = char_at(text, *index) {
                 if ch == '\\'
-                    && let Some(&escaped) = chars.get(*index + 1)
+                    && let Some(escaped) = char_at(text, *index + 1)
                 {
                     out.push(escaped);
-                    *index += 2;
+                    *index += 1 + escaped.len_utf8();
                     continue;
                 }
-                *index += 1;
+                *index += ch.len_utf8();
                 if ch == quote {
                     break;
                 }
@@ -162,7 +164,7 @@ fn read_value(chars: &[char], index: &mut usize) -> String {
             }
             out
         }
-        _ => read_token(chars, index),
+        _ => read_token(text, index),
     }
 }
 

--- a/crates/carta-readers/src/commonmark/autolink.rs
+++ b/crates/carta-readers/src/commonmark/autolink.rs
@@ -16,8 +16,6 @@
 
 use carta_ast::{Attr, Inline, Target};
 
-use super::scan::matches_at;
-
 /// Whether a matched autolink is a URL or an email address; selects its dialect class.
 #[derive(Clone, Copy)]
 enum Kind {
@@ -86,20 +84,18 @@ struct Match {
 
 /// Scan one text token, emitting `Str` for the gaps and `Link` for each autolink found.
 fn split_text(text: &str, markdown: bool, out: &mut Vec<Inline>) {
-    let chars: Vec<char> = text.chars().collect();
-    let len = chars.len();
+    let len = text.len();
     let mut i = 0;
     let mut emit_from = 0;
     while i < len {
         // A bare `www.` host (no scheme) autolinks only in the strict dialect; the Markdown dialect
         // links scheme URLs and emails alone.
-        let found = match_url(&chars, i)
-            .or_else(|| (!markdown).then(|| match_www(&chars, i)).flatten())
-            .or_else(|| match_email(&chars, i, emit_from, markdown));
+        let found = match_url(text, i)
+            .or_else(|| (!markdown).then(|| match_www(text, i)).flatten())
+            .or_else(|| match_email(text, i, emit_from, markdown));
         if let Some(m) = found {
-            push_text(&chars, emit_from, m.start, out);
-            if let Some(span) = chars.get(m.start..m.end) {
-                let label: String = span.iter().collect();
+            push_text(text, emit_from, m.start, out);
+            if let Some(span) = text.get(m.start..m.end) {
                 let attr = if markdown {
                     Attr {
                         id: carta_ast::Text::default(),
@@ -118,7 +114,7 @@ fn split_text(text: &str, markdown: bool, out: &mut Vec<Inline>) {
                 };
                 out.push(Inline::Link(
                     Box::new(attr),
-                    vec![Inline::Str(label.into())],
+                    vec![Inline::Str(span.into())],
                     Box::new(Target {
                         url: url.into(),
                         title: carta_ast::Text::default(),
@@ -128,35 +124,45 @@ fn split_text(text: &str, markdown: bool, out: &mut Vec<Inline>) {
             emit_from = m.end;
             i = m.end;
         } else {
-            i += 1;
+            i += char_at(text, i).map_or(1, char::len_utf8);
         }
     }
-    push_text(&chars, emit_from, len, out);
+    push_text(text, emit_from, len, out);
 }
 
-fn push_text(chars: &[char], a: usize, b: usize, out: &mut Vec<Inline>) {
-    if let Some(slice) = chars.get(a..b)
+/// The character beginning at byte offset `at`, or `None` at or past the end of `text`.
+fn char_at(text: &str, at: usize) -> Option<char> {
+    text.get(at..).and_then(|rest| rest.chars().next())
+}
+
+/// The character ending just before byte offset `at`, or `None` at the start of `text`.
+fn char_before(text: &str, at: usize) -> Option<char> {
+    text.get(..at).and_then(|head| head.chars().next_back())
+}
+
+fn push_text(text: &str, a: usize, b: usize, out: &mut Vec<Inline>) {
+    if let Some(slice) = text.get(a..b)
         && !slice.is_empty()
     {
-        out.push(Inline::Str(slice.iter().collect()));
+        out.push(Inline::Str(slice.into()));
     }
 }
 
-fn match_url(chars: &[char], i: usize) -> Option<Match> {
-    if alnum_before(chars, i) {
+fn match_url(text: &str, i: usize) -> Option<Match> {
+    if alnum_before(text, i) {
         return None;
     }
-    let scheme_len = url_scheme_len(chars, i)?;
+    let scheme_len = url_scheme_len(text, i)?;
     let content_start = i + scheme_len;
-    let scan_end = forward_scan(chars, i);
-    if !valid_host(chars.get(content_start..scan_end)?) {
+    let scan_end = forward_scan(text, i);
+    if !valid_host(text.get(content_start..scan_end)?) {
         return None;
     }
-    let end = trim_trailing(chars, content_start, scan_end);
+    let end = trim_trailing(text, content_start, scan_end);
     if end <= content_start {
         return None;
     }
-    let href: String = chars.get(i..end)?.iter().collect();
+    let href = text.get(i..end)?.to_owned();
     Some(Match {
         start: i,
         end,
@@ -170,19 +176,19 @@ fn match_url(chars: &[char], i: usize) -> Option<Match> {
 /// such prefix whose labels are non-empty and end in neither `-` nor `_`. It is usable when that
 /// prefix holds at least two labels. Whatever follows the domain (port, path, an extra dot) is not
 /// examined here — it stays part of the link.
-fn valid_host(rest: &[char]) -> bool {
+fn valid_host(rest: &str) -> bool {
     let mut labels = 0;
     let mut i = 0;
     loop {
         let start = i;
-        while rest.get(i).is_some_and(|&c| is_label_char(c)) {
-            i += 1;
+        while char_at(rest, i).is_some_and(is_label_char) {
+            i += char_at(rest, i).map_or(1, char::len_utf8);
         }
-        if i == start || matches!(rest.get(i - 1), Some('-' | '_')) {
+        if i == start || matches!(char_before(rest, i), Some('-' | '_')) {
             break;
         }
         labels += 1;
-        if rest.get(i) != Some(&'.') {
+        if char_at(rest, i) != Some('.') {
             break;
         }
         i += 1;
@@ -194,20 +200,20 @@ fn is_label_char(c: char) -> bool {
     c.is_alphanumeric() || matches!(c, '-' | '_')
 }
 
-fn match_www(chars: &[char], i: usize) -> Option<Match> {
-    if alnum_before(chars, i) || !matches_at(chars, i, "www.") {
+fn match_www(text: &str, i: usize) -> Option<Match> {
+    if alnum_before(text, i) || !text.get(i..).is_some_and(|rest| rest.starts_with("www.")) {
         return None;
     }
     let content_start = i + 4;
-    let scan_end = forward_scan(chars, i);
-    if !valid_host(chars.get(i..scan_end)?) {
+    let scan_end = forward_scan(text, i);
+    if !valid_host(text.get(i..scan_end)?) {
         return None;
     }
-    let end = trim_trailing(chars, content_start, scan_end);
+    let end = trim_trailing(text, content_start, scan_end);
     if end <= content_start {
         return None;
     }
-    let label: String = chars.get(i..end)?.iter().collect();
+    let label = text.get(i..end)?;
     let href = format!("http://{label}");
     Some(Match {
         start: i,
@@ -222,14 +228,14 @@ fn match_www(chars: &[char], i: usize) -> Option<Match> {
 /// domain extends right over `[A-Za-z0-9._-]` and must end on an alphanumeric with no empty label.
 /// The strict dialect additionally requires the domain to be dotted; the Markdown dialect accepts a
 /// single-label domain such as `5@home`.
-fn match_email(chars: &[char], at: usize, lower: usize, markdown: bool) -> Option<Match> {
-    if chars.get(at) != Some(&'@') {
+fn match_email(text: &str, at: usize, lower: usize, markdown: bool) -> Option<Match> {
+    if char_at(text, at) != Some('@') {
         return None;
     }
     let mut start = at;
     while start > lower {
-        match chars.get(start - 1) {
-            Some(&c) if is_local_char(c) => start -= 1,
+        match char_before(text, start) {
+            Some(c) if is_local_char(c) => start -= c.len_utf8(),
             _ => break,
         }
     }
@@ -237,19 +243,22 @@ fn match_email(chars: &[char], at: usize, lower: usize, markdown: bool) -> Optio
         return None;
     }
     let mut end = at + 1;
-    while chars.get(end).is_some_and(|&c| is_domain_char(c)) {
-        end += 1;
+    while char_at(text, end).is_some_and(is_domain_char) {
+        end += char_at(text, end).map_or(1, char::len_utf8);
     }
-    while end > at + 1 && chars.get(end - 1) == Some(&'.') {
+    while end > at + 1 && char_before(text, end) == Some('.') {
         end -= 1;
     }
-    let domain = chars.get(at + 1..end)?;
-    let ends_alnum = domain.last().is_some_and(char::is_ascii_alphanumeric);
-    let dotted_ok = markdown || domain.contains(&'.');
-    if !dotted_ok || !ends_alnum || domain.windows(2).any(|w| matches!(w, ['.', '.'])) {
+    let domain = text.get(at + 1..end)?;
+    let ends_alnum = domain
+        .chars()
+        .next_back()
+        .is_some_and(|c| c.is_ascii_alphanumeric());
+    let dotted_ok = markdown || domain.contains('.');
+    if !dotted_ok || !ends_alnum || domain.contains("..") {
         return None;
     }
-    let label: String = chars.get(start..end)?.iter().collect();
+    let label = text.get(start..end)?.to_owned();
     let href = format!("mailto:{label}");
     Some(Match {
         start,
@@ -261,10 +270,10 @@ fn match_email(chars: &[char], at: usize, lower: usize, markdown: bool) -> Optio
 
 /// Walk the URL run forward from `from`, stopping at whitespace or `<`, at an unbalanced `)`, or at a
 /// `]` outside any parenthesis. Returns the index just past the last character of the run.
-fn forward_scan(chars: &[char], from: usize) -> usize {
+fn forward_scan(text: &str, from: usize) -> usize {
     let mut depth: i32 = 0;
     let mut j = from;
-    while let Some(&c) = chars.get(j) {
+    while let Some(c) = char_at(text, j) {
         if c.is_whitespace() || c == '<' {
             break;
         }
@@ -274,23 +283,23 @@ fn forward_scan(chars: &[char], from: usize) -> usize {
             ')' => depth -= 1,
             _ => {}
         }
-        j += 1;
+        j += c.len_utf8();
     }
     j
 }
 
 /// Drop trailing punctuation from a URL run, never trimming below `min` (the start of the host).
 /// A trailing `;` takes its preceding `&entity;` with it when one is present.
-fn trim_trailing(chars: &[char], min: usize, mut end: usize) -> usize {
+fn trim_trailing(text: &str, min: usize, mut end: usize) -> usize {
     while end > min {
-        match chars.get(end - 1) {
+        match char_before(text, end) {
             Some('!' | '"' | '\'' | '*' | ',' | '.' | ':' | '?' | '_' | '~') => end -= 1,
             Some(';') => {
                 let mut j = end - 1;
-                while j > min && chars.get(j - 1).is_some_and(|&c| is_entity_char(c)) {
-                    j -= 1;
+                while j > min && char_before(text, j).is_some_and(is_entity_char) {
+                    j -= char_before(text, j).map_or(1, char::len_utf8);
                 }
-                end = if j > min && chars.get(j - 1) == Some(&'&') {
+                end = if j > min && char_before(text, j) == Some('&') {
                     j - 1
                 } else {
                     end - 1
@@ -302,17 +311,15 @@ fn trim_trailing(chars: &[char], min: usize, mut end: usize) -> usize {
     end
 }
 
-fn url_scheme_len(chars: &[char], i: usize) -> Option<usize> {
+fn url_scheme_len(text: &str, i: usize) -> Option<usize> {
     ["https://", "http://", "ftp://"]
         .into_iter()
-        .find(|scheme| matches_at(chars, i, scheme))
+        .find(|scheme| text.get(i..).is_some_and(|rest| rest.starts_with(scheme)))
         .map(str::len)
 }
 
-fn alnum_before(chars: &[char], i: usize) -> bool {
-    i.checked_sub(1)
-        .and_then(|p| chars.get(p))
-        .is_some_and(|c| c.is_alphanumeric())
+fn alnum_before(text: &str, i: usize) -> bool {
+    char_before(text, i).is_some_and(char::is_alphanumeric)
 }
 
 fn is_local_char(c: char) -> bool {
@@ -373,11 +380,11 @@ mod tests {
     }
 
     fn host(s: &str) -> bool {
-        valid_host(&s.chars().collect::<Vec<_>>())
+        valid_host(s)
     }
 
     fn scan(s: &str) -> usize {
-        forward_scan(&s.chars().collect::<Vec<_>>(), 0)
+        forward_scan(s, 0)
     }
 
     #[test]
@@ -411,10 +418,10 @@ mod tests {
 
     #[test]
     fn trim_trailing_drops_punctuation_and_entities() {
-        let chars: Vec<char> = "http://e.com/p.,".chars().collect();
-        assert_eq!(trim_trailing(&chars, 7, chars.len()), 14); // drops the trailing '.' and ','
-        let ent: Vec<char> = "http://e.com/p&amp;".chars().collect();
-        assert_eq!(trim_trailing(&ent, 7, ent.len()), 14); // a trailing '&entity;' goes whole
+        let url = "http://e.com/p.,";
+        assert_eq!(trim_trailing(url, 7, url.len()), 14); // drops the trailing '.' and ','
+        let ent = "http://e.com/p&amp;";
+        assert_eq!(trim_trailing(ent, 7, ent.len()), 14); // a trailing '&entity;' goes whole
     }
 
     #[test]

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -647,27 +647,20 @@ fn split_header_attr(text: &str, ext: Extensions) -> (&str, Attr) {
     if ext.contains(Extension::HeaderAttributes) || ext.contains(Extension::Attributes) {
         let trimmed = text.trim_end();
         if trimmed.ends_with('}') {
-            let chars: Vec<char> = trimmed.chars().collect();
-            for start in (0..chars.len()).rev() {
-                if chars.get(start) != Some(&'{') {
+            for (start, ch) in trimmed.char_indices().rev() {
+                if ch != '{' {
                     continue;
                 }
                 // The block must be set off from the heading text by whitespace, else it belongs to
                 // the preceding word rather than the heading.
-                let preceded_by_space = start == 0
-                    || chars
-                        .get(start - 1)
-                        .copied()
-                        .is_some_and(is_unicode_whitespace);
+                let preceded_by_space =
+                    start == 0 || char_before(trimmed, start).is_some_and(is_unicode_whitespace);
                 if preceded_by_space
-                    && let Some((attr, end)) = attr::parse_attributes_chars(&chars, start)
-                    && end == chars.len()
+                    && let Some((attr, end)) = attr::parse_attributes_bytes(trimmed, start)
+                    && end == trimmed.len()
                     && attr::is_non_empty(&attr)
                 {
-                    let byte_start: usize = chars
-                        .get(..start)
-                        .map_or(0, |s| s.iter().map(|c| c.len_utf8()).sum());
-                    let content = text.get(..byte_start).unwrap_or(text).trim_end();
+                    let content = text.get(..start).unwrap_or(text).trim_end();
                     return (content, attr);
                 }
             }
@@ -698,14 +691,14 @@ fn split_mmd_header_id(text: &str) -> Option<(&str, String)> {
     if !trimmed.ends_with(']') {
         return None;
     }
-    let chars: Vec<char> = trimmed.chars().collect();
-    let close = chars.len().checked_sub(1)?;
+    // The closing `]` is ASCII, so it occupies the final byte of `trimmed`.
+    let close = trimmed.len().checked_sub(1)?;
     let mut depth = 0i32;
     let mut open = None;
-    for i in (0..chars.len()).rev() {
-        match chars.get(i).copied() {
-            Some(']') => depth += 1,
-            Some('[') => {
+    for (i, ch) in trimmed.char_indices().rev() {
+        match ch {
+            ']' => depth += 1,
+            '[' => {
                 depth -= 1;
                 if depth == 0 {
                     open = Some(i);
@@ -719,27 +712,23 @@ fn split_mmd_header_id(text: &str) -> Option<(&str, String)> {
     // A bracket group directly before the label (only whitespace between) makes the pair a
     // reference-link construct, not an identifier.
     let mut before = open;
-    while before > 0
-        && chars
-            .get(before - 1)
-            .copied()
-            .is_some_and(is_unicode_whitespace)
-    {
-        before -= 1;
+    while let Some(c) = char_before(trimmed, before) {
+        if c.is_whitespace() {
+            before -= c.len_utf8();
+        } else {
+            break;
+        }
     }
-    if before > 0 && chars.get(before - 1) == Some(&']') {
+    if char_before(trimmed, before) == Some(']') {
         return None;
     }
-    let id: String = chars
+    let id: String = trimmed
         .get(open + 1..close)?
-        .iter()
+        .chars()
         .filter(|c| !c.is_whitespace())
-        .flat_map(|c| c.to_lowercase())
+        .flat_map(char::to_lowercase)
         .collect();
-    let byte_open: usize = chars
-        .get(..open)
-        .map_or(0, |s| s.iter().map(|c| c.len_utf8()).sum());
-    let content = text.get(..byte_open).unwrap_or(text).trim_end();
+    let content = text.get(..open).unwrap_or(text).trim_end();
     Some((content, id))
 }
 
@@ -801,11 +790,20 @@ fn resolve_inline_nodes(mut nodes: Vec<Node>, ext: Extensions, markdown: bool) -
     collapse(nodes)
 }
 
+/// The character beginning at byte offset `at`, or `None` at or past the end of `text`.
+fn char_at(text: &str, at: usize) -> Option<char> {
+    text.get(at..).and_then(|rest| rest.chars().next())
+}
+
+/// The character ending just before byte offset `at`, or `None` at the start of `text`.
+fn char_before(text: &str, at: usize) -> Option<char> {
+    text.get(..at).and_then(|head| head.chars().next_back())
+}
+
 #[allow(clippy::similar_names)]
 fn parse_inlines(text: &str, refs: &RefMap, notes: RefContext, ext: Extensions) -> Vec<Inline> {
-    let chars: Vec<char> = text.chars().collect();
     let mut parser = InlineParser {
-        chars: &chars,
+        text,
         pos: 0,
         nodes: Vec::new(),
         refs,
@@ -847,7 +845,8 @@ pub(crate) fn parse_meta_inlines(text: &str, ext: Extensions, markdown: bool) ->
 }
 
 struct InlineParser<'a> {
-    chars: &'a [char],
+    text: &'a str,
+    /// Cursor as a byte offset into `text`; every mutation lands on a UTF-8 character boundary.
     pos: usize,
     nodes: Vec<Node>,
     refs: &'a RefMap,
@@ -859,11 +858,11 @@ struct InlineParser<'a> {
     /// For each ASCII code, whether a character can start a syntactic construct under the active
     /// extensions. Everything else is ordinary text a run scan can skip over in one step.
     interesting: [bool; 128],
-    /// Start positions of every maximal backtick run in `chars`, grouped by run length and
-    /// ascending within each group. Built lazily on the first code-span attempt (`None` until
-    /// then, so backtick-free text pays nothing) and immutable afterwards: it stays valid because
-    /// `chars` never changes during inline parsing. A feature that mutated the buffer mid-parse
-    /// would have to rebuild it.
+    /// Byte offsets of every maximal backtick run in `text`, grouped by run length and ascending
+    /// within each group. Built lazily on the first code-span attempt (`None` until then, so
+    /// backtick-free text pays nothing) and immutable afterwards: it stays valid because `text`
+    /// never changes during inline parsing. A feature that mutated the buffer mid-parse would have
+    /// to rebuild it.
     backtick_runs: Option<BTreeMap<usize, Vec<usize>>>,
 }
 
@@ -892,11 +891,13 @@ fn interesting_chars(ext: Extensions) -> [bool; 128] {
 
 impl InlineParser<'_> {
     fn peek(&self) -> Option<char> {
-        self.chars.get(self.pos).copied()
+        char_at(self.text, self.pos)
     }
 
     fn at(&self, offset: usize) -> Option<char> {
-        self.chars.get(self.pos + offset).copied()
+        self.text
+            .get(self.pos..)
+            .and_then(|rest| rest.chars().nth(offset))
     }
 
     fn is_interesting(&self, ch: char) -> bool {
@@ -907,18 +908,32 @@ impl InlineParser<'_> {
             .unwrap_or(false)
     }
 
+    /// Whether the byte at `pos` begins an interesting construct. Every interesting trigger is an
+    /// ASCII character, so a byte `>= 128` (any part of a multi-byte character) is never a boundary
+    /// this scan stops on — the run scan can advance one byte at a time and still break only on a
+    /// character boundary.
+    fn interesting_byte(&self, byte: u8) -> bool {
+        byte < 128
+            && self
+                .interesting
+                .get(usize::from(byte))
+                .copied()
+                .unwrap_or(false)
+    }
+
     fn run(&mut self) {
         while let Some(ch) = self.peek() {
             if !self.is_interesting(ch) {
                 let start = self.pos;
-                while let Some(&next) = self.chars.get(self.pos) {
-                    if self.is_interesting(next) {
+                let bytes = self.text.as_bytes();
+                while let Some(&next) = bytes.get(self.pos) {
+                    if self.interesting_byte(next) {
                         break;
                     }
                     self.pos += 1;
                 }
-                if let Some(run) = self.chars.get(start..self.pos) {
-                    self.push_chars(run);
+                if let Some(run) = self.text.get(start..self.pos) {
+                    self.push_str(run);
                 }
                 continue;
             }
@@ -965,7 +980,7 @@ impl InlineParser<'_> {
                 }
                 ']' => self.close_bracket(),
                 _ => {
-                    self.pos += 1;
+                    self.pos += ch.len_utf8();
                     self.push_text(ch);
                 }
             }
@@ -988,14 +1003,6 @@ impl InlineParser<'_> {
         }
     }
 
-    fn push_chars(&mut self, run: &[char]) {
-        if let Some(Node::Text(text)) = self.nodes.last_mut() {
-            text.extend(run.iter());
-        } else {
-            self.nodes.push(Node::Text(run.iter().collect()));
-        }
-    }
-
     /// Resolve an `@` at the cursor. An example-list label assigned a number becomes that number; a
     /// well-formed citation key becomes a bare author-in-text `Cite`; anything else leaves the `@`
     /// as literal text, so the rest of the run reparses normally.
@@ -1014,23 +1021,24 @@ impl InlineParser<'_> {
     /// item is replaced with that number and the cursor advances past it, returning `true`. An
     /// undefined or empty label leaves the cursor in place and returns `false`.
     fn try_example_ref(&mut self) -> bool {
-        let mut len = 0;
+        // The `@` and every label character (`[0-9A-Za-z_-]`) are ASCII, so byte and character
+        // offsets coincide across the label.
+        let name_start = self.pos + 1;
+        let mut end = name_start;
         while matches!(
-            self.at(1 + len),
+            char_at(self.text, end),
             Some('0'..='9' | 'a'..='z' | 'A'..='Z' | '-' | '_')
         ) {
-            len += 1;
+            end += 1;
         }
-        if len == 0 {
+        if end == name_start {
             return false;
         }
-        let label: String = self
-            .chars
-            .get(self.pos + 1..self.pos + 1 + len)
-            .map(|run| run.iter().collect())
-            .unwrap_or_default();
-        if let Some(number) = self.notes.examples.get(&label) {
-            self.pos += 1 + len;
+        let Some(label) = self.text.get(name_start..end) else {
+            return false;
+        };
+        if let Some(number) = self.notes.examples.get(label) {
+            self.pos = end;
             self.push_str(&number.to_string());
             return true;
         }
@@ -1043,10 +1051,10 @@ impl InlineParser<'_> {
     /// single-entry `Cite` is pushed whose fallback text is the literal `@key`. Returns `false`
     /// (without advancing) otherwise, leaving the `@` for literal handling.
     fn try_bare_citation(&mut self) -> bool {
-        if self.pos > 0 && matches!(self.chars.get(self.pos - 1), Some(c) if is_citation_word(*c)) {
+        if matches!(char_before(self.text, self.pos), Some(c) if is_citation_word(c)) {
             return false;
         }
-        let Some((id, next)) = scan_citation_id(self.chars, self.pos + 1) else {
+        let Some((id, next)) = scan_citation_id(self.text, self.pos + 1) else {
             return false;
         };
         let note_num = self.bump_cite_count();
@@ -1080,22 +1088,22 @@ impl InlineParser<'_> {
     /// past the closing `:` and `true` is returned. An unrecognized name (or no closing `:`) leaves
     /// the leading `:` untouched and returns `false`, so the run reparses as literal text.
     fn try_emoji(&mut self) -> bool {
+        // The `:` delimiters and every name character (`[0-9A-Za-z_+-]`) are ASCII.
         let name_start = self.pos + 1;
         let mut index = name_start;
         while matches!(
-            self.chars.get(index),
+            char_at(self.text, index),
             Some('0'..='9' | 'a'..='z' | 'A'..='Z' | '_' | '+' | '-')
         ) {
             index += 1;
         }
-        if index == name_start || self.chars.get(index) != Some(&':') {
+        if index == name_start || char_at(self.text, index) != Some(':') {
             return false;
         }
-        let name: String = match self.chars.get(name_start..index) {
-            Some(slice) => slice.iter().collect(),
-            None => return false,
+        let Some(name) = self.text.get(name_start..index) else {
+            return false;
         };
-        let Some(codepoints) = emoji::lookup(&name) else {
+        let Some(codepoints) = emoji::lookup(name) else {
             return false;
         };
         let attr = Attr {
@@ -1121,40 +1129,42 @@ impl InlineParser<'_> {
     fn try_short_script(&mut self, delimiter: char) -> bool {
         let mut preceding = 0usize;
         let mut behind = self.pos;
-        while behind > 0 {
-            match self.chars.get(behind - 1).copied() {
-                Some(ch) if ch.is_whitespace() => break,
-                Some(ch) => {
-                    if ch == delimiter {
-                        preceding += 1;
-                    }
-                    behind -= 1;
-                }
-                None => break,
+        while let Some(ch) = char_before(self.text, behind) {
+            if ch.is_whitespace() {
+                break;
             }
+            if ch == delimiter {
+                preceding += 1;
+            }
+            behind -= ch.len_utf8();
         }
         // An odd count leaves this delimiter closing a prior opener, never starting a short script.
         if preceding % 2 == 1 {
             return false;
         }
         // An opener pairs into the delimited form when another matching delimiter follows in-span.
+        // The delimiter (`~`/`^`) is ASCII, so the span begins one byte past the cursor.
         let mut ahead = self.pos + 1;
-        while let Some(&ch) = self.chars.get(ahead) {
+        while let Some(ch) = char_at(self.text, ahead) {
             if ch.is_whitespace() {
                 break;
             }
             if ch == delimiter {
                 return false;
             }
-            ahead += 1;
+            ahead += ch.len_utf8();
         }
         let start = self.pos + 1;
         let mut end = start;
-        while self.chars.get(end).is_some_and(|ch| ch.is_alphanumeric()) {
-            end += 1;
+        while let Some(ch) = char_at(self.text, end) {
+            if ch.is_alphanumeric() {
+                end += ch.len_utf8();
+            } else {
+                break;
+            }
         }
-        let content: String = match self.chars.get(start..end) {
-            Some(slice) if !slice.is_empty() => slice.iter().collect(),
+        let content = match self.text.get(start..end) {
+            Some(slice) if !slice.is_empty() => slice,
             _ => return false,
         };
         let inner = vec![Inline::Str(content.into())];
@@ -1222,14 +1232,14 @@ impl InlineParser<'_> {
     /// Returns `true` (and advances past the closer) on a match, leaving a fallback escape otherwise.
     fn try_backslash_math(&mut self) -> bool {
         if self.ext.contains(Extension::TexMathDoubleBackslash)
-            && self.chars.get(self.pos) == Some(&'\\')
-            && self.chars.get(self.pos + 1) == Some(&'\\')
+            && char_at(self.text, self.pos) == Some('\\')
+            && char_at(self.text, self.pos + 1) == Some('\\')
             && self.scan_backslash_math(2)
         {
             return true;
         }
         if self.ext.contains(Extension::TexMathSingleBackslash)
-            && self.chars.get(self.pos) == Some(&'\\')
+            && char_at(self.text, self.pos) == Some('\\')
             && self.scan_backslash_math(1)
         {
             return true;
@@ -1238,9 +1248,9 @@ impl InlineParser<'_> {
     }
 
     /// Scan a backslash math span at the cursor (on the first backslash), pushing a `Math` node and
-    /// advancing past the closer on a match. See [`crate::inline_scan::scan_backslash_math`].
+    /// advancing past the closer on a match. See [`crate::inline_scan::scan_backslash_math_bytes`].
     fn scan_backslash_math(&mut self, slashes: usize) -> bool {
-        match crate::inline_scan::scan_backslash_math(self.chars, self.pos, slashes) {
+        match crate::inline_scan::scan_backslash_math_bytes(self.text, self.pos, slashes) {
             Some((math_type, content, next)) => {
                 self.pos = next;
                 self.nodes
@@ -1269,16 +1279,18 @@ impl InlineParser<'_> {
         if !self.ext.contains(Extension::RawTex) {
             return false;
         }
-        if self.chars.get(self.pos) != Some(&'\\') {
+        if char_at(self.text, self.pos) != Some('\\') {
             return false;
         }
+        // The leading `\` and the command name (ASCII letters and digits) are single-byte, so
+        // byte and character offsets coincide up to `i`.
         let mut i = self.pos + 1;
-        if !self.chars.get(i).is_some_and(char::is_ascii_alphabetic) {
+        if !char_at(self.text, i).is_some_and(|c| c.is_ascii_alphabetic()) {
             return false;
         }
         i += 1;
         let mut name_all_letters = true;
-        while let Some(&ch) = self.chars.get(i) {
+        while let Some(ch) = char_at(self.text, i) {
             if ch.is_ascii_alphabetic() {
                 i += 1;
             } else if ch.is_ascii_digit() {
@@ -1290,17 +1302,17 @@ impl InlineParser<'_> {
         }
         // `\begin`/`\end` are raw TeX only as a complete, matched environment, never as bare
         // commands: capture the whole `\begin{ENV}`…`\end{ENV}`, or leave the text literal.
-        let name = self.chars.get(self.pos + 1..i);
-        if name.is_some_and(|n| "begin".chars().eq(n.iter().copied())) {
+        let name = self.text.get(self.pos + 1..i);
+        if name == Some("begin") {
             return self.try_raw_tex_environment(i);
         }
-        if name.is_some_and(|n| "end".chars().eq(n.iter().copied())) {
+        if name == Some("end") {
             return false;
         }
         // Consume argument groups. A `{`-group must balance or the entire command reverts to text.
         let mut had_group = false;
         loop {
-            match self.chars.get(i).copied() {
+            match char_at(self.text, i) {
                 Some('{') => match self.scan_balanced_group(i, '{', '}') {
                     Some(end) => {
                         i = end;
@@ -1322,13 +1334,13 @@ impl InlineParser<'_> {
         // A bare command whose name is all letters (no argument groups, no digits) absorbs a
         // trailing run of spaces and tabs.
         if !had_group && name_all_letters {
-            while matches!(self.chars.get(i).copied(), Some(' ' | '\t')) {
+            while matches!(char_at(self.text, i), Some(' ' | '\t')) {
                 i += 1;
             }
         }
 
-        let source: String = match self.chars.get(self.pos..i) {
-            Some(slice) => slice.iter().collect(),
+        let source = match self.text.get(self.pos..i) {
+            Some(slice) => slice.to_owned(),
             None => return false,
         };
         self.pos = i;
@@ -1345,21 +1357,22 @@ impl InlineParser<'_> {
     /// depth to zero. Without a `{ENV}` group or a matching close the `\begin` is not raw TeX and
     /// the call reverts to literal text by returning `false`.
     fn try_raw_tex_environment(&mut self, name_end: usize) -> bool {
-        if self.chars.get(name_end).copied() != Some('{') {
+        if char_at(self.text, name_end) != Some('{') {
             return false;
         }
         let Some(group_end) = self.scan_balanced_group(name_end, '{', '}') else {
             return false;
         };
-        let env: Vec<char> = match self.chars.get(name_end + 1..group_end - 1) {
-            Some(slice) => slice.to_vec(),
-            None => return false,
-        };
-        let Some(end) = self.scan_environment_close(group_end, &env) else {
+        // `group_end` sits just past the closing `}` (ASCII), so `group_end - 1` is its byte offset
+        // and `name_end + 1` the byte past the opening `{`.
+        let Some(env) = self.text.get(name_end + 1..group_end - 1) else {
             return false;
         };
-        let source: String = match self.chars.get(self.pos..end) {
-            Some(slice) => slice.iter().collect(),
+        let Some(end) = self.scan_environment_close(group_end, env) else {
+            return false;
+        };
+        let source = match self.text.get(self.pos..end) {
+            Some(slice) => slice.to_owned(),
             None => return false,
         };
         self.pos = end;
@@ -1372,11 +1385,11 @@ impl InlineParser<'_> {
 
     /// From `from`, find the index just past the `\end{ENV}` that closes an open `\begin{ENV}`,
     /// tracking nested same-name environments by depth. `None` when no matching close is found.
-    fn scan_environment_close(&self, from: usize, env: &[char]) -> Option<usize> {
+    fn scan_environment_close(&self, from: usize, env: &str) -> Option<usize> {
         let mut depth = 1usize;
         let mut i = from;
-        while i < self.chars.len() {
-            if self.chars.get(i).copied() == Some('\\') {
+        while let Some(ch) = char_at(self.text, i) {
+            if ch == '\\' {
                 if let Some(after) = self.match_environment_marker(i, "begin", env) {
                     depth += 1;
                     i = after;
@@ -1391,36 +1404,36 @@ impl InlineParser<'_> {
                     continue;
                 }
             }
-            i += 1;
+            i += ch.len_utf8();
         }
         None
     }
 
     /// If the characters at `at` spell `\KEYWORD{ENV}` (e.g. `\end{equation}`), return the index
     /// just past the closing brace; otherwise `None`.
-    fn match_environment_marker(&self, at: usize, keyword: &str, env: &[char]) -> Option<usize> {
+    fn match_environment_marker(&self, at: usize, keyword: &str, env: &str) -> Option<usize> {
         let mut i = at;
-        if self.chars.get(i).copied() != Some('\\') {
+        if char_at(self.text, i) != Some('\\') {
             return None;
         }
         i += 1;
         for kc in keyword.chars() {
-            if self.chars.get(i).copied() != Some(kc) {
+            if char_at(self.text, i) != Some(kc) {
                 return None;
             }
-            i += 1;
+            i += kc.len_utf8();
         }
-        if self.chars.get(i).copied() != Some('{') {
+        if char_at(self.text, i) != Some('{') {
             return None;
         }
         i += 1;
-        for &ec in env {
-            if self.chars.get(i).copied() != Some(ec) {
+        for ec in env.chars() {
+            if char_at(self.text, i) != Some(ec) {
                 return None;
             }
-            i += 1;
+            i += ec.len_utf8();
         }
-        if self.chars.get(i).copied() != Some('}') {
+        if char_at(self.text, i) != Some('}') {
             return None;
         }
         Some(i + 1)
@@ -1428,11 +1441,11 @@ impl InlineParser<'_> {
 
     /// Scan a balanced group `open`…`close` starting at index `start` (which must hold `open`),
     /// returning the index just past the matching `close`, or `None` if it never closes. Nested
-    /// same-kind delimiters are tracked by depth.
+    /// same-kind delimiters are tracked by depth. `open` and `close` are ASCII delimiters.
     fn scan_balanced_group(&self, start: usize, open: char, close: char) -> Option<usize> {
         let mut depth = 0usize;
         let mut i = start;
-        while let Some(&ch) = self.chars.get(i) {
+        while let Some(ch) = char_at(self.text, i) {
             if ch == open {
                 depth += 1;
             } else if ch == close {
@@ -1441,20 +1454,20 @@ impl InlineParser<'_> {
                     return Some(i + 1);
                 }
             }
-            i += 1;
+            i += ch.len_utf8();
         }
         None
     }
 
     fn code_span(&mut self) {
         let start = self.pos;
-        let open = backtick_run_len(self.chars, self.pos);
+        let open = backtick_run_len(self.text, self.pos);
         self.pos += open;
         if let Some(close) = self.next_backtick_run(open, self.pos) {
-            let content: String = self
-                .chars
+            let content = self
+                .text
                 .get(self.pos..close)
-                .map(|s| s.iter().collect())
+                .map(str::to_owned)
                 .unwrap_or_default();
             self.pos = close + open;
             if let Some((format, next)) = self.scan_raw_format() {
@@ -1473,10 +1486,10 @@ impl InlineParser<'_> {
             return;
         }
         // No closing run: emit the opening backticks literally.
-        let literal: String = self
-            .chars
+        let literal = self
+            .text
             .get(start..self.pos)
-            .map(|s| s.iter().collect())
+            .map(str::to_owned)
             .unwrap_or_default();
         self.push_str(&literal);
     }
@@ -1486,13 +1499,16 @@ impl InlineParser<'_> {
     /// keyed by run length; the index is built once on first use and then binary-searched, so a
     /// close search costs O(log n) rather than a scan to end-of-buffer.
     fn next_backtick_run(&mut self, len: usize, from: usize) -> Option<usize> {
-        let chars = self.chars;
+        let text = self.text;
         let runs = self.backtick_runs.get_or_insert_with(|| {
             let mut index: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+            let bytes = text.as_bytes();
             let mut scan = 0;
-            while scan < chars.len() {
-                if chars.get(scan) == Some(&'`') {
-                    let run = backtick_run_len(chars, scan);
+            while scan < bytes.len() {
+                // The backtick is ASCII, so advancing one byte over any non-backtick byte (including
+                // every byte of a multi-byte character) never lands mid-run or records a false start.
+                if bytes.get(scan) == Some(&b'`') {
+                    let run = backtick_run_len(text, scan);
                     index.entry(run).or_default().push(scan);
                     scan += run;
                 } else {
@@ -1516,7 +1532,7 @@ impl InlineParser<'_> {
     fn dollar_math(&mut self) {
         if self.at(1) == Some('$') {
             if let Some((content, next)) =
-                crate::inline_scan::scan_display_math(self.chars, self.pos)
+                crate::inline_scan::scan_display_math_bytes(self.text, self.pos)
             {
                 self.pos = next;
                 self.nodes.push(Node::Inline(Inline::Math(
@@ -1526,7 +1542,7 @@ impl InlineParser<'_> {
                 return;
             }
         } else if let Some((content, next)) =
-            crate::inline_scan::scan_inline_math(self.chars, self.pos)
+            crate::inline_scan::scan_inline_math_bytes(self.text, self.pos)
         {
             self.pos = next;
             self.nodes.push(Node::Inline(Inline::Math(
@@ -1540,7 +1556,7 @@ impl InlineParser<'_> {
     }
 
     fn left_angle(&mut self) {
-        if let Some((inline, next)) = scan_autolink(self.chars, self.pos) {
+        if let Some((inline, next)) = scan_autolink(self.text, self.pos) {
             self.pos = next;
             // The markdown dialect tags an explicit angle autolink with a `uri` or `email` class
             // and percent-encodes its destination; the strict dialect leaves it unclassed and
@@ -1554,7 +1570,7 @@ impl InlineParser<'_> {
             self.nodes.push(Node::Inline(inline));
             return;
         }
-        if let Some((html, next)) = scan_html_tag(self.chars, self.pos) {
+        if let Some((html, next)) = scan_html_tag(self.text, self.pos) {
             self.pos = next;
             // In the Markdown dialect with `raw_html` off the tag is still recognized as a unit but
             // kept as literal text rather than a passthrough span. The bare CommonMark engine always
@@ -1574,7 +1590,7 @@ impl InlineParser<'_> {
     }
 
     fn entity(&mut self) {
-        if let Some((decoded, next)) = scan_entity(self.chars, self.pos) {
+        if let Some((decoded, next)) = scan_entity(self.text, self.pos) {
             self.pos = next;
             self.push_str(&decoded);
         } else {
@@ -1611,12 +1627,9 @@ impl InlineParser<'_> {
         while self.peek() == Some(ch as char) {
             self.pos += 1;
         }
+        // The delimiter is ASCII, so the run's byte length equals its character count.
         let count = self.pos - start;
-        let before = if start == 0 {
-            None
-        } else {
-            self.chars.get(start - 1).copied()
-        };
+        let before = char_before(self.text, start);
         let after = self.peek();
         // With `intraword_underscores` off in the Markdown dialect, a `_` run pairs like `*`,
         // emphasizing even between word characters; otherwise the CommonMark `_` rule keeps an
@@ -1766,8 +1779,7 @@ impl InlineParser<'_> {
     /// the brackets for literal handling) when the content is not a citation list.
     fn try_bracket_citation(&mut self, opener_index: usize, is_image: bool) -> bool {
         let raw = self.raw_label(opener_index);
-        let raw_chars: Vec<char> = raw.chars().collect();
-        let Some(segments) = split_citation_segments(&raw_chars) else {
+        let Some(segments) = split_citation_segments(&raw) else {
             return false;
         };
         // Scanning the interior may have counted bare citations that are about to be discarded with
@@ -1783,7 +1795,7 @@ impl InlineParser<'_> {
         self.bump_cite_count();
         let mut citations = Vec::with_capacity(segments.len());
         for segment in &segments {
-            let Some(entry) = self.parse_citation_entry(&raw_chars, segment.clone()) else {
+            let Some(entry) = self.parse_citation_entry(&raw, segment.clone()) else {
                 return false;
             };
             citations.push(entry);
@@ -1807,15 +1819,11 @@ impl InlineParser<'_> {
     /// text before it as the prefix and the text after as the suffix. A `-` directly before the key
     /// (itself at the segment start or preceded by whitespace) suppresses the author. Returns `None`
     /// when the segment holds no top-level key.
-    fn parse_citation_entry(
-        &self,
-        chars: &[char],
-        range: std::ops::Range<usize>,
-    ) -> Option<Citation> {
-        let key = find_citation_key(chars, range.clone())?;
+    fn parse_citation_entry(&self, raw: &str, range: std::ops::Range<usize>) -> Option<Citation> {
+        let key = find_citation_key(raw, range.clone())?;
         let prefix_end = if key.suppress { key.dash } else { key.at };
-        let prefix_src: String = chars.get(range.start..prefix_end)?.iter().collect();
-        let suffix_src: String = chars.get(key.id_end..range.end)?.iter().collect();
+        let prefix_src = raw.get(range.start..prefix_end)?;
+        let suffix_src = raw.get(key.id_end..range.end)?;
         let mode = if key.suppress {
             CitationMode::SuppressAuthor
         } else {
@@ -1852,8 +1860,8 @@ impl InlineParser<'_> {
     /// [`Attr`], with the position past the last block. An empty block (`{}`) alone is not consumed;
     /// a space between blocks ends the run.
     fn scan_attr_block(&self) -> Option<(Attr, usize)> {
-        let (mut merged, mut next) = attr::parse_attributes_chars(self.chars, self.pos)?;
-        while let Some((more, after)) = attr::parse_attributes_chars(self.chars, next) {
+        let (mut merged, mut next) = attr::parse_attributes_bytes(self.text, self.pos)?;
+        while let Some((more, after)) = attr::parse_attributes_bytes(self.text, next) {
             attr::merge(&mut merged, more);
             next = after;
         }
@@ -1869,25 +1877,25 @@ impl InlineParser<'_> {
         if !self.ext.contains(Extension::RawAttribute) {
             return None;
         }
-        if self.chars.get(self.pos).copied() != Some('{') {
+        if char_at(self.text, self.pos) != Some('{') {
             return None;
         }
         let mut index = self.pos + 1;
-        while let Some(&ch) = self.chars.get(index) {
+        while let Some(ch) = char_at(self.text, index) {
             if ch == ' ' || ch == '\t' {
                 index += 1;
             } else {
                 break;
             }
         }
-        if self.chars.get(index).copied() != Some('=') {
+        if char_at(self.text, index) != Some('=') {
             return None;
         }
         index += 1;
         let format_start = index;
-        while let Some(&ch) = self.chars.get(index) {
+        while let Some(ch) = char_at(self.text, index) {
             if is_format_name_char(ch) {
-                index += 1;
+                index += ch.len_utf8();
             } else {
                 break;
             }
@@ -1895,15 +1903,15 @@ impl InlineParser<'_> {
         if index == format_start {
             return None;
         }
-        let format: String = self.chars.get(format_start..index)?.iter().collect();
-        while let Some(&ch) = self.chars.get(index) {
+        let format = self.text.get(format_start..index)?.to_owned();
+        while let Some(ch) = char_at(self.text, index) {
             if ch == ' ' || ch == '\t' {
                 index += 1;
             } else {
                 break;
             }
         }
-        if self.chars.get(index).copied() != Some('}') {
+        if char_at(self.text, index) != Some('}') {
             return None;
         }
         Some((format, index + 1))
@@ -1980,9 +1988,9 @@ impl InlineParser<'_> {
             // The markdown dialect lets an unbracketed destination hold spaces and balanced
             // parentheses; the strict dialect ends a destination at the first space.
             let scanned = if self.notes.markdown {
-                scan_markdown_inline_target(self.chars, self.pos)
+                scan_markdown_inline_target(self.text, self.pos)
             } else {
-                scan_inline_target(self.chars, self.pos)
+                scan_inline_target(self.text, self.pos)
             };
             if let Some((target, next)) = scanned {
                 return Explicit::Target(target, next);
@@ -1994,14 +2002,11 @@ impl InlineParser<'_> {
         // target handled above.
         let mut label_start = self.pos;
         if self.ext.contains(Extension::SpacedReferenceLinks) {
-            while matches!(
-                self.chars.get(label_start).copied(),
-                Some(' ' | '\t' | '\n')
-            ) {
+            while matches!(char_at(self.text, label_start), Some(' ' | '\t' | '\n')) {
                 label_start += 1;
             }
         }
-        if let Some((label, next)) = scan_following_label(self.chars, label_start) {
+        if let Some((label, next)) = scan_following_label(self.text, label_start) {
             let key = if label.is_empty() {
                 normalize_label(&self.raw_label(opener_index))
             } else {
@@ -2021,9 +2026,10 @@ impl InlineParser<'_> {
             Some(Node::Delimiter(d)) => d.text_start,
             _ => return String::new(),
         };
-        self.chars
+        // The closing `]` is ASCII, so its byte offset is `self.pos - 1`.
+        self.text
             .get(start..self.pos.saturating_sub(1))
-            .map(|s| s.iter().collect())
+            .map(str::to_owned)
             .unwrap_or_default()
     }
 
@@ -2064,13 +2070,14 @@ impl InlineParser<'_> {
     /// becomes a single-paragraph `Note`. Returns `false` without advancing when the bracket has no
     /// balanced closer, leaving the `^` for literal/superscript handling.
     fn try_inline_note(&mut self) -> bool {
-        // self.pos is the caret; the `[` sits at self.pos + 1. Walk forward tracking bracket depth.
+        // self.pos is the caret; the `[` sits at self.pos + 1 (the `^` is ASCII). Walk forward
+        // tracking bracket depth.
         let mut depth = 0usize;
         let mut index = self.pos + 1;
         let mut end = None;
-        while let Some(&ch) = self.chars.get(index) {
+        while let Some(ch) = char_at(self.text, index) {
             match ch {
-                '\\' => index += 2,
+                '\\' => index += 1 + char_at(self.text, index + 1).map_or(0, char::len_utf8),
                 '[' => {
                     depth += 1;
                     index += 1;
@@ -2083,16 +2090,18 @@ impl InlineParser<'_> {
                         break;
                     }
                 }
-                _ => index += 1,
+                _ => index += ch.len_utf8(),
             }
         }
         let Some(end) = end else {
             return false;
         };
-        let inner: String = self
-            .chars
+        // The bracket content lies between `[` (at self.pos + 1) and the closing `]` (ASCII, at
+        // end - 1).
+        let inner = self
+            .text
             .get(self.pos + 2..end.saturating_sub(1))
-            .map(|run| run.iter().collect())
+            .map(str::to_owned)
             .unwrap_or_default();
         let inlines = parse_inlines(&inner, self.refs, self.notes, self.ext);
         self.pos = end;
@@ -2181,36 +2190,37 @@ fn is_citation_key_start(ch: char) -> bool {
 /// `:`, and `/` extend it only when another key character follows, so a trailing `-key.` keeps the
 /// `key` but drops the `.`. Returns the key text and the index just past it, or `None` when no key
 /// begins at `start`.
-fn scan_citation_id(chars: &[char], start: usize) -> Option<(String, usize)> {
-    let first = chars.get(start).copied()?;
+fn scan_citation_id(text: &str, start: usize) -> Option<(String, usize)> {
+    let first = char_at(text, start)?;
     if !is_citation_key_start(first) {
         return None;
     }
-    let mut end = start + 1;
-    while let Some(&ch) = chars.get(end) {
+    let mut end = start + first.len_utf8();
+    while let Some(ch) = char_at(text, end) {
         if is_citation_key_start(ch) {
-            end += 1;
+            end += ch.len_utf8();
         } else if matches!(ch, '-' | '.' | ':' | '/')
-            && matches!(chars.get(end + 1), Some(&next) if is_citation_key_start(next))
+            // The internal punctuation is ASCII, so the following key character begins one byte on.
+            && matches!(char_at(text, end + 1), Some(next) if is_citation_key_start(next))
         {
-            end += 2;
+            end += 1 + char_at(text, end + 1).map_or(0, char::len_utf8);
         } else {
             break;
         }
     }
-    let id: String = chars.get(start..end)?.iter().collect();
+    let id = text.get(start..end)?.to_owned();
     Some((id, end))
 }
 
 /// Advance past one escape, backtick code span, or bracket at `index`, updating bracket `depth` and
 /// returning the next index. Returns `None` when the character is none of those — the caller then
 /// inspects it for a top-level delimiter (`;` or `@`) and advances itself.
-fn step_citation_scan(chars: &[char], index: usize, depth: &mut usize) -> Option<usize> {
-    match chars.get(index) {
-        Some('\\') => Some(index + 2),
+fn step_citation_scan(text: &str, index: usize, depth: &mut usize) -> Option<usize> {
+    match char_at(text, index) {
+        Some('\\') => Some(index + 1 + char_at(text, index + 1).map_or(0, char::len_utf8)),
         Some('`') => {
-            let run = backtick_run_len(chars, index);
-            Some(skip_code_span(chars, index, run))
+            let run = backtick_run_len(text, index);
+            Some(skip_code_span(text, index, run))
         }
         Some('[') => {
             *depth += 1;
@@ -2228,31 +2238,31 @@ fn step_citation_scan(chars: &[char], index: usize, depth: &mut usize) -> Option
 /// a nested `[...]` or a backtick code span does not split. Returns `None` when the content is not a
 /// citation list: it has no `@` at all, or any segment is empty (including a leading or trailing
 /// empty segment from a stray semicolon).
-fn split_citation_segments(chars: &[char]) -> Option<Vec<std::ops::Range<usize>>> {
-    if !chars.contains(&'@') {
+fn split_citation_segments(text: &str) -> Option<Vec<std::ops::Range<usize>>> {
+    if !text.contains('@') {
         return None;
     }
     let mut segments = Vec::new();
     let mut start = 0;
     let mut index = 0;
     let mut depth = 0usize;
-    while index < chars.len() {
-        if let Some(next) = step_citation_scan(chars, index, &mut depth) {
+    while index < text.len() {
+        if let Some(next) = step_citation_scan(text, index, &mut depth) {
             index = next;
-        } else if chars.get(index) == Some(&';') && depth == 0 {
+        } else if char_at(text, index) == Some(';') && depth == 0 {
             segments.push(start..index);
             start = index + 1;
             index += 1;
         } else {
-            index += 1;
+            index += char_at(text, index).map_or(1, char::len_utf8);
         }
     }
-    segments.push(start..chars.len());
+    segments.push(start..text.len());
     // An empty segment (a stray `;`, or whitespace-only between separators) is not a citation list.
     for segment in &segments {
-        if chars
+        if text
             .get(segment.clone())
-            .is_none_or(|s| s.iter().all(|c| c.is_whitespace()))
+            .is_none_or(|s| s.chars().all(char::is_whitespace))
         {
             return None;
         }
@@ -2260,10 +2270,11 @@ fn split_citation_segments(chars: &[char]) -> Option<Vec<std::ops::Range<usize>>
     Some(segments)
 }
 
-/// The length of the backtick run starting at `index`.
-fn backtick_run_len(chars: &[char], index: usize) -> usize {
+/// The length in bytes of the backtick run starting at byte offset `index`.
+fn backtick_run_len(text: &str, index: usize) -> usize {
+    let bytes = text.as_bytes();
     let mut len = 0;
-    while chars.get(index + len) == Some(&'`') {
+    while bytes.get(index + len) == Some(&b'`') {
         len += 1;
     }
     len
@@ -2272,11 +2283,12 @@ fn backtick_run_len(chars: &[char], index: usize) -> usize {
 /// Skip past a code span opened by `run` backticks at `index`, returning the index just past its
 /// closing run. With no matching closer the backticks are not a code span and only the opening run
 /// is skipped.
-fn skip_code_span(chars: &[char], index: usize, run: usize) -> usize {
+fn skip_code_span(text: &str, index: usize, run: usize) -> usize {
+    let bytes = text.as_bytes();
     let mut scan = index + run;
-    while scan < chars.len() {
-        if chars.get(scan) == Some(&'`') {
-            let closer = backtick_run_len(chars, scan);
+    while scan < bytes.len() {
+        if bytes.get(scan) == Some(&b'`') {
+            let closer = backtick_run_len(text, scan);
             if closer == run {
                 return scan + closer;
             }
@@ -2302,22 +2314,24 @@ struct CitationKey {
 /// backtick code span, immediately followed by a key. A `-` directly before the `@`, itself at the
 /// segment start or preceded by whitespace, marks author suppression. Returns `None` when no such
 /// key is present.
-fn find_citation_key(chars: &[char], range: std::ops::Range<usize>) -> Option<CitationKey> {
+fn find_citation_key(text: &str, range: std::ops::Range<usize>) -> Option<CitationKey> {
     let mut index = range.start;
     let mut depth = 0usize;
     while index < range.end {
-        if let Some(next) = step_citation_scan(chars, index, &mut depth) {
+        if let Some(next) = step_citation_scan(text, index, &mut depth) {
             index = next;
             continue;
         }
         if depth == 0
-            && chars.get(index) == Some(&'@')
-            && let Some((id, id_end)) = scan_citation_id(chars, index + 1)
+            && char_at(text, index) == Some('@')
+            && let Some((id, id_end)) = scan_citation_id(text, index + 1)
         {
-            let dash_before = index > range.start && chars.get(index - 1) == Some(&'-');
+            // A `-` is ASCII, so when it precedes the `@` it sits at byte `index - 1`, and the
+            // character before it ends at `index - 1`.
+            let dash_before = index > range.start && char_before(text, index) == Some('-');
             let dash_anchored = dash_before
                 && (index - 1 == range.start
-                    || chars.get(index - 2).is_some_and(|c| c.is_whitespace()));
+                    || char_before(text, index - 1).is_some_and(char::is_whitespace));
             let suppress = dash_anchored;
             return Some(CitationKey {
                 at: index,
@@ -2327,7 +2341,7 @@ fn find_citation_key(chars: &[char], range: std::ops::Range<usize>) -> Option<Ci
                 suppress,
             });
         }
-        index += 1;
+        index += char_at(text, index).map_or(1, char::len_utf8);
     }
     None
 }
@@ -2782,19 +2796,19 @@ fn match_use_count(
 /// runs until the parenthesis that balances the link's opener, save for a trailing quoted title
 /// separated by whitespace. Returns `None` when the parentheses are unbalanced or a quoted title is
 /// not immediately followed by the closing parenthesis. `pos` points at the opening `(`.
-fn scan_markdown_inline_target(chars: &[char], pos: usize) -> Option<(Target, usize)> {
+fn scan_markdown_inline_target(text: &str, pos: usize) -> Option<(Target, usize)> {
     let mut index = pos + 1;
-    skip_target_whitespace(chars, &mut index);
-    if chars.get(index).copied() == Some('<') {
+    skip_target_whitespace(text, &mut index);
+    if char_at(text, index) == Some('<') {
         // The angle-bracketed form has no special space handling; defer to the shared scanner,
         // which already reads `<...>` destinations and an optional title.
-        return scan_inline_target(chars, pos);
+        return scan_inline_target(text, pos);
     }
     let mut url = String::new();
     let mut title = String::new();
     let mut depth: usize = 0;
     loop {
-        match chars.get(index).copied() {
+        match char_at(text, index) {
             None => return None,
             Some(')') if depth == 0 => {
                 index += 1;
@@ -2812,26 +2826,21 @@ fn scan_markdown_inline_target(chars: &[char], pos: usize) -> Option<(Target, us
             }
             // An escaped space is always part of the destination — never a title separator — and
             // encodes as `%20` like any other destination space.
-            Some('\\') if matches!(chars.get(index + 1).copied(), Some(' ' | '\t')) => {
+            Some('\\') if matches!(char_at(text, index + 1), Some(' ' | '\t')) => {
                 url.push_str("%20");
                 index += 2;
             }
-            Some('\\')
-                if chars
-                    .get(index + 1)
-                    .copied()
-                    .is_some_and(is_ascii_punctuation) =>
-            {
-                if let Some(&next) = chars.get(index + 1) {
+            Some('\\') if char_at(text, index + 1).is_some_and(is_ascii_punctuation) => {
+                if let Some(next) = char_at(text, index + 1) {
                     url.push('\\');
                     url.push(next);
+                    index += 1 + next.len_utf8();
                 }
-                index += 2;
             }
             Some(ch) if ch == ' ' || ch == '\t' => {
                 let mut after = index;
-                skip_target_whitespace(chars, &mut after);
-                match chars.get(after).copied() {
+                skip_target_whitespace(text, &mut after);
+                match char_at(text, after) {
                     // Trailing whitespace before the closing parenthesis ends the destination.
                     Some(')') if depth == 0 => {
                         index = after;
@@ -2839,10 +2848,10 @@ fn scan_markdown_inline_target(chars: &[char], pos: usize) -> Option<(Target, us
                     // A quoted title separated by whitespace ends the destination. It must be the
                     // last element before the closing parenthesis, else the whole tail fails.
                     Some('"' | '\'') if depth == 0 => {
-                        let (parsed, mut close) = scan_target_title(chars, after)?;
+                        let (parsed, mut close) = scan_target_title(text, after)?;
                         title = parsed;
-                        skip_target_whitespace(chars, &mut close);
-                        if chars.get(close).copied() != Some(')') {
+                        skip_target_whitespace(text, &mut close);
+                        if char_at(text, close) != Some(')') {
                             return None;
                         }
                         index = close + 1;
@@ -2858,7 +2867,7 @@ fn scan_markdown_inline_target(chars: &[char], pos: usize) -> Option<(Target, us
             }
             Some(ch) => {
                 url.push(ch);
-                index += 1;
+                index += ch.len_utf8();
             }
         }
     }
@@ -2872,40 +2881,36 @@ fn scan_markdown_inline_target(chars: &[char], pos: usize) -> Option<(Target, us
 }
 
 /// Advance `index` past a run of spaces and tabs.
-fn skip_target_whitespace(chars: &[char], index: &mut usize) {
-    while matches!(chars.get(*index).copied(), Some(' ' | '\t')) {
+fn skip_target_whitespace(text: &str, index: &mut usize) {
+    while matches!(char_at(text, *index), Some(' ' | '\t')) {
         *index += 1;
     }
 }
 
 /// Scan a quoted link title starting at `start` (a `"` or `'`), returning its raw content and the
 /// index just past the closing quote. A backslash escapes the following punctuation character.
-fn scan_target_title(chars: &[char], start: usize) -> Option<(String, usize)> {
-    let close = chars.get(start).copied()?;
+fn scan_target_title(text: &str, start: usize) -> Option<(String, usize)> {
+    let close = char_at(text, start)?;
     if close != '"' && close != '\'' {
         return None;
     }
     let mut index = start + 1;
     let mut out = String::new();
-    while let Some(&ch) = chars.get(index) {
+    while let Some(ch) = char_at(text, index) {
         if ch == close {
             return Some((out, index + 1));
         }
         if ch == '\\'
-            && chars
-                .get(index + 1)
-                .copied()
-                .is_some_and(is_ascii_punctuation)
+            && let Some(next) = char_at(text, index + 1)
+            && is_ascii_punctuation(next)
         {
-            if let Some(&next) = chars.get(index + 1) {
-                out.push('\\');
-                out.push(next);
-            }
-            index += 2;
+            out.push('\\');
+            out.push(next);
+            index += 1 + next.len_utf8();
             continue;
         }
         out.push(ch);
-        index += 1;
+        index += ch.len_utf8();
     }
     None
 }
@@ -3186,39 +3191,39 @@ fn classify_span_tag(raw: &str) -> SpanTag {
     if !opens_span_tag(raw) {
         return SpanTag::Other;
     }
-    let chars: Vec<char> = raw.chars().collect();
-    if chars.get(1).copied() == Some('/') {
+    if char_at(raw, 1) == Some('/') {
         // `</span>` with optional trailing whitespace before `>`.
         let mut i = 2;
-        if !matches_name(&chars, &mut i, "span") {
+        if !matches_name(raw, &mut i, "span") {
             return SpanTag::Other;
         }
-        while matches!(chars.get(i).copied(), Some(' ' | '\t' | '\n')) {
+        while matches!(char_at(raw, i), Some(' ' | '\t' | '\n')) {
             i += 1;
         }
-        if chars.get(i).copied() == Some('>') && i + 1 == chars.len() {
+        if char_at(raw, i) == Some('>') && i + 1 == raw.len() {
             return SpanTag::Close;
         }
         return SpanTag::Other;
     }
     let mut i = 1;
-    if !matches_name(&chars, &mut i, "span") {
+    if !matches_name(raw, &mut i, "span") {
         return SpanTag::Other;
     }
     // A name character right after `span` means a different tag (`<spanner>`).
-    if matches!(chars.get(i).copied(), Some(c) if c.is_ascii_alphanumeric() || c == '-') {
+    if matches!(char_at(raw, i), Some(c) if c.is_ascii_alphanumeric() || c == '-') {
         return SpanTag::Other;
     }
-    match parse_span_attributes(&chars, i) {
+    match parse_span_attributes(raw, i) {
         Some(attr) => SpanTag::Open(attr),
         None => SpanTag::Other,
     }
 }
 
-/// Match the literal `name` case-insensitively at `*i`, advancing `*i` past it on success.
-fn matches_name(chars: &[char], i: &mut usize, name: &str) -> bool {
+/// Match the literal `name` case-insensitively at `*i`, advancing `*i` past it on success. `name`
+/// is ASCII, so its character offsets are byte offsets.
+fn matches_name(text: &str, i: &mut usize, name: &str) -> bool {
     for (offset, expected) in name.chars().enumerate() {
-        match chars.get(*i + offset).copied() {
+        match char_at(text, *i + offset) {
             Some(c) if c.eq_ignore_ascii_case(&expected) => {}
             _ => return false,
         }
@@ -3232,17 +3237,17 @@ fn matches_name(chars: &[char], i: &mut usize, name: &str) -> bool {
 /// becomes the identifier and a `class` attribute splits into classes; only the first of each is
 /// kept. Every other attribute becomes a key/value pair in source order; a valueless attribute
 /// carries an empty value. Entity and numeric character references in values are decoded.
-fn parse_span_attributes(chars: &[char], start: usize) -> Option<Attr> {
+fn parse_span_attributes(text: &str, start: usize) -> Option<Attr> {
     let mut attr = Attr::default();
     let mut seen_class = false;
     let mut i = start;
     loop {
         let ws_start = i;
-        while matches!(chars.get(i).copied(), Some(' ' | '\t' | '\n')) {
+        while matches!(char_at(text, i), Some(' ' | '\t' | '\n')) {
             i += 1;
         }
-        match chars.get(i).copied() {
-            Some('>') if i + 1 == chars.len() => return Some(attr),
+        match char_at(text, i) {
+            Some('>') if i + 1 == text.len() => return Some(attr),
             // A self-closing tag has no content to wrap.
             Some('/') => return None,
             _ => {}
@@ -3253,7 +3258,7 @@ fn parse_span_attributes(chars: &[char], start: usize) -> Option<Attr> {
         }
         let name_start = i;
         while matches!(
-            chars.get(i).copied(),
+            char_at(text, i),
             Some(c) if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ':' | '.')
         ) {
             i += 1;
@@ -3261,19 +3266,19 @@ fn parse_span_attributes(chars: &[char], start: usize) -> Option<Attr> {
         if i == name_start {
             return None;
         }
-        let name: String = chars.get(name_start..i)?.iter().collect();
+        let name = text.get(name_start..i)?.to_owned();
         let mut value = String::new();
         // Optional `= value` with whitespace allowed around `=`.
         let mut after = i;
-        while matches!(chars.get(after).copied(), Some(' ' | '\t' | '\n')) {
+        while matches!(char_at(text, after), Some(' ' | '\t' | '\n')) {
             after += 1;
         }
-        if chars.get(after).copied() == Some('=') {
+        if char_at(text, after) == Some('=') {
             after += 1;
-            while matches!(chars.get(after).copied(), Some(' ' | '\t' | '\n')) {
+            while matches!(char_at(text, after), Some(' ' | '\t' | '\n')) {
                 after += 1;
             }
-            let (parsed, next) = read_attr_value(chars, after)?;
+            let (parsed, next) = read_attr_value(text, after)?;
             value = parsed;
             i = next;
         } else {
@@ -3299,17 +3304,17 @@ fn parse_span_attributes(chars: &[char], start: usize) -> Option<Attr> {
 /// Read an HTML attribute value at `start`: a double- or single-quoted string, or an unquoted run.
 /// Returns the decoded value and the index just past it. Character references inside the value are
 /// decoded.
-fn read_attr_value(chars: &[char], start: usize) -> Option<(String, usize)> {
-    let quote = chars.get(start).copied();
+fn read_attr_value(text: &str, start: usize) -> Option<(String, usize)> {
+    let quote = char_at(text, start);
     if matches!(quote, Some('"' | '\'')) {
         let quote = quote?;
         let mut i = start + 1;
         let mut out = String::new();
         loop {
-            match chars.get(i).copied() {
+            match char_at(text, i) {
                 Some(c) if c == quote => return Some((out, i + 1)),
                 Some('&') => {
-                    if let Some((decoded, next)) = scan_entity(chars, i) {
+                    if let Some((decoded, next)) = scan_entity(text, i) {
                         out.push_str(&decoded);
                         i = next;
                     } else {
@@ -3319,7 +3324,7 @@ fn read_attr_value(chars: &[char], start: usize) -> Option<(String, usize)> {
                 }
                 Some(c) => {
                     out.push(c);
-                    i += 1;
+                    i += c.len_utf8();
                 }
                 None => return None,
             }
@@ -3328,19 +3333,19 @@ fn read_attr_value(chars: &[char], start: usize) -> Option<(String, usize)> {
     // Unquoted value: a run with no whitespace, quotes, `=`, `<`, `>`, or backtick.
     let mut i = start;
     let mut out = String::new();
-    while let Some(c) = chars.get(i).copied() {
+    while let Some(c) = char_at(text, i) {
         if matches!(c, ' ' | '\t' | '\n' | '"' | '\'' | '=' | '<' | '>' | '`') {
             break;
         }
         if c == '&'
-            && let Some((decoded, next)) = scan_entity(chars, i)
+            && let Some((decoded, next)) = scan_entity(text, i)
         {
             out.push_str(&decoded);
             i = next;
             continue;
         }
         out.push(c);
-        i += 1;
+        i += c.len_utf8();
     }
     if out.is_empty() {
         return None;

--- a/crates/carta-readers/src/commonmark/inline.rs
+++ b/crates/carta-readers/src/commonmark/inline.rs
@@ -4088,6 +4088,44 @@ mod inline_tests {
         assert_eq!(p("_a_b"), vec![str("_a_b")]);
     }
 
+    #[test]
+    fn emphasis_flanks_across_multi_byte_neighbors() {
+        // `*` pairs intraword, so multi-byte word characters around the delimiters behave like
+        // ASCII ones.
+        assert_eq!(
+            p("α*β*γ"),
+            vec![str("α"), Inline::Emph(vec![str("β")]), str("γ")]
+        );
+    }
+
+    #[test]
+    fn emphasis_with_multi_byte_content_at_input_edges() {
+        // The opener sits at the very start of the input and the closer at its very end, so both
+        // boundary lookups run against the buffer's edges.
+        assert_eq!(p("*β*"), vec![Inline::Emph(vec![str("β")])]);
+    }
+
+    #[test]
+    fn emphasis_between_emoji_neighbors() {
+        // An emoji is a symbol (punctuation for flanking purposes), not a word character, so the
+        // run still opens and closes around it.
+        assert_eq!(
+            p("😀*a*😀"),
+            vec![str("😀"), Inline::Emph(vec![str("a")]), str("😀")]
+        );
+    }
+
+    #[test]
+    fn underscore_intraword_stays_literal_with_multi_byte_neighbors() {
+        // The word-character test before and after a `_` run reads whole characters, not bytes.
+        assert_eq!(p("α_β_γ"), vec![str("α_β_γ")]);
+    }
+
+    #[test]
+    fn empty_input_parses_to_nothing() {
+        assert_eq!(p(""), Vec::new());
+    }
+
     // --- Links and images ---
 
     #[test]

--- a/crates/carta-readers/src/commonmark/scan.rs
+++ b/crates/carta-readers/src/commonmark/scan.rs
@@ -1,11 +1,10 @@
-//! Shared raw-text scanners over character slices, used by both parsing phases.
+//! Shared raw-text scanners over string slices, used by both parsing phases.
 //!
-//! These are pure functions: given a `&[char]` (or `&str`) and a start index, each recognizes one
-//! construct — an autolink, a raw inline HTML tag, a character reference, a link destination /
-//! title / label, or a full link reference definition — and returns the parsed value together with
-//! the index just past it. They hold no parser state. The inline phase drives most of them; the
-//! block phase reuses the link-reference-definition and unescaping scanners while collecting
-//! definitions.
+//! These are pure functions: given a `&str` and a start byte offset, each recognizes one construct
+//! — an autolink, a raw inline HTML tag, a character reference, a link destination / title / label,
+//! or a full link reference definition — and returns the parsed value together with the byte offset
+//! just past it. They hold no parser state. The inline phase drives most of them; the block phase
+//! reuses the link-reference-definition and unescaping scanners while collecting definitions.
 
 use carta_ast::{Inline, Target};
 
@@ -77,29 +76,34 @@ pub(crate) fn is_ascii_punctuation(ch: char) -> bool {
     )
 }
 
-pub(crate) fn scan_autolink(chars: &[char], start: usize) -> Option<(Inline, usize)> {
-    if chars.get(start).copied() != Some('<') {
+/// The character beginning at byte offset `at`, or `None` at or past the end of `text`.
+fn char_at(text: &str, at: usize) -> Option<char> {
+    text.get(at..).and_then(|rest| rest.chars().next())
+}
+
+pub(crate) fn scan_autolink(text: &str, start: usize) -> Option<(Inline, usize)> {
+    if char_at(text, start) != Some('<') {
         return None;
     }
-    let mut end = start + 1;
-    let mut content = String::new();
-    while let Some(&ch) = chars.get(end) {
+    let content_start = start + 1;
+    let mut end = content_start;
+    while let Some(ch) = char_at(text, end) {
         if ch == '>' {
             break;
         }
         if ch == '<' || ch.is_whitespace() {
             return None;
         }
-        content.push(ch);
-        end += 1;
+        end += ch.len_utf8();
     }
-    if chars.get(end).copied() != Some('>') {
+    if char_at(text, end) != Some('>') {
         return None;
     }
+    let content = text.get(content_start..end)?;
     let after = end + 1;
-    if is_uri_autolink(&content) {
+    if is_uri_autolink(content) {
         let target = Target {
-            url: content.clone().into(),
+            url: content.into(),
             title: carta_ast::Text::default(),
         };
         return Some((
@@ -111,7 +115,7 @@ pub(crate) fn scan_autolink(chars: &[char], start: usize) -> Option<(Inline, usi
             after,
         ));
     }
-    if is_email_autolink(&content) {
+    if is_email_autolink(content) {
         let url = format!("mailto:{content}");
         let target = Target {
             url: url.into(),
@@ -160,190 +164,180 @@ fn is_email_autolink(text: &str) -> bool {
 
 /// Recognize raw inline HTML at `start` (an open/closing tag, comment, processing instruction,
 /// declaration, or CDATA section) per spec §6.6. Returns the verbatim text and the end position.
-pub(crate) fn scan_html_tag(chars: &[char], start: usize) -> Option<(String, usize)> {
-    let end = match_html(chars, start)?;
-    let text: String = chars.get(start..end)?.iter().collect();
-    Some((text, end))
+pub(crate) fn scan_html_tag(text: &str, start: usize) -> Option<(String, usize)> {
+    let end = match_html(text, start)?;
+    Some((text.get(start..end)?.to_owned(), end))
 }
 
-fn match_html(chars: &[char], start: usize) -> Option<usize> {
-    if chars.get(start).copied() != Some('<') {
+fn match_html(text: &str, start: usize) -> Option<usize> {
+    if char_at(text, start) != Some('<') {
         return None;
     }
-    match chars.get(start + 1).copied()? {
-        '/' => match_closing_tag(chars, start + 2),
-        '?' => match_until(chars, start + 2, "?>"),
-        '!' => match_declaration(chars, start),
-        c if c.is_ascii_alphabetic() => match_open_tag(chars, start + 1),
+    match char_at(text, start + 1)? {
+        '/' => match_closing_tag(text, start + 2),
+        '?' => match_until(text, start + 2, "?>"),
+        '!' => match_declaration(text, start),
+        c if c.is_ascii_alphabetic() => match_open_tag(text, start + 1),
         _ => None,
     }
 }
 
-fn match_open_tag(chars: &[char], mut index: usize) -> Option<usize> {
-    index = match_tag_name(chars, index)?;
-    while let Some(next) = match_attribute(chars, index) {
+fn match_open_tag(text: &str, mut index: usize) -> Option<usize> {
+    index = match_tag_name(text, index)?;
+    while let Some(next) = match_attribute(text, index) {
         index = next;
     }
-    index = skip_html_whitespace(chars, index);
-    if chars.get(index).copied() == Some('/') {
+    index = skip_html_whitespace(text, index);
+    if char_at(text, index) == Some('/') {
         index += 1;
     }
-    (chars.get(index).copied() == Some('>')).then_some(index + 1)
+    (char_at(text, index) == Some('>')).then_some(index + 1)
 }
 
-fn match_closing_tag(chars: &[char], index: usize) -> Option<usize> {
-    let index = skip_html_whitespace(chars, match_tag_name(chars, index)?);
-    (chars.get(index).copied() == Some('>')).then_some(index + 1)
+fn match_closing_tag(text: &str, index: usize) -> Option<usize> {
+    let index = skip_html_whitespace(text, match_tag_name(text, index)?);
+    (char_at(text, index) == Some('>')).then_some(index + 1)
 }
 
 /// A comment (`<!-->`, `<!--->`, or `<!--` … `-->`), CDATA section, or declaration. `start` points
 /// at `<`; the following `!` is already known.
-fn match_declaration(chars: &[char], start: usize) -> Option<usize> {
+fn match_declaration(text: &str, start: usize) -> Option<usize> {
     let body = start + 2;
-    if chars.get(body).copied() == Some('-') && chars.get(body + 1).copied() == Some('-') {
+    if char_at(text, body) == Some('-') && char_at(text, body + 1) == Some('-') {
         let after = body + 2;
-        if chars.get(after).copied() == Some('>') {
+        if char_at(text, after) == Some('>') {
             return Some(after + 1);
         }
-        if chars.get(after).copied() == Some('-') && chars.get(after + 1).copied() == Some('>') {
+        if char_at(text, after) == Some('-') && char_at(text, after + 1) == Some('>') {
             return Some(after + 2);
         }
-        return match_until(chars, after, "-->");
+        return match_until(text, after, "-->");
     }
-    if matches_at(chars, body, "[CDATA[") {
-        return match_until(chars, body + 7, "]]>");
-    }
-    if chars
-        .get(body)
-        .copied()
-        .is_some_and(|c| c.is_ascii_alphabetic())
+    if text
+        .get(body..)
+        .is_some_and(|rest| rest.starts_with("[CDATA["))
     {
-        return match_until_char(chars, body + 1, '>');
+        return match_until(text, body + 7, "]]>");
+    }
+    if char_at(text, body).is_some_and(|c| c.is_ascii_alphabetic()) {
+        return match_until_char(text, body + 1, '>');
     }
     None
 }
 
-fn match_tag_name(chars: &[char], index: usize) -> Option<usize> {
-    if !chars.get(index).copied()?.is_ascii_alphabetic() {
+fn match_tag_name(text: &str, index: usize) -> Option<usize> {
+    if !char_at(text, index)?.is_ascii_alphabetic() {
         return None;
     }
     let mut end = index + 1;
-    while chars
-        .get(end)
-        .copied()
-        .is_some_and(|c| c.is_ascii_alphanumeric() || c == '-')
-    {
-        end += 1;
+    while let Some(c) = char_at(text, end) {
+        if c.is_ascii_alphanumeric() || c == '-' {
+            end += c.len_utf8();
+        } else {
+            break;
+        }
     }
     Some(end)
 }
 
 /// An attribute: at least one whitespace, an attribute name, then an optional value specification.
-fn match_attribute(chars: &[char], index: usize) -> Option<usize> {
-    let after_space = skip_html_whitespace(chars, index);
+fn match_attribute(text: &str, index: usize) -> Option<usize> {
+    let after_space = skip_html_whitespace(text, index);
     if after_space == index {
         return None;
     }
-    let mut end = match_attribute_name(chars, after_space)?;
-    if let Some(next) = match_attribute_value_spec(chars, end) {
+    let mut end = match_attribute_name(text, after_space)?;
+    if let Some(next) = match_attribute_value_spec(text, end) {
         end = next;
     }
     Some(end)
 }
 
-fn match_attribute_name(chars: &[char], index: usize) -> Option<usize> {
-    let first = chars.get(index).copied()?;
+fn match_attribute_name(text: &str, index: usize) -> Option<usize> {
+    let first = char_at(text, index)?;
     if !(first.is_ascii_alphabetic() || first == '_' || first == ':') {
         return None;
     }
     let mut end = index + 1;
-    while chars
-        .get(end)
-        .copied()
-        .is_some_and(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | ':' | '-'))
-    {
-        end += 1;
+    while let Some(c) = char_at(text, end) {
+        if c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | ':' | '-') {
+            end += c.len_utf8();
+        } else {
+            break;
+        }
     }
     Some(end)
 }
 
-fn match_attribute_value_spec(chars: &[char], index: usize) -> Option<usize> {
-    let equals = skip_html_whitespace(chars, index);
-    if chars.get(equals).copied() != Some('=') {
+fn match_attribute_value_spec(text: &str, index: usize) -> Option<usize> {
+    let equals = skip_html_whitespace(text, index);
+    if char_at(text, equals) != Some('=') {
         return None;
     }
-    let value = skip_html_whitespace(chars, equals + 1);
-    match_attribute_value(chars, value)
+    let value = skip_html_whitespace(text, equals + 1);
+    match_attribute_value(text, value)
 }
 
-fn match_attribute_value(chars: &[char], index: usize) -> Option<usize> {
-    match chars.get(index).copied()? {
-        '\'' => match_until_char(chars, index + 1, '\''),
-        '"' => match_until_char(chars, index + 1, '"'),
+fn match_attribute_value(text: &str, index: usize) -> Option<usize> {
+    match char_at(text, index)? {
+        '\'' => match_until_char(text, index + 1, '\''),
+        '"' => match_until_char(text, index + 1, '"'),
         _ => {
             let mut end = index;
-            while chars.get(end).copied().is_some_and(|c| {
-                !matches!(
+            while let Some(c) = char_at(text, end) {
+                if matches!(
                     c,
                     ' ' | '\t' | '\n' | '\r' | '"' | '\'' | '=' | '<' | '>' | '`'
-                )
-            }) {
-                end += 1;
+                ) {
+                    break;
+                }
+                end += c.len_utf8();
             }
             (end != index).then_some(end)
         }
     }
 }
 
-fn skip_html_whitespace(chars: &[char], mut index: usize) -> usize {
-    while matches!(chars.get(index).copied(), Some(' ' | '\t' | '\n' | '\r')) {
+fn skip_html_whitespace(text: &str, mut index: usize) -> usize {
+    while matches!(char_at(text, index), Some(' ' | '\t' | '\n' | '\r')) {
         index += 1;
     }
     index
 }
 
-pub(crate) fn matches_at(chars: &[char], index: usize, needle: &str) -> bool {
-    needle
-        .chars()
-        .enumerate()
-        .all(|(offset, c)| chars.get(index + offset).copied() == Some(c))
-}
-
 /// Position just past the first occurrence of `needle` at or after `from`, or `None` if absent.
-fn match_until(chars: &[char], from: usize, needle: &str) -> Option<usize> {
-    let pattern: Vec<char> = needle.chars().collect();
-    let mut index = from;
-    while index + pattern.len() <= chars.len() {
-        if chars.get(index..index + pattern.len()) == Some(pattern.as_slice()) {
-            return Some(index + pattern.len());
-        }
-        index += 1;
-    }
-    None
+fn match_until(text: &str, from: usize, needle: &str) -> Option<usize> {
+    text.get(from..)
+        .and_then(|rest| rest.find(needle))
+        .map(|offset| from + offset + needle.len())
 }
 
-fn match_until_char(chars: &[char], from: usize, needle: char) -> Option<usize> {
-    let mut index = from;
-    while let Some(c) = chars.get(index).copied() {
-        if c == needle {
-            return Some(index + 1);
-        }
-        index += 1;
-    }
-    None
+fn match_until_char(text: &str, from: usize, needle: char) -> Option<usize> {
+    text.get(from..)
+        .and_then(|rest| rest.find(needle))
+        .map(|offset| from + offset + needle.len_utf8())
 }
 
-pub(crate) fn scan_entity(chars: &[char], start: usize) -> Option<(String, usize)> {
-    if chars.get(start).copied() != Some('&') {
+pub(crate) fn scan_entity(text: &str, start: usize) -> Option<(String, usize)> {
+    if char_at(text, start) != Some('&') {
         return None;
     }
-    let semi =
-        (start + 1..(start + 33).min(chars.len())).find(|&i| chars.get(i).copied() == Some(';'))?;
-    let body: String = chars
-        .get(start + 1..semi)
-        .map(|s| s.iter().collect())
-        .unwrap_or_default();
-    let decoded = decode_entity(&body)?;
+    // A character reference's body runs at most 32 characters before the closing `;`.
+    let mut index = start + 1;
+    let mut semi = None;
+    for _ in 0..32 {
+        match char_at(text, index) {
+            Some(';') => {
+                semi = Some(index);
+                break;
+            }
+            Some(c) => index += c.len_utf8(),
+            None => break,
+        }
+    }
+    let semi = semi?;
+    let body = text.get(start + 1..semi)?;
+    let decoded = decode_entity(body)?;
     Some((decoded, semi + 1))
 }
 
@@ -368,20 +362,20 @@ fn decode_entity(body: &str) -> Option<String> {
 }
 
 /// Scan an inline link tail `(url "title")` beginning at `pos` (which points at `(`).
-pub(crate) fn scan_inline_target(chars: &[char], pos: usize) -> Option<(Target, usize)> {
+pub(crate) fn scan_inline_target(text: &str, pos: usize) -> Option<(Target, usize)> {
     let mut index = pos + 1;
-    skip_inline_whitespace(chars, &mut index);
-    let (url, next) = scan_destination(chars, index)?;
+    skip_inline_whitespace(text, &mut index);
+    let (url, next) = scan_destination(text, index)?;
     index = next;
-    skip_inline_whitespace(chars, &mut index);
+    skip_inline_whitespace(text, &mut index);
     let mut title = String::new();
-    if matches!(chars.get(index).copied(), Some('"' | '\'' | '(')) {
-        let (parsed, after) = scan_title(chars, index)?;
+    if matches!(char_at(text, index), Some('"' | '\'' | '(')) {
+        let (parsed, after) = scan_title(text, index)?;
         title = parsed;
         index = after;
-        skip_inline_whitespace(chars, &mut index);
+        skip_inline_whitespace(text, &mut index);
     }
-    if chars.get(index).copied() != Some(')') {
+    if char_at(text, index) != Some(')') {
         return None;
     }
     Some((
@@ -393,27 +387,24 @@ pub(crate) fn scan_inline_target(chars: &[char], pos: usize) -> Option<(Target, 
     ))
 }
 
-fn scan_destination(chars: &[char], start: usize) -> Option<(String, usize)> {
+fn scan_destination(text: &str, start: usize) -> Option<(String, usize)> {
     let mut index = start;
-    if chars.get(index).copied() == Some('<') {
+    if char_at(text, index) == Some('<') {
         index += 1;
         let mut out = String::new();
-        while let Some(&ch) = chars.get(index) {
+        while let Some(ch) = char_at(text, index) {
             match ch {
                 '>' => return Some((out, index + 1)),
                 '<' | '\n' => return None,
-                '\\' if chars
-                    .get(index + 1)
-                    .is_some_and(|c| is_ascii_punctuation(*c)) =>
-                {
-                    if let Some(&next) = chars.get(index + 1) {
+                '\\' if char_at(text, index + 1).is_some_and(is_ascii_punctuation) => {
+                    if let Some(next) = char_at(text, index + 1) {
                         out.push(next);
+                        index += 1 + next.len_utf8();
                     }
-                    index += 2;
                 }
                 _ => {
                     out.push(ch);
-                    index += 1;
+                    index += ch.len_utf8();
                 }
             }
         }
@@ -421,7 +412,7 @@ fn scan_destination(chars: &[char], start: usize) -> Option<(String, usize)> {
     }
     let mut out = String::new();
     let mut depth = 0;
-    while let Some(&ch) = chars.get(index) {
+    while let Some(ch) = char_at(text, index) {
         match ch {
             ' ' => break,
             c if c.is_control() => break,
@@ -438,18 +429,15 @@ fn scan_destination(chars: &[char], start: usize) -> Option<(String, usize)> {
                 out.push(')');
                 index += 1;
             }
-            '\\' if chars
-                .get(index + 1)
-                .is_some_and(|c| is_ascii_punctuation(*c)) =>
-            {
-                if let Some(&next) = chars.get(index + 1) {
+            '\\' if char_at(text, index + 1).is_some_and(is_ascii_punctuation) => {
+                if let Some(next) = char_at(text, index + 1) {
                     out.push(next);
+                    index += 1 + next.len_utf8();
                 }
-                index += 2;
             }
             _ => {
                 out.push(ch);
-                index += 1;
+                index += ch.len_utf8();
             }
         }
     }
@@ -462,8 +450,8 @@ fn scan_destination(chars: &[char], start: usize) -> Option<(String, usize)> {
     Some((out, index))
 }
 
-fn scan_title(chars: &[char], start: usize) -> Option<(String, usize)> {
-    let open = chars.get(start).copied()?;
+fn scan_title(text: &str, start: usize) -> Option<(String, usize)> {
+    let open = char_at(text, start)?;
     let close = match open {
         '"' => '"',
         '\'' => '\'',
@@ -472,59 +460,53 @@ fn scan_title(chars: &[char], start: usize) -> Option<(String, usize)> {
     };
     let mut index = start + 1;
     let mut out = String::new();
-    while let Some(&ch) = chars.get(index) {
+    while let Some(ch) = char_at(text, index) {
         if ch == close {
             return Some((out, index + 1));
         }
         if ch == '\\'
-            && chars
-                .get(index + 1)
-                .is_some_and(|c| is_ascii_punctuation(*c))
+            && let Some(next) = char_at(text, index + 1)
+            && is_ascii_punctuation(next)
         {
-            if let Some(&next) = chars.get(index + 1) {
-                out.push(next);
-            }
-            index += 2;
+            out.push(next);
+            index += 1 + next.len_utf8();
             continue;
         }
         out.push(ch);
-        index += 1;
+        index += ch.len_utf8();
     }
     None
 }
 
 /// Scan a `[label]` immediately following a `]`, returning the raw label and the next position.
-pub(crate) fn scan_following_label(chars: &[char], pos: usize) -> Option<(String, usize)> {
-    if chars.get(pos).copied() != Some('[') {
+pub(crate) fn scan_following_label(text: &str, pos: usize) -> Option<(String, usize)> {
+    if char_at(text, pos) != Some('[') {
         return None;
     }
     let mut index = pos + 1;
     let mut out = String::new();
-    while let Some(&ch) = chars.get(index) {
+    while let Some(ch) = char_at(text, index) {
         match ch {
             ']' => return Some((out, index + 1)),
             '[' => return None,
-            '\\' if chars
-                .get(index + 1)
-                .is_some_and(|c| is_ascii_punctuation(*c)) =>
-            {
+            '\\' if char_at(text, index + 1).is_some_and(is_ascii_punctuation) => {
                 out.push('\\');
-                if let Some(&next) = chars.get(index + 1) {
+                if let Some(next) = char_at(text, index + 1) {
                     out.push(next);
+                    index += 1 + next.len_utf8();
                 }
-                index += 2;
             }
             _ => {
                 out.push(ch);
-                index += 1;
+                index += ch.len_utf8();
             }
         }
     }
     None
 }
 
-fn skip_inline_whitespace(chars: &[char], index: &mut usize) {
-    while matches!(chars.get(*index).copied(), Some(' ' | '\t' | '\n')) {
+fn skip_inline_whitespace(text: &str, index: &mut usize) {
+    while matches!(char_at(text, *index), Some(' ' | '\t' | '\n')) {
         *index += 1;
     }
 }
@@ -538,27 +520,26 @@ pub(crate) fn normalize_label(label: &str) -> String {
 
 /// Remove backslash escapes of ASCII punctuation from a string, leaving other backslashes intact.
 pub(crate) fn unescape_string(text: &str) -> String {
-    let chars: Vec<char> = text.chars().collect();
     let mut out = String::with_capacity(text.len());
     let mut index = 0;
-    while let Some(&ch) = chars.get(index) {
+    while let Some(ch) = char_at(text, index) {
         if ch == '\\'
-            && let Some(&next) = chars.get(index + 1)
+            && let Some(next) = char_at(text, index + 1)
             && is_ascii_punctuation(next)
         {
             out.push(next);
-            index += 2;
+            index += 1 + next.len_utf8();
             continue;
         }
         if ch == '&'
-            && let Some((decoded, next)) = scan_entity(&chars, index)
+            && let Some((decoded, next)) = scan_entity(text, index)
         {
             out.push_str(&decoded);
             index = next;
             continue;
         }
         out.push(ch);
-        index += 1;
+        index += ch.len_utf8();
     }
     out
 }
@@ -572,16 +553,15 @@ pub(crate) fn parse_link_reference_definition(
     text: &str,
     markdown: bool,
 ) -> Option<(String, LinkDef, &str)> {
-    let chars: Vec<char> = text.chars().collect();
     let mut index = 0;
-    skip_spaces_up_to_three(&chars, &mut index);
-    if chars.get(index).copied() != Some('[') {
+    skip_spaces_up_to_three(text, &mut index);
+    if char_at(text, index) != Some('[') {
         return None;
     }
     index += 1;
     let mut label = String::new();
     let mut closed = false;
-    while let Some(&ch) = chars.get(index) {
+    while let Some(ch) = char_at(text, index) {
         match ch {
             ']' => {
                 closed = true;
@@ -589,52 +569,49 @@ pub(crate) fn parse_link_reference_definition(
                 break;
             }
             '[' => return None,
-            '\\' if chars
-                .get(index + 1)
-                .is_some_and(|c| is_ascii_punctuation(*c)) =>
-            {
+            '\\' if char_at(text, index + 1).is_some_and(is_ascii_punctuation) => {
                 label.push('\\');
-                if let Some(&next) = chars.get(index + 1) {
+                if let Some(next) = char_at(text, index + 1) {
                     label.push(next);
+                    index += 1 + next.len_utf8();
                 }
-                index += 2;
             }
             _ => {
                 label.push(ch);
-                index += 1;
+                index += ch.len_utf8();
             }
         }
     }
-    if !closed || chars.get(index).copied() != Some(':') {
+    if !closed || char_at(text, index) != Some(':') {
         return None;
     }
     index += 1;
-    skip_inline_whitespace_no_double_newline(&chars, &mut index)?;
-    let angle = chars.get(index).copied() == Some('<');
+    skip_inline_whitespace_no_double_newline(text, &mut index)?;
+    let angle = char_at(text, index) == Some('<');
 
     let (url, title) = if markdown && !angle {
-        let (url, same_line_title, line_end) = scan_markdown_reference_body(&chars, index)?;
+        let (url, same_line_title, line_end) = scan_markdown_reference_body(text, index)?;
         index = line_end;
         if let Some(title) = same_line_title {
             (url, title)
         } else {
-            let (title, end) = scan_following_title(&chars, index)?;
+            let (title, end) = scan_following_title(text, index)?;
             index = end;
             (url, title)
         }
     } else {
-        let (url, next) = scan_destination(&chars, index)?;
+        let (url, next) = scan_destination(text, index)?;
         // A bare (non-angle) destination must be non-empty; `<>` is a valid empty destination.
         if url.is_empty() && !angle {
             return None;
         }
-        let (title, end) = scan_following_title(&chars, next)?;
+        let (title, end) = scan_following_title(text, next)?;
         index = end;
         (url, title)
     };
 
     // Consume the trailing newline.
-    if chars.get(index).copied() == Some('\n') {
+    if char_at(text, index) == Some('\n') {
         index += 1;
     }
 
@@ -646,10 +623,7 @@ pub(crate) fn parse_link_reference_definition(
         url: unescape_string(&url),
         title: unescape_string(&title),
     };
-    let consumed_bytes: usize = chars
-        .get(..index)
-        .map_or(0, |s| s.iter().map(|c| c.len_utf8()).sum());
-    let rest = text.get(consumed_bytes..).unwrap_or("");
+    let rest = text.get(index..).unwrap_or("");
     Some((normalized, def, rest))
 }
 
@@ -660,19 +634,18 @@ pub(crate) fn parse_link_reference_definition(
 /// the term is affected — so this returns just the unconsumed remainder of `text`, or `None` when the
 /// line does not open a definition.
 pub(crate) fn parse_abbreviation_definition(text: &str) -> Option<&str> {
-    let chars: Vec<char> = text.chars().collect();
     let mut index = 0;
-    if chars.get(index).copied() != Some('*') {
+    if char_at(text, index) != Some('*') {
         return None;
     }
     index += 1;
-    if chars.get(index).copied() != Some('[') {
+    if char_at(text, index) != Some('[') {
         return None;
     }
     index += 1;
     let mut depth = 1;
     loop {
-        match chars.get(index).copied() {
+        match char_at(text, index) {
             None | Some('\n') => return None,
             Some('[') => {
                 depth += 1;
@@ -685,32 +658,29 @@ pub(crate) fn parse_abbreviation_definition(text: &str) -> Option<&str> {
                     break;
                 }
             }
-            Some(_) => index += 1,
+            Some(c) => index += c.len_utf8(),
         }
     }
-    if chars.get(index).copied() != Some(':') {
+    if char_at(text, index) != Some(':') {
         return None;
     }
-    while let Some(&ch) = chars.get(index) {
-        index += 1;
+    while let Some(ch) = char_at(text, index) {
+        index += ch.len_utf8();
         if ch == '\n' {
             break;
         }
     }
-    let consumed_bytes: usize = chars
-        .get(..index)
-        .map_or(0, |s| s.iter().map(|c| c.len_utf8()).sum());
-    Some(text.get(consumed_bytes..).unwrap_or(""))
+    Some(text.get(index..).unwrap_or(""))
 }
 
 /// After a destination ending at `after_dest`, scan an optional title separated from it by
 /// whitespace and at most one newline. Returns the title (empty when absent) together with the
 /// index at the end of the definition's last line. Returns `None` when non-whitespace other than a
 /// well-formed title follows the destination, which invalidates the whole definition.
-fn scan_following_title(chars: &[char], after_dest: usize) -> Option<(String, usize)> {
+fn scan_following_title(text: &str, after_dest: usize) -> Option<(String, usize)> {
     let mut probe = after_dest;
     let mut newlines = 0;
-    while let Some(ch) = chars.get(probe).copied() {
+    while let Some(ch) = char_at(text, probe) {
         match ch {
             ' ' | '\t' => probe += 1,
             '\n' if newlines == 0 => {
@@ -722,18 +692,18 @@ fn scan_following_title(chars: &[char], after_dest: usize) -> Option<(String, us
     }
     let separated = probe > after_dest;
     if separated
-        && matches!(chars.get(probe).copied(), Some('"' | '\'' | '('))
-        && let Some((parsed, after)) = scan_title(chars, probe)
+        && matches!(char_at(text, probe), Some('"' | '\'' | '('))
+        && let Some((parsed, after)) = scan_title(text, probe)
     {
         let mut tail = after;
-        skip_blanks_to_line_end(chars, &mut tail);
-        if at_line_end(chars, tail) {
+        skip_blanks_to_line_end(text, &mut tail);
+        if at_line_end(text, tail) {
             return Some((parsed, tail));
         }
     }
     let mut index = after_dest;
-    skip_blanks_to_line_end(chars, &mut index);
-    if !at_line_end(chars, index) {
+    skip_blanks_to_line_end(text, &mut index);
+    if !at_line_end(text, index) {
         return None;
     }
     Some((String::new(), index))
@@ -756,16 +726,16 @@ enum TitleScan {
 /// non-whitespace after that, the definition is invalid. A quote whose closing delimiter abuts more
 /// text is not a title token at all and reverts to literal destination text, whereas a parenthesized
 /// run in that position still invalidates the definition.
-fn try_reference_title(chars: &[char], at: usize) -> TitleScan {
-    let Some(opener @ ('"' | '\'' | '(')) = chars.get(at).copied() else {
+fn try_reference_title(text: &str, at: usize) -> TitleScan {
+    let Some(opener @ ('"' | '\'' | '(')) = char_at(text, at) else {
         return TitleScan::Absent;
     };
-    match scan_title(chars, at) {
+    match scan_title(text, at) {
         Some((parsed, after)) => {
-            if at_line_end(chars, after) || matches!(chars.get(after).copied(), Some(' ' | '\t')) {
+            if at_line_end(text, after) || matches!(char_at(text, after), Some(' ' | '\t')) {
                 let mut tail = after;
-                skip_blanks_to_line_end(chars, &mut tail);
-                if at_line_end(chars, tail) {
+                skip_blanks_to_line_end(text, &mut tail);
+                if at_line_end(text, tail) {
                     TitleScan::Title(parsed, tail)
                 } else {
                     TitleScan::Reject
@@ -787,11 +757,11 @@ fn try_reference_title(chars: &[char], at: usize) -> TitleScan {
 /// title when one ends the line, and the index at line end. Returns `None` when the line cannot form
 /// a valid definition (a parenthesized title not at the line's end).
 fn scan_markdown_reference_body(
-    chars: &[char],
+    text: &str,
     start: usize,
 ) -> Option<(String, Option<String>, usize)> {
     let mut index = start;
-    match try_reference_title(chars, index) {
+    match try_reference_title(text, index) {
         TitleScan::Title(parsed, end) => return Some((String::new(), Some(parsed), end)),
         TitleScan::Reject => return None,
         TitleScan::Literal | TitleScan::Absent => {}
@@ -799,7 +769,7 @@ fn scan_markdown_reference_body(
     let mut url = String::new();
     let mut depth: usize = 0;
     loop {
-        match chars.get(index).copied() {
+        match char_at(text, index) {
             None | Some('\n') => break,
             Some('(') => {
                 depth += 1;
@@ -811,31 +781,26 @@ fn scan_markdown_reference_body(
                 url.push(')');
                 index += 1;
             }
-            Some('\\') if matches!(chars.get(index + 1).copied(), Some(' ' | '\t')) => {
+            Some('\\') if matches!(char_at(text, index + 1), Some(' ' | '\t')) => {
                 url.push(' ');
                 index += 2;
             }
-            Some('\\')
-                if chars
-                    .get(index + 1)
-                    .copied()
-                    .is_some_and(is_ascii_punctuation) =>
-            {
+            Some('\\') if char_at(text, index + 1).is_some_and(is_ascii_punctuation) => {
                 url.push('\\');
-                if let Some(&next) = chars.get(index + 1) {
+                if let Some(next) = char_at(text, index + 1) {
                     url.push(next);
+                    index += 1 + next.len_utf8();
                 }
-                index += 2;
             }
             Some(' ' | '\t') => {
                 let mut after = index;
-                skip_blanks_to_line_end(chars, &mut after);
-                if at_line_end(chars, after) {
+                skip_blanks_to_line_end(text, &mut after);
+                if at_line_end(text, after) {
                     index = after;
                     break;
                 }
                 if depth == 0 {
-                    match try_reference_title(chars, after) {
+                    match try_reference_title(text, after) {
                         TitleScan::Title(parsed, end) => return Some((url, Some(parsed), end)),
                         TitleScan::Reject => return None,
                         TitleScan::Literal | TitleScan::Absent => {
@@ -850,24 +815,24 @@ fn scan_markdown_reference_body(
             }
             Some(ch) => {
                 url.push(ch);
-                index += 1;
+                index += ch.len_utf8();
             }
         }
     }
     Some((url, None, index))
 }
 
-fn skip_spaces_up_to_three(chars: &[char], index: &mut usize) {
+fn skip_spaces_up_to_three(text: &str, index: &mut usize) {
     let mut count = 0;
-    while count < 3 && chars.get(*index).copied() == Some(' ') {
+    while count < 3 && char_at(text, *index) == Some(' ') {
         *index += 1;
         count += 1;
     }
 }
 
-fn skip_inline_whitespace_no_double_newline(chars: &[char], index: &mut usize) -> Option<()> {
+fn skip_inline_whitespace_no_double_newline(text: &str, index: &mut usize) -> Option<()> {
     let mut newlines = 0;
-    while let Some(&ch) = chars.get(*index) {
+    while let Some(ch) = char_at(text, *index) {
         match ch {
             ' ' | '\t' => *index += 1,
             '\n' => {
@@ -883,14 +848,14 @@ fn skip_inline_whitespace_no_double_newline(chars: &[char], index: &mut usize) -
     Some(())
 }
 
-fn skip_blanks_to_line_end(chars: &[char], index: &mut usize) {
-    while matches!(chars.get(*index).copied(), Some(' ' | '\t')) {
+fn skip_blanks_to_line_end(text: &str, index: &mut usize) {
+    while matches!(char_at(text, *index), Some(' ' | '\t')) {
         *index += 1;
     }
 }
 
-fn at_line_end(chars: &[char], index: usize) -> bool {
-    matches!(chars.get(index).copied(), None | Some('\n'))
+fn at_line_end(text: &str, index: usize) -> bool {
+    matches!(char_at(text, index), None | Some('\n'))
 }
 
 #[cfg(test)]

--- a/crates/carta-readers/src/inline_scan.rs
+++ b/crates/carta-readers/src/inline_scan.rs
@@ -1,9 +1,11 @@
 //! Inline scanners and folds shared by the `CommonMark` and HTML readers.
 //!
-//! These are stateless character-slice utilities: each takes the source as a `&[char]` and a cursor
-//! position (or a length), so both readers can drive them from their own inline machinery without
-//! coupling to either parser's state. The TeX-math scanners recognize the same delimiter shapes the
-//! readers gate behind their math extensions; the dash/ellipsis folds back the `smart` typography.
+//! These are stateless scanning utilities: each takes the source as a `&[char]` or `&str` and a
+//! cursor position (or a length), so both readers can drive them from their own inline machinery
+//! without coupling to either parser's state. The `CommonMark` reader works over byte offsets into a
+//! `&str` (the `_bytes` variants) while the HTML reader works over a `&[char]`. The TeX-math scanners
+//! recognize the same delimiter shapes the readers gate behind their math extensions; the
+//! dash/ellipsis folds back the `smart` typography.
 
 use carta_ast::MathType;
 
@@ -13,6 +15,7 @@ use carta_ast::MathType;
 /// Inline math opens only when the `$` is followed by a non-space character, and closes at the next
 /// unescaped `$` that is preceded by a non-space and not followed by a digit. A backslash escapes
 /// the next character, so the content never holds an unescaped `$`.
+#[cfg(feature = "html")]
 pub(crate) fn scan_inline_math(chars: &[char], pos: usize) -> Option<(String, usize)> {
     if chars
         .get(pos + 1)
@@ -44,6 +47,7 @@ pub(crate) fn scan_inline_math(chars: &[char], pos: usize) -> Option<(String, us
 
 /// Scan display math `$$…$$` starting at the opening `$$` (at `pos`). Returns the content and the
 /// index past the closing `$$`, or `None` if no closing `$$` follows.
+#[cfg(feature = "html")]
 pub(crate) fn scan_display_math(chars: &[char], pos: usize) -> Option<(String, usize)> {
     let content_start = pos + 2;
     let mut i = content_start;
@@ -63,6 +67,7 @@ pub(crate) fn scan_display_math(chars: &[char], pos: usize) -> Option<(String, u
 /// `\`-escapes inside the single-backslash form, and must be non-empty before any trimming. Inline
 /// content is trimmed of surrounding whitespace; display content is kept verbatim. Returns the math
 /// type, its content, and the index past the closer, or `None` on no match.
+#[cfg(feature = "html")]
 pub(crate) fn scan_backslash_math(
     chars: &[char],
     pos: usize,
@@ -102,8 +107,114 @@ pub(crate) fn scan_backslash_math(
 }
 
 /// Whether a `slashes`-backslash run followed by `close` begins at index `i`.
+#[cfg(feature = "html")]
 fn is_backslash_math_closer(chars: &[char], i: usize, slashes: usize, close: char) -> bool {
     (0..slashes).all(|k| chars.get(i + k) == Some(&'\\')) && chars.get(i + slashes) == Some(&close)
+}
+
+/// The character beginning at byte offset `at`, or `None` at or past the end of `text`.
+#[cfg(feature = "commonmark")]
+fn char_at(text: &str, at: usize) -> Option<char> {
+    text.get(at..).and_then(|rest| rest.chars().next())
+}
+
+/// The character ending just before byte offset `at`, or `None` at the start of `text`.
+#[cfg(feature = "commonmark")]
+fn char_before(text: &str, at: usize) -> Option<char> {
+    text.get(..at).and_then(|head| head.chars().next_back())
+}
+
+/// Byte-offset twin of [`scan_inline_math`]: `pos` is the byte offset of the opening `$`, and the
+/// returned end position is a byte offset.
+#[cfg(feature = "commonmark")]
+pub(crate) fn scan_inline_math_bytes(text: &str, pos: usize) -> Option<(String, usize)> {
+    if char_at(text, pos + 1).is_none_or(is_unicode_whitespace) {
+        return None;
+    }
+    let content_start = pos + 1;
+    let mut i = content_start;
+    while let Some(ch) = char_at(text, i) {
+        if ch == '\\'
+            && let Some(next) = char_at(text, i + 1)
+        {
+            i += 1 + next.len_utf8();
+            continue;
+        }
+        if ch == '$' {
+            let prev_space = char_before(text, i).is_none_or(is_unicode_whitespace);
+            let next_digit = char_at(text, i + 1).is_some_and(|c| c.is_ascii_digit());
+            if prev_space || next_digit {
+                return None;
+            }
+            let content = text.get(content_start..i)?.to_owned();
+            return Some((content, i + 1));
+        }
+        i += ch.len_utf8();
+    }
+    None
+}
+
+/// Byte-offset twin of [`scan_display_math`]: `pos` is the byte offset of the opening `$$`, and the
+/// returned end position is a byte offset.
+#[cfg(feature = "commonmark")]
+pub(crate) fn scan_display_math_bytes(text: &str, pos: usize) -> Option<(String, usize)> {
+    let content_start = pos + 2;
+    let mut i = content_start;
+    while let Some(ch) = char_at(text, i) {
+        if text.get(i..).is_some_and(|rest| rest.starts_with("$$")) {
+            let content = text.get(content_start..i)?.to_owned();
+            return Some((content, i + 2));
+        }
+        i += ch.len_utf8();
+    }
+    None
+}
+
+/// Byte-offset twin of [`scan_backslash_math`]: `pos` is the byte offset of the first backslash, and
+/// the returned end position is a byte offset.
+#[cfg(feature = "commonmark")]
+pub(crate) fn scan_backslash_math_bytes(
+    text: &str,
+    pos: usize,
+    slashes: usize,
+) -> Option<(MathType, String, usize)> {
+    let open = pos + slashes;
+    let (close_bracket, math_type) = match char_at(text, open) {
+        Some('(') => (')', MathType::InlineMath),
+        Some('[') => (']', MathType::DisplayMath),
+        _ => return None,
+    };
+    let content_start = open + 1;
+    let mut i = content_start;
+    while let Some(ch) = char_at(text, i) {
+        if is_backslash_math_closer_bytes(text, i, slashes, close_bracket) {
+            if i == content_start {
+                return None; // empty content is not a math span
+            }
+            let raw = text.get(content_start..i)?.to_owned();
+            let content = match math_type {
+                MathType::InlineMath => raw.trim().to_owned(),
+                MathType::DisplayMath => raw,
+            };
+            return Some((math_type, content, i + slashes + 1));
+        }
+        if slashes == 1
+            && ch == '\\'
+            && let Some(next) = char_at(text, i + 1)
+        {
+            i += 1 + next.len_utf8();
+            continue;
+        }
+        i += ch.len_utf8();
+    }
+    None
+}
+
+/// Byte-offset twin of [`is_backslash_math_closer`].
+#[cfg(feature = "commonmark")]
+fn is_backslash_math_closer_bytes(text: &str, i: usize, slashes: usize, close: char) -> bool {
+    (0..slashes).all(|k| text.as_bytes().get(i + k) == Some(&b'\\'))
+        && char_at(text, i + slashes) == Some(close)
 }
 
 /// Fold a run of `len` hyphens (`len >= 2`) into the fewest em (`—`) and en (`–`) dashes that sum to

--- a/crates/carta-readers/src/inline_scan.rs
+++ b/crates/carta-readers/src/inline_scan.rs
@@ -259,3 +259,57 @@ pub(crate) fn is_unicode_whitespace(ch: char) -> bool {
         || ch == '\r'
         || ch.is_whitespace()
 }
+
+#[cfg(all(test, feature = "commonmark"))]
+mod tests {
+    use super::{scan_display_math_bytes, scan_inline_math_bytes};
+
+    #[test]
+    fn inline_math_spans_multi_byte_content() {
+        // The content and the returned end position are byte offsets; the closing `$` follows a
+        // multi-byte character.
+        assert_eq!(
+            scan_inline_math_bytes("$αβ$", 0),
+            Some(("αβ".to_owned(), 6))
+        );
+    }
+
+    #[test]
+    fn inline_math_opens_after_a_multi_byte_neighbor() {
+        // The opener sits at a byte offset past a multi-byte character.
+        assert_eq!(scan_inline_math_bytes("é$β$", 2), Some(("β".to_owned(), 6)));
+    }
+
+    #[test]
+    fn inline_math_escape_hops_over_a_multi_byte_character() {
+        // A backslash escapes the following character whole, so an escaped multi-byte character
+        // never leaves the cursor mid-character.
+        assert_eq!(
+            scan_inline_math_bytes("$\\éx$", 0),
+            Some(("\\éx".to_owned(), 6))
+        );
+    }
+
+    #[test]
+    fn inline_math_rejects_ill_flanked_closers() {
+        // Whitespace before the closing `$`, a digit after it, or whitespace after the opener each
+        // void the span.
+        assert_eq!(scan_inline_math_bytes("$x $", 0), None);
+        assert_eq!(scan_inline_math_bytes("$x$5", 0), None);
+        assert_eq!(scan_inline_math_bytes("$ x$", 0), None);
+    }
+
+    #[test]
+    fn display_math_spans_multi_byte_content() {
+        assert_eq!(
+            scan_display_math_bytes("$$α+β$$", 0),
+            Some(("α+β".to_owned(), 9))
+        );
+    }
+
+    #[test]
+    fn display_math_without_a_closer_is_not_math() {
+        // A lone `$` after multi-byte content does not close a `$$` opener.
+        assert_eq!(scan_display_math_bytes("$$αβ$", 0), None);
+    }
+}


### PR DESCRIPTION
## Summary

The inline parser materialized every block's text into a `Vec<char>` and re-collected each extracted span into a fresh `String`; it now scans byte offsets over the source `&str` and borrows spans directly, matching the block cursor's representation. Output is byte-identical throughout (spec suite, 1M fuzz runs, non-ASCII differential fixtures), and peak RSS drops ~8.5% on a 2.27 MB inline-dense document.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing reliability for links, autolinks, HTML tags, attributes, and inline math, especially around multi-byte Unicode text and edge cases.
  * Preserved existing Markdown/CommonMark behavior while fixing several boundary and escaping scenarios.

* **Refactor**
  * Reworked inline parsing to use direct string scanning for better UTF-8 handling and consistency.
  * Updated math parsing to use byte-offset logic for CommonMark content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->