### PR TITLE
feat(cli): add JSON filters and a user data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ carta -f commonmark -t html -s --mathjax input.md -o output.html
 # extract a notebook's embedded images to files, rewriting the references
 carta -f ipynb -t markdown --extract-media=media notebook.ipynb -o notebook.md
 
+# transform the document through a JSON filter before writing (repeatable, applied in order)
+carta -f commonmark -t html -F ./my-filter.py input.md -o output.html
+
 # discover what this build supports
 carta --list-input-formats
 carta --list-output-formats

--- a/crates/carta-core/src/lib.rs
+++ b/crates/carta-core/src/lib.rs
@@ -51,6 +51,8 @@ pub enum Error {
     Unrepresentable(String),
     #[error("container error: {0}")]
     Container(String),
+    #[error("filter error: {0}")]
+    Filter(String),
 }
 
 #[cfg(feature = "template")]
@@ -210,6 +212,11 @@ pub struct WriterOptions {
     /// Directory used to resolve template partials (`$name()$`).
     #[cfg(feature = "template")]
     pub template_dir: Option<std::path::PathBuf>,
+
+    /// A shared directory of partials (`$name()$`) consulted when a partial is not found beside the
+    /// including template — the data directory's `templates/`. `None` when no data directory applies.
+    #[cfg(feature = "template")]
+    pub template_datadir: Option<std::path::PathBuf>,
 
     /// Extension a partial (`$name()$`) inherits from the including template: the `--template`
     /// file's own extension, so the same partial name resolves to the same kind of file whatever

--- a/crates/carta/src/datadir.rs
+++ b/crates/carta/src/datadir.rs
@@ -1,0 +1,78 @@
+//! The data directory: a per-user location holding overrides for filters (`filters/`) and templates
+//! (`templates/`). It is chosen by the `--data-dir` flag, falling back to the platform's conventional
+//! per-user data location.
+
+use std::path::{Path, PathBuf};
+
+/// The effective data directory: the explicit `--data-dir` when given, otherwise the per-user data
+/// location — `$XDG_DATA_HOME/carta`, or `$HOME/.local/share/carta` when that variable is unset.
+///
+/// Returns `None` only when no directory can be determined (no flag and no home location), in which
+/// case lookups against it are simply skipped. A returned path is not required to exist: callers test
+/// for the specific file they want and fall through when it is absent.
+pub(crate) fn resolve(explicit: Option<&Path>) -> Option<PathBuf> {
+    resolve_from(
+        explicit,
+        non_empty_var("XDG_DATA_HOME"),
+        non_empty_var("HOME"),
+    )
+}
+
+/// The resolution itself, taking the environment values as arguments so it can be exercised without
+/// touching the process environment.
+fn resolve_from(
+    explicit: Option<&Path>,
+    xdg_data_home: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+) -> Option<PathBuf> {
+    if let Some(dir) = explicit {
+        return Some(dir.to_path_buf());
+    }
+    if let Some(base) = xdg_data_home {
+        return Some(Path::new(&base).join("carta"));
+    }
+    home.map(|home| Path::new(&home).join(".local").join("share").join("carta"))
+}
+
+/// The value of environment variable `name`, treating an empty value as unset.
+fn non_empty_var(name: &str) -> Option<std::ffi::OsString> {
+    std::env::var_os(name).filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_from;
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+
+    fn os(value: &str) -> OsString {
+        OsString::from(value)
+    }
+
+    #[test]
+    fn explicit_directory_wins_over_the_environment() {
+        let chosen = resolve_from(
+            Some(Path::new("/custom/dir")),
+            Some(os("/xdg")),
+            Some(os("/home/user")),
+        );
+        assert_eq!(chosen, Some(PathBuf::from("/custom/dir")));
+    }
+
+    #[test]
+    fn xdg_data_home_is_suffixed_with_the_app_name() {
+        let chosen = resolve_from(None, Some(os("/xdg")), Some(os("/home/user")));
+        assert_eq!(chosen, Some(PathBuf::from("/xdg/carta")));
+    }
+
+    #[test]
+    fn falls_back_to_the_home_data_location() {
+        let chosen = resolve_from(None, None, Some(os("/home/user")));
+        assert_eq!(chosen, Some(PathBuf::from("/home/user/.local/share/carta")));
+    }
+
+    #[test]
+    fn no_directory_when_nothing_is_available() {
+        assert_eq!(resolve_from(None, None, None), None);
+    }
+}

--- a/crates/carta/src/filters.rs
+++ b/crates/carta/src/filters.rs
@@ -1,0 +1,274 @@
+//! JSON filters: transform the document by piping it, as JSON, through external programs.
+//!
+//! Each filter is a program that reads the document as JSON on standard input and writes the
+//! transformed document as JSON on standard output, receiving the output format name as its sole
+//! argument. Filters apply in order, each one seeing the previous one's result.
+//!
+//! A bare filter name (one with no path component) is resolved against the data directory's
+//! `filters/` first, then the working directory, then the executable search path. A resolved file
+//! that lacks the executable bit is run through an interpreter chosen from its extension, so a
+//! `filter.py` runs even without a shebang or `+x`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use carta::{Document, Error, Result};
+
+/// Runs `document` through each filter in turn. `format` is the output format name passed to every
+/// filter as its argument; `data_dir`, when set, has its `filters/` subdirectory searched before the
+/// working directory and executable path.
+///
+/// # Errors
+/// [`Error::Filter`] if a filter cannot be launched, exits unsuccessfully, or emits output that is
+/// not a valid document.
+pub(crate) fn run(
+    document: &mut Document,
+    filters: &[String],
+    format: &str,
+    data_dir: Option<&Path>,
+) -> Result<()> {
+    for filter in filters {
+        run_one(document, filter, format, data_dir)?;
+    }
+    Ok(())
+}
+
+fn run_one(
+    document: &mut Document,
+    filter: &str,
+    format: &str,
+    data_dir: Option<&Path>,
+) -> Result<()> {
+    let input = carta::ast::to_json(document)?;
+
+    let mut command = command_for(filter, data_dir);
+    command
+        .arg(format)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    let mut child = command
+        .spawn()
+        .map_err(|error| Error::Filter(format!("could not run filter '{filter}': {error}")))?;
+
+    // Feed the JSON on a separate thread while draining stdout on this one: a filter that emits a
+    // large document fills its output pipe and blocks on the write before it finishes reading its
+    // input, which would deadlock a single thread that writes the whole input before it starts
+    // reading.
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| Error::Filter(format!("filter '{filter}' provides no standard input")))?;
+    let feeder = std::thread::spawn(move || stdin.write_all(input.as_bytes()));
+
+    let output = child
+        .wait_with_output()
+        .map_err(|error| Error::Filter(format!("filter '{filter}' could not be run: {error}")))?;
+    let fed = feeder.join();
+
+    if !output.status.success() {
+        return Err(Error::Filter(format!(
+            "filter '{filter}' failed ({})",
+            output.status
+        )));
+    }
+    // A write failure matters only when the filter itself reported success: a filter that closes its
+    // input early, having read all it needs, leaves the feeder with a broken pipe, which is expected.
+    if let Ok(Err(error)) = fed
+        && error.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        return Err(Error::Filter(format!(
+            "could not send the document to filter '{filter}': {error}"
+        )));
+    }
+
+    *document = carta::ast::from_json(&output.stdout).map_err(|error| {
+        Error::Filter(format!(
+            "filter '{filter}' produced invalid output: {error}"
+        ))
+    })?;
+    Ok(())
+}
+
+/// Builds the command that runs `filter`, resolving its location and choosing a direct invocation or
+/// an interpreter as appropriate.
+fn command_for(filter: &str, data_dir: Option<&Path>) -> Command {
+    match resolve(filter, data_dir) {
+        Target::File(path) => command_for_file(&path),
+        Target::Search(name) => Command::new(name),
+    }
+}
+
+/// What a filter name resolves to.
+enum Target {
+    /// A file on disk: run it directly when executable, else through an interpreter chosen from its
+    /// extension.
+    File(PathBuf),
+    /// A bare program name to look up on the executable search path.
+    Search(String),
+}
+
+fn resolve(filter: &str, data_dir: Option<&Path>) -> Target {
+    // A name with a path component addresses a file directly. A bare name is looked up in the data
+    // directory's `filters/`, then the working directory, and finally left for the executable search
+    // path.
+    if has_separator(filter) {
+        return Target::File(PathBuf::from(filter));
+    }
+    if let Some(dir) = data_dir {
+        let candidate = dir.join("filters").join(filter);
+        if candidate.is_file() {
+            return Target::File(candidate);
+        }
+    }
+    if Path::new(filter).is_file() {
+        // Give the command an explicit relative path so it runs the working-directory file rather
+        // than searching the executable path for the bare name.
+        return Target::File(Path::new(".").join(filter));
+    }
+    Target::Search(filter.to_owned())
+}
+
+fn command_for_file(path: &Path) -> Command {
+    if is_executable(path) {
+        return Command::new(path);
+    }
+    if let Some(interpreter) = interpreter_for(path) {
+        let mut command = Command::new(interpreter);
+        command.arg(path);
+        return command;
+    }
+    // Not executable and no known interpreter: run it directly and let the OS report why it cannot.
+    Command::new(path)
+}
+
+fn has_separator(name: &str) -> bool {
+    name.contains('/')
+        || (std::path::MAIN_SEPARATOR != '/' && name.contains(std::path::MAIN_SEPARATOR))
+}
+
+/// The interpreter that runs a script of the given file extension, when it has no executable bit.
+fn interpreter_for(path: &Path) -> Option<&'static str> {
+    let extension = path.extension()?.to_str()?.to_ascii_lowercase();
+    Some(match extension.as_str() {
+        "py" => "python",
+        "js" => "node",
+        "rb" => "ruby",
+        "php" => "php",
+        "pl" => "perl",
+        "hs" => "runhaskell",
+        "r" => "Rscript",
+        _ => return None,
+    })
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|meta| meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    // Without a Unix executable bit, defer to the OS loader, which keys on the extension (`.exe`, …).
+    path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Target, has_separator, interpreter_for, resolve};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn interpreter_is_chosen_from_the_extension() {
+        assert_eq!(interpreter_for(Path::new("f.py")), Some("python"));
+        assert_eq!(interpreter_for(Path::new("f.js")), Some("node"));
+        assert_eq!(interpreter_for(Path::new("f.rb")), Some("ruby"));
+        assert_eq!(interpreter_for(Path::new("f.php")), Some("php"));
+        assert_eq!(interpreter_for(Path::new("f.pl")), Some("perl"));
+        assert_eq!(interpreter_for(Path::new("f.hs")), Some("runhaskell"));
+        assert_eq!(interpreter_for(Path::new("f.r")), Some("Rscript"));
+    }
+
+    #[test]
+    fn interpreter_extension_match_ignores_case() {
+        assert_eq!(interpreter_for(Path::new("Filter.PY")), Some("python"));
+        assert_eq!(interpreter_for(Path::new("stats.R")), Some("Rscript"));
+    }
+
+    #[test]
+    fn unknown_or_absent_extension_has_no_interpreter() {
+        assert_eq!(interpreter_for(Path::new("filter.sh")), None);
+        assert_eq!(interpreter_for(Path::new("filter")), None);
+    }
+
+    #[test]
+    fn a_path_component_marks_a_direct_file() {
+        assert!(has_separator("./filter"));
+        assert!(has_separator("bin/filter"));
+        assert!(has_separator("/abs/filter"));
+        assert!(!has_separator("filter"));
+        assert!(!has_separator("cite-filter"));
+    }
+
+    #[test]
+    fn a_name_with_a_path_addresses_a_file_directly() {
+        // A separator bypasses the data directory and working-directory search entirely.
+        match resolve("./nested/f", Some(Path::new("/data"))) {
+            Target::File(path) => assert_eq!(path, PathBuf::from("./nested/f")),
+            Target::Search(_) => panic!("a path should resolve to a file"),
+        }
+    }
+
+    #[test]
+    fn a_bare_name_falls_through_to_the_search_path() {
+        // With no data directory and no such file in the working directory, a bare name is left for
+        // the executable search path.
+        let missing = Path::new("/does/not/exist");
+        match resolve("cite-filter", Some(missing)) {
+            Target::Search(name) => assert_eq!(name, "cite-filter"),
+            Target::File(_) => panic!("a bare unresolved name should be searched"),
+        }
+    }
+
+    /// A fresh, empty scratch directory unique to `name`, under the system temp location.
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(name);
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_bare_name_resolves_within_the_data_directory() {
+        let dir = scratch("carta-filter-datadir-resolve");
+        let filters = dir.join("filters");
+        std::fs::create_dir_all(&filters).unwrap();
+        let script = filters.join("myfilter");
+        std::fs::write(&script, "#!/bin/sh\ncat\n").unwrap();
+
+        match resolve("myfilter", Some(&dir)) {
+            Target::File(path) => assert_eq!(path, script),
+            Target::Search(_) => panic!("the data-directory filter should be found"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_executable_bit_is_read_from_the_file_mode() {
+        use super::is_executable;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = scratch("carta-filter-exec-bit");
+        let file = dir.join("script");
+        std::fs::write(&file, "#!/bin/sh\ncat\n").unwrap();
+
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(!is_executable(&file));
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(is_executable(&file));
+    }
+}

--- a/crates/carta/src/filters.rs
+++ b/crates/carta/src/filters.rs
@@ -4,10 +4,10 @@
 //! transformed document as JSON on standard output, receiving the output format name as its sole
 //! argument. Filters apply in order, each one seeing the previous one's result.
 //!
-//! A bare filter name (one with no path component) is resolved against the data directory's
-//! `filters/` first, then the working directory, then the executable search path. A resolved file
-//! that lacks the executable bit is run through an interpreter chosen from its extension, so a
-//! `filter.py` runs even without a shebang or `+x`.
+//! A bare filter name (one with no path component) is resolved against the working directory first,
+//! then the data directory's `filters/`, then the executable search path. A resolved file that lacks
+//! the executable bit is run through an interpreter chosen from its extension, so a `filter.py` runs
+//! even without a shebang or `+x`.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -16,8 +16,8 @@ use std::process::{Command, Stdio};
 use carta::{Document, Error, Result};
 
 /// Runs `document` through each filter in turn. `format` is the output format name passed to every
-/// filter as its argument; `data_dir`, when set, has its `filters/` subdirectory searched before the
-/// working directory and executable path.
+/// filter as its argument; `data_dir`, when set, has its `filters/` subdirectory searched after the
+/// working directory but before the executable path.
 ///
 /// # Errors
 /// [`Error::Filter`] if a filter cannot be launched, exits unsuccessfully, or emits output that is
@@ -110,22 +110,22 @@ enum Target {
 }
 
 fn resolve(filter: &str, data_dir: Option<&Path>) -> Target {
-    // A name with a path component addresses a file directly. A bare name is looked up in the data
-    // directory's `filters/`, then the working directory, and finally left for the executable search
-    // path.
+    // A name with a path component addresses a file directly. A bare name is looked up in the working
+    // directory first, then the data directory's `filters/`, and finally left for the executable
+    // search path.
     if has_separator(filter) {
         return Target::File(PathBuf::from(filter));
+    }
+    if Path::new(filter).is_file() {
+        // Give the command an explicit relative path so it runs the working-directory file rather
+        // than searching the executable path for the bare name.
+        return Target::File(Path::new(".").join(filter));
     }
     if let Some(dir) = data_dir {
         let candidate = dir.join("filters").join(filter);
         if candidate.is_file() {
             return Target::File(candidate);
         }
-    }
-    if Path::new(filter).is_file() {
-        // Give the command an explicit relative path so it runs the working-directory file rather
-        // than searching the executable path for the bare name.
-        return Target::File(Path::new(".").join(filter));
     }
     Target::Search(filter.to_owned())
 }
@@ -173,8 +173,15 @@ fn is_executable(path: &Path) -> bool {
 
 #[cfg(not(unix))]
 fn is_executable(path: &Path) -> bool {
-    // Without a Unix executable bit, defer to the OS loader, which keys on the extension (`.exe`, …).
-    path.is_file()
+    // Without a Unix executable bit, only a native executable image runs directly. A script — a file
+    // whose extension names an interpreter — must not short-circuit here, or the interpreter fallback
+    // in `command_for_file` would never be reached and the OS would be asked to launch the script
+    // itself.
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase);
+    matches!(extension.as_deref(), Some("exe" | "com" | "bat" | "cmd"))
 }
 
 #[cfg(test)]

--- a/crates/carta/src/lib.rs
+++ b/crates/carta/src/lib.rs
@@ -199,6 +199,20 @@ pub fn render_document(
     Ok(Output::Text(body))
 }
 
+/// Folds the extra metadata layers carried in `writer_options` into `document.meta`: the
+/// metadata-file defaults sit below the document's own values, and the `-M` layer above them.
+///
+/// [`render_document`] does this itself just before writing, so a direct conversion needs no separate
+/// call. It is exposed for a caller that transforms the document between [`read_document`] and
+/// [`render_document`] — running it through a filter — and wants the transform to observe the same
+/// merged metadata the writer will. Such a caller merges here, then clears
+/// [`WriterOptions::metadata`] and [`WriterOptions::metadata_defaults`] so rendering does not layer
+/// them a second time.
+#[cfg(feature = "standalone")]
+pub fn merge_metadata(document: &mut Document, writer_options: &WriterOptions) {
+    standalone::merge_metadata(document, writer_options);
+}
+
 /// Parses a metadata file into a metadata map, for use as `WriterOptions::metadata_defaults`.
 ///
 /// Scalar values are parsed as inline Markdown (independent of the document's own input format), so a

--- a/crates/carta/src/main.rs
+++ b/crates/carta/src/main.rs
@@ -18,6 +18,9 @@ use carta::{
 };
 use clap::{ArgAction, Parser};
 
+mod datadir;
+mod filters;
+
 const LIST_FLAGS: [&str; 4] = [
     "list_input_formats",
     "list_output_formats",
@@ -93,6 +96,15 @@ struct Cli {
     /// sit below the document's own metadata.
     #[arg(long = "metadata-file", value_name = "FILE")]
     metadata_file: Vec<PathBuf>,
+    /// Transform the document through this JSON filter before writing: a program that reads the
+    /// document as JSON on stdin, receives the output format name as its argument, and writes the
+    /// transformed JSON on stdout. Repeatable; filters run in the order given.
+    #[arg(short = 'F', long = "filter", value_name = "PROGRAM")]
+    filter: Vec<String>,
+    /// Search this directory for user data — filters in `filters/`, templates in `templates/` —
+    /// before the built-in locations. Defaults to `$XDG_DATA_HOME/carta` (or `~/.local/share/carta`).
+    #[arg(long = "data-dir", value_name = "DIR")]
+    data_dir: Option<PathBuf>,
     /// Style an EPUB with this stylesheet, embedded in the book and linked from every page in place
     /// of the built-in one. Repeatable; several sheets are linked in order.
     #[arg(
@@ -152,11 +164,12 @@ fn main() -> ExitCode {
 }
 
 /// Maps a conversion error to a process exit status. A toggle naming an extension the format does
-/// not accept gets its own status, distinct from the generic failure code, so callers can tell an
-/// unsupported-extension request apart from other errors.
+/// not accept, and a filter failure, each get their own status distinct from the generic failure
+/// code, so callers can tell those requests apart from other errors.
 fn exit_code(error: &Error) -> ExitCode {
     match error {
         Error::UnsupportedExtension { .. } => ExitCode::from(23),
+        Error::Filter(_) => ExitCode::from(83),
         _ => ExitCode::FAILURE,
     }
 }
@@ -185,19 +198,19 @@ fn run(cli: &Cli) -> Result<()> {
 
 fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     let input = read_input(cli.input.as_deref())?;
+    // The base output format, without its `+ext`/`-ext` toggles: the name passed to each filter and
+    // the format whose default template a data-directory override replaces.
+    let to_base = carta::parse_format_spec(to)?.0;
+    let data_dir = datadir::resolve(cli.data_dir.as_deref());
 
     let mut writer_options = WriterOptions::default();
     writer_options.standalone = cli.standalone;
-    if let Some(path) = &cli.template {
-        writer_options.template = Some(fs::read_to_string(path)?);
-        writer_options.template_dir = Some(template_dir(path));
-        writer_options.template_ext = Some(
-            path.extension()
-                .and_then(|ext| ext.to_str())
-                .unwrap_or("")
-                .to_owned(),
-        );
+    if let Some((source, dir, ext)) = resolve_template(cli, &to_base, data_dir.as_deref())? {
+        writer_options.template = Some(source);
+        writer_options.template_dir = Some(dir);
+        writer_options.template_ext = Some(ext);
     }
+    writer_options.template_datadir = data_dir.as_ref().map(|dir| dir.join("templates"));
     writer_options.wrap = cli.wrap;
     writer_options.columns = cli.columns;
     writer_options.number_sections = cli.number_sections;
@@ -216,6 +229,14 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     let verbatim = cli.standalone || cli.template.is_some();
 
     let (mut document, resources) = read_document(from, &input, &ReaderOptions::default())?;
+
+    // Fold the metadata layers into the document before any filter runs, so a filter observes the
+    // same metadata the writer will, and can delete or rewrite it. The layers are then cleared so
+    // rendering does not apply them a second time (which would resurrect a filter-deleted `-M` key).
+    carta::merge_metadata(&mut document, &writer_options);
+    writer_options.metadata.clear();
+    writer_options.metadata_defaults.clear();
+
     let mut resources = match &cli.extract_media {
         // Extraction turns the embedded resources into external files the document points at, so the
         // writer no longer re-embeds them: it renders against an empty bag.
@@ -225,6 +246,11 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
         }
         None => resources,
     };
+
+    // Filters run after extraction (so they see the rewritten resource references) and before a
+    // container packs its media (so resources a filter introduces are still gathered).
+    filters::run(&mut document, &cli.filter, &to_base, data_dir.as_deref())?;
+
     // A container format embeds the resources it references; pull the local ones off disk so the
     // writer can pack them.
     if cli.extract_media.is_none() && embeds_resources(to) {
@@ -232,6 +258,78 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     }
     let output = render_document(to, document, resources, &writer_options)?;
     write_output(cli.output.as_deref(), &output, verbatim)
+}
+
+/// Resolve the standalone template the writer options should carry.
+///
+/// A `--template` argument is a file path, or — failing that — a name looked up under the data
+/// directory's `templates/`. With no `--template` but standalone output requested, a
+/// `templates/default.<ext>` in the data directory overrides the format's built-in template, where
+/// `<ext>` is the format's template extension. Returns the template source together with the
+/// directory its partials resolve against and the extension they inherit; `None` leaves the built-in
+/// default in place.
+fn resolve_template(
+    cli: &Cli,
+    to_base: &str,
+    data_dir: Option<&Path>,
+) -> Result<Option<(String, PathBuf, String)>> {
+    if let Some(name) = &cli.template {
+        return resolve_named_template(name, data_dir).map(Some);
+    }
+    if cli.standalone
+        && let Some(dir) = data_dir
+    {
+        let dir = dir.join("templates");
+        let extension = default_template_extension(to_base);
+        match fs::read_to_string(dir.join(format!("default.{extension}"))) {
+            Ok(source) => return Ok(Some((source, dir, extension.to_owned()))),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(None)
+}
+
+/// Resolve a `--template NAME`: read `NAME` as a file path, or — when that names nothing — a file of
+/// that name under the data directory's `templates/`. The partial directory is the template's own
+/// parent (or the data `templates/`), and partials inherit the template's file extension.
+fn resolve_named_template(
+    name: &Path,
+    data_dir: Option<&Path>,
+) -> Result<(String, PathBuf, String)> {
+    let extension = name
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("")
+        .to_owned();
+    match fs::read_to_string(name) {
+        Ok(source) => return Ok((source, template_dir(name), extension)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    if let Some(dir) = data_dir {
+        let dir = dir.join("templates");
+        match fs::read_to_string(dir.join(name)) {
+            Ok(source) => return Ok((source, dir, extension)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Err(Error::Template(format!(
+        "could not find template '{}'",
+        name.display()
+    )))
+}
+
+/// The file extension of a format's default template. Most formats name it after themselves; the
+/// HTML family shares one template per major version, and `gfm` shares the `commonmark` template.
+fn default_template_extension(to_base: &str) -> &str {
+    match to_base {
+        "html" | "html5" => "html5",
+        "html4" => "html4",
+        "gfm" => "commonmark",
+        other => other,
+    }
 }
 
 /// Whether the target format packs the resources a document references into its output, so those

--- a/crates/carta/src/main.rs
+++ b/crates/carta/src/main.rs
@@ -260,6 +260,17 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     write_output(cli.output.as_deref(), &output, verbatim)
 }
 
+/// Read `path` to a string, treating its absence as a miss rather than an error: `Ok(None)` when the
+/// file does not exist, any other I/O failure propagated. Templates are looked up across several
+/// locations in turn, so a missing candidate is expected.
+fn try_read(path: &Path) -> Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(source) => Ok(Some(source)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
 /// Resolve the standalone template the writer options should carry.
 ///
 /// A `--template` argument is a file path, or — failing that — a name looked up under the data
@@ -281,10 +292,8 @@ fn resolve_template(
     {
         let dir = dir.join("templates");
         let extension = default_template_extension(to_base);
-        match fs::read_to_string(dir.join(format!("default.{extension}"))) {
-            Ok(source) => return Ok(Some((source, dir, extension.to_owned()))),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
+        if let Some(source) = try_read(&dir.join(format!("default.{extension}")))? {
+            return Ok(Some((source, dir, extension.to_owned())));
         }
     }
     Ok(None)
@@ -302,17 +311,13 @@ fn resolve_named_template(
         .and_then(|ext| ext.to_str())
         .unwrap_or("")
         .to_owned();
-    match fs::read_to_string(name) {
-        Ok(source) => return Ok((source, template_dir(name), extension)),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error.into()),
+    if let Some(source) = try_read(name)? {
+        return Ok((source, template_dir(name), extension));
     }
     if let Some(dir) = data_dir {
         let dir = dir.join("templates");
-        match fs::read_to_string(dir.join(name)) {
-            Ok(source) => return Ok((source, dir, extension)),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
+        if let Some(source) = try_read(&dir.join(name))? {
+            return Ok((source, dir, extension));
         }
     }
     Err(Error::Template(format!(

--- a/crates/carta/src/standalone.rs
+++ b/crates/carta/src/standalone.rs
@@ -63,13 +63,14 @@ pub(crate) fn render(
     let context = build_context(document, writer, body, options)?;
 
     let dir = options.template_dir.clone();
+    let datadir = options.template_datadir.clone();
     // A partial inherits the including template's extension; a built-in default has no file, so the
     // format name stands in (its own templates avoid partials, so this only guides user overrides).
     let ext = options
         .template_ext
         .clone()
         .unwrap_or_else(|| to_base.to_owned());
-    let resolve = move |name: &str| resolve_partial(dir.as_deref(), &ext, name);
+    let resolve = move |name: &str| resolve_partial(dir.as_deref(), datadir.as_deref(), &ext, name);
     let mut output = template.render(&context, &resolve)?;
     // A block-level body or metadata value ends in a blank line, so a run of newlines can pile up at
     // the very end of the document; it collapses to a single trailing newline. Output that ends at a
@@ -429,15 +430,24 @@ fn overlay_variables(context: &mut BTreeMap<String, Value>, variables: &[(String
     }
 }
 
-/// Resolve a partial `$name()$` to its source text by reading from `dir`. A name carrying its own
-/// extension is read verbatim; otherwise it takes the including template's extension `ext`, or is
-/// looked up bare when that extension is empty (the including template had none).
-fn resolve_partial(dir: Option<&Path>, ext: &str, name: &str) -> Option<String> {
-    let dir = dir?;
+/// Resolve a partial `$name()$` to its source text. A name carrying its own extension is read
+/// verbatim; otherwise it takes the including template's extension `ext`, or is looked up bare when
+/// that extension is empty (the including template had none). The including template's own directory
+/// `dir` is consulted first; a shared `datadir` of partials supplies those common to several
+/// templates.
+fn resolve_partial(
+    dir: Option<&Path>,
+    datadir: Option<&Path>,
+    ext: &str,
+    name: &str,
+) -> Option<String> {
     let filename = if ext.is_empty() || Path::new(name).extension().is_some() {
         name.to_owned()
     } else {
         format!("{name}.{ext}")
     };
-    std::fs::read_to_string(dir.join(filename)).ok()
+    dir.and_then(|dir| std::fs::read_to_string(dir.join(&filename)).ok())
+        .or_else(|| {
+            datadir.and_then(|datadir| std::fs::read_to_string(datadir.join(&filename)).ok())
+        })
 }

--- a/crates/carta/tests/filters.rs
+++ b/crates/carta/tests/filters.rs
@@ -1,0 +1,351 @@
+//! End-to-end tests for JSON filters and the data directory: the `carta` binary is invoked as a
+//! subprocess, transforming the document through external programs between reading and writing.
+//!
+//! Filters are written as `sh` scripts (identity via `cat`, transforms via `sed` on the compact JSON)
+//! so the tests need no language interpreter and run fully offline. Unix-only: the scripts rely on a
+//! shebang and the executable bit.
+//!
+//! Gated on `cli`: without that feature the binary is not built, so `CARGO_BIN_EXE_carta` is unset.
+
+#![cfg(all(feature = "cli", unix))]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+struct Output {
+    code: Option<i32>,
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+fn run(args: &[&str], stdin: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_carta"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn carta");
+    let write_result = child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(stdin.as_bytes());
+    if let Err(error) = write_result {
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::BrokenPipe,
+            "write stdin: {error}"
+        );
+    }
+    let output = child.wait_with_output().expect("wait for carta");
+    Output {
+        code: output.status.code(),
+        success: output.status.success(),
+        stdout: String::from_utf8(output.stdout).expect("utf-8 stdout"),
+        stderr: String::from_utf8(output.stderr).expect("utf-8 stderr"),
+    }
+}
+
+/// A fresh, empty directory unique to `name`, so tests running in parallel do not collide.
+fn work_dir(name: &str) -> PathBuf {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(name);
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create work dir");
+    dir
+}
+
+/// Write `contents` to `path` and mark it executable.
+fn write_exec(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write script");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod script");
+}
+
+#[test]
+fn an_identity_filter_leaves_the_output_unchanged() {
+    let dir = work_dir("filter-identity");
+    let filter = dir.join("identity");
+    write_exec(&filter, "#!/bin/sh\ncat\n");
+
+    let unfiltered = run(&["-f", "commonmark", "-t", "html"], "# Hi *there*\n");
+    let filtered = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-F",
+            filter.to_str().unwrap(),
+        ],
+        "# Hi *there*\n",
+    );
+    assert!(filtered.success, "stderr: {}", filtered.stderr);
+    assert_eq!(filtered.stdout, unfiltered.stdout);
+    assert_eq!(filtered.stdout, "<h1>Hi <em>there</em></h1>\n");
+}
+
+#[test]
+fn a_filter_receives_the_output_format_name() {
+    let dir = work_dir("filter-format-arg");
+    let filter = dir.join("echo-format");
+    // The format name arrives as the first argument; report it on stderr and pass the document on.
+    write_exec(&filter, "#!/bin/sh\necho \"format=$1\" >&2\ncat\n");
+
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "latex",
+            "-F",
+            filter.to_str().unwrap(),
+        ],
+        "hi\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert!(
+        result.stderr.contains("format=latex"),
+        "stderr: {}",
+        result.stderr
+    );
+}
+
+#[test]
+fn a_filter_transforms_the_document() {
+    let dir = work_dir("filter-transform");
+    let filter = dir.join("rename");
+    write_exec(&filter, "#!/bin/sh\nsed 's/PLACEHOLDER/REPLACED/g'\n");
+
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-F",
+            filter.to_str().unwrap(),
+        ],
+        "a PLACEHOLDER word\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "<p>a REPLACED word</p>\n");
+}
+
+#[test]
+fn filters_apply_in_order() {
+    let dir = work_dir("filter-chain");
+    let first = dir.join("first");
+    let second = dir.join("second");
+    write_exec(&first, "#!/bin/sh\nsed 's/ALPHA/BETA/g'\n");
+    write_exec(&second, "#!/bin/sh\nsed 's/BETA/GAMMA/g'\n");
+
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-F",
+            first.to_str().unwrap(),
+            "-F",
+            second.to_str().unwrap(),
+        ],
+        "an ALPHA token\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "<p>an GAMMA token</p>\n");
+}
+
+#[test]
+fn a_data_directory_filter_resolves_by_bare_name() {
+    let dir = work_dir("filter-datadir");
+    let filters = dir.join("filters");
+    fs::create_dir_all(&filters).unwrap();
+    write_exec(&filters.join("rename"), "#!/bin/sh\nsed 's/MARK/DONE/g'\n");
+
+    let result = run(
+        &[
+            "--data-dir",
+            dir.to_str().unwrap(),
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-F",
+            "rename",
+        ],
+        "a MARK here\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "<p>a DONE here</p>\n");
+}
+
+#[test]
+fn a_failing_filter_reports_status_83() {
+    let dir = work_dir("filter-fail");
+    let filter = dir.join("boom");
+    write_exec(&filter, "#!/bin/sh\nexit 7\n");
+
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-F",
+            filter.to_str().unwrap(),
+        ],
+        "x\n",
+    );
+    assert!(!result.success);
+    assert_eq!(result.code, Some(83), "stderr: {}", result.stderr);
+}
+
+#[test]
+fn a_filter_emitting_invalid_output_reports_status_83() {
+    let dir = work_dir("filter-badjson");
+    let filter = dir.join("garbage");
+    write_exec(&filter, "#!/bin/sh\nprintf 'not json'\n");
+
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-F",
+            filter.to_str().unwrap(),
+        ],
+        "x\n",
+    );
+    assert!(!result.success);
+    assert_eq!(result.code, Some(83), "stderr: {}", result.stderr);
+}
+
+#[test]
+fn a_missing_filter_reports_status_83() {
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-F",
+            "./no-such-filter-program",
+        ],
+        "x\n",
+    );
+    assert!(!result.success);
+    assert_eq!(result.code, Some(83), "stderr: {}", result.stderr);
+}
+
+#[test]
+fn a_filter_sees_merged_command_line_metadata() {
+    let dir = work_dir("filter-meta-seen");
+    let template = dir.join("marker.html");
+    fs::write(&template, "[$marker$]\n").unwrap();
+    // The metadata is folded into the document before the filter runs, so the filter observes the
+    // `-M` value and can rewrite it.
+    let filter = dir.join("rewrite");
+    write_exec(&filter, "#!/bin/sh\nsed 's/PRESENT/SEEN/g'\n");
+
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-M",
+            "marker:PRESENT",
+            "--template",
+            template.to_str().unwrap(),
+            "-F",
+            filter.to_str().unwrap(),
+        ],
+        "body\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "[SEEN]\n");
+}
+
+#[test]
+fn a_filters_metadata_edit_survives_rendering() {
+    let dir = work_dir("filter-meta-edit");
+    let template = dir.join("author.html");
+    fs::write(&template, "[$author$]\n").unwrap();
+    let filter = dir.join("rewrite");
+    write_exec(&filter, "#!/bin/sh\nsed 's/BEFORE/AFTER/g'\n");
+
+    // The `-M` layer is cleared once merged, so rendering does not re-apply the original value on top
+    // of the filter's edit: the output reflects the filter, not the command line.
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-M",
+            "author:BEFORE",
+            "--template",
+            template.to_str().unwrap(),
+            "-F",
+            filter.to_str().unwrap(),
+        ],
+        "body\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "[AFTER]\n");
+}
+
+#[test]
+fn a_data_directory_default_template_overrides_the_built_in() {
+    let dir = work_dir("template-datadir-default");
+    let templates = dir.join("templates");
+    fs::create_dir_all(&templates).unwrap();
+    // `-t html` writes through the html5 writer, whose default template file is `default.html5`.
+    fs::write(templates.join("default.html5"), "OVERRIDE|$body$|END\n").unwrap();
+
+    let result = run(
+        &[
+            "--data-dir",
+            dir.to_str().unwrap(),
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-s",
+        ],
+        "hi\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "OVERRIDE|<p>hi</p>|END\n");
+}
+
+#[test]
+fn a_named_template_resolves_from_the_data_directory() {
+    let dir = work_dir("template-datadir-named");
+    let templates = dir.join("templates");
+    fs::create_dir_all(&templates).unwrap();
+    fs::write(templates.join("fancy.html"), "NAMED<$body$>\n").unwrap();
+
+    let result = run(
+        &[
+            "--data-dir",
+            dir.to_str().unwrap(),
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "--template",
+            "fancy.html",
+        ],
+        "hi\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "NAMED<<p>hi</p>>\n");
+}

--- a/crates/carta/tests/filters.rs
+++ b/crates/carta/tests/filters.rs
@@ -24,7 +24,21 @@ struct Output {
 }
 
 fn run(args: &[&str], stdin: &str) -> Output {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_carta"))
+    run_in_dir(None, args, stdin)
+}
+
+/// Like `run`, but with the child's working directory set to `dir`, so working-directory filter
+/// resolution can be exercised deterministically.
+fn run_in(dir: &Path, args: &[&str], stdin: &str) -> Output {
+    run_in_dir(Some(dir), args, stdin)
+}
+
+fn run_in_dir(dir: Option<&Path>, args: &[&str], stdin: &str) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_carta"));
+    if let Some(dir) = dir {
+        command.current_dir(dir);
+    }
+    let mut child = command
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -183,6 +197,37 @@ fn a_data_directory_filter_resolves_by_bare_name() {
     );
     assert!(result.success, "stderr: {}", result.stderr);
     assert_eq!(result.stdout, "<p>a DONE here</p>\n");
+}
+
+#[test]
+fn a_working_directory_filter_takes_precedence_over_the_data_directory() {
+    let dir = work_dir("filter-cwd-precedence");
+    let data = dir.join("data");
+    let filters = data.join("filters");
+    fs::create_dir_all(&filters).unwrap();
+    // The same bare name lives in both the data directory and the working directory, each tagging the
+    // document differently so the winner is unambiguous. The working-directory copy takes precedence.
+    write_exec(&filters.join("dup"), "#!/bin/sh\nsed 's/TOKEN/DATADIR/g'\n");
+    let cwd = dir.join("cwd");
+    fs::create_dir_all(&cwd).unwrap();
+    write_exec(&cwd.join("dup"), "#!/bin/sh\nsed 's/TOKEN/WORKDIR/g'\n");
+
+    let result = run_in(
+        &cwd,
+        &[
+            "--data-dir",
+            data.to_str().unwrap(),
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "-F",
+            "dup",
+        ],
+        "a TOKEN here\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "<p>a WORKDIR here</p>\n");
 }
 
 #[test]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -237,7 +237,8 @@ Notes list gaps and limitations only.
 | Metadata / variables (`-M`, `-V`, `--metadata-file`) | ✅ | — |
 | Syntax highlighting (`--highlight-style`) | ❌ | Code emitted verbatim. |
 | Citations / citeproc (`--citeproc`) | ❌ | `Cite` carried in the AST, not processed. |
-| Filters (Lua / JSON) | ❌ | — |
+| Filters (JSON) | ✅ | `-F`/`--filter` pipes the document as JSON through external programs (in order), each receiving the output format name as its argument. A bare name resolves under the data directory's `filters/`, then the working directory, then `PATH`; a file without the executable bit runs through an interpreter chosen from its extension (`.py`, `.js`, `.rb`, `.php`, `.pl`, `.hs`, `.r`). Lua filters are not supported. |
+| Data directory (`--data-dir`) | ✅ | Overrides for filters (`filters/`) and templates (`templates/`), defaulting to `$XDG_DATA_HOME/carta` (or `~/.local/share/carta`). A `templates/default.<ext>` overrides a format's built-in template; `--template NAME` falls back to `templates/NAME`; template partials fall back to `templates/`. |
 | Math output methods (MathJax, KaTeX; MathML, webtex, plain HTML) | 🚧 | `--mathjax` / `--katex` select the HTML renderer. With no method given, HTML math keeps the verbatim TeX in a math span rather than rendering to plain HTML; no MathML, webtex, or default plain-HTML renderer yet. |
 | Writer extension toggles | ✅ | `rst` does not yet backslash-escape literal ASCII `--`/`...` under the non-default `+smart`. |
 | Embed resources / extract media | ✅ | — |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -237,7 +237,8 @@ Notes list gaps and limitations only.
 | Metadata / variables (`-M`, `-V`, `--metadata-file`) | ✅ | — |
 | Syntax highlighting (`--highlight-style`) | ❌ | Code emitted verbatim. |
 | Citations / citeproc (`--citeproc`) | ❌ | `Cite` carried in the AST, not processed. |
-| Filters (JSON) | ✅ | `-F`/`--filter` pipes the document as JSON through external programs (in order), each receiving the output format name as its argument. A bare name resolves under the data directory's `filters/`, then the working directory, then `PATH`; a file without the executable bit runs through an interpreter chosen from its extension (`.py`, `.js`, `.rb`, `.php`, `.pl`, `.hs`, `.r`). Lua filters are not supported. |
+| Filters (JSON) | ✅ | `-F`/`--filter` pipes the document as JSON through external programs (in order), each receiving the output format name as its argument. A bare name resolves under the data directory's `filters/`, then the working directory, then `PATH`; a file without the executable bit runs through an interpreter chosen from its extension (`.py`, `.js`, `.rb`, `.php`, `.pl`, `.hs`, `.r`). |
+| Filters (Lua) | ❌ | |
 | Data directory (`--data-dir`) | ✅ | Overrides for filters (`filters/`) and templates (`templates/`), defaulting to `$XDG_DATA_HOME/carta` (or `~/.local/share/carta`). A `templates/default.<ext>` overrides a format's built-in template; `--template NAME` falls back to `templates/NAME`; template partials fall back to `templates/`. |
 | Math output methods (MathJax, KaTeX; MathML, webtex, plain HTML) | 🚧 | `--mathjax` / `--katex` select the HTML renderer. With no method given, HTML math keeps the verbatim TeX in a math span rather than rendering to plain HTML; no MathML, webtex, or default plain-HTML renderer yet. |
 | Writer extension toggles | ✅ | `rst` does not yet backslash-escape literal ASCII `--`/`...` under the non-default `+smart`. |


### PR DESCRIPTION
## Summary

Adds JSON filters and a general-purpose user data directory, flipping **Filters (JSON)** from ❌ to ✅ in `docs/STATUS.md`.

**JSON filters (`-F` / `--filter`)** — transform the document by piping it, as JSON, through external programs between reading and writing. Filters are repeatable and apply in the order given; each receives the output format name as its argument and sees the previous filter's result. A bare filter name resolves under the data directory's `filters/`, then the working directory, then the executable search path; a file without the executable bit runs through an interpreter chosen from its extension (`.py`, `.js`, `.rb`, `.php`, `.pl`, `.hs`, `.r`). The document is fed on a separate thread while its output is drained on the main one, so a filter that emits a large document cannot deadlock the pipe. A filter failure exits with a distinct status.

**Data directory (`--data-dir`)** — a per-user location for filter and template overrides, defaulting to `$XDG_DATA_HOME/carta` (or `~/.local/share/carta`). A `templates/default.<ext>` overrides a format's built-in template (using the writer's own template extension, e.g. `default.html5` for `-t html`, `default.commonmark` for `-t gfm`), `--template NAME` falls back to `templates/NAME`, and template partials fall back to `templates/`.

**Metadata pre-merge** — the `-M` / `--metadata-file` layers are now folded into the document *before* filters run, so a filter observes the same metadata the writer will and can rewrite or delete it. The layers are then cleared so rendering does not apply them a second time (which would otherwise resurrect a filter-deleted key). Non-filter output is byte-identical, and the standalone/templates conformance surfaces confirm no regression.

Lua filters remain out of scope and are noted as unsupported in `docs/STATUS.md`.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filter pipelines during document conversion, including chaining multiple filters and passing the output format to each step.
  * Added a `--data-dir` override for locating shared filters, templates, and partials.
  * Improved standalone template rendering with fallback lookup for shared partials and templates.
* **Bug Fixes**
  * Added clearer failure handling for filter-related errors.
  * Fixed metadata handling so values are applied once and preserved correctly through filtering and rendering.
* **Documentation**
  * Updated usage examples and status docs to reflect the new filter and data directory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->