### PR TITLE
fix(readers): guard latex #0 and roman enumerator arithmetic

### DIFF
--- a/crates/carta-readers/src/commonmark/cursor.rs
+++ b/crates/carta-readers/src/commonmark/cursor.rs
@@ -744,7 +744,7 @@ fn roman_value(run: &[u8]) -> Option<i32> {
 
     // Thousands: any number of `m`.
     while lower.get(pos) == Some(&b'm') {
-        total += 1000;
+        total = total.checked_add(1000)?;
         pos += 1;
     }
     total += take_roman_place(&lower, &mut pos, b'c', b'd', b'm', 100);
@@ -813,4 +813,22 @@ fn rest_is_blank(bytes: &[u8], start: usize) -> bool {
         .flatten()
         .take_while(|byte| **byte != b'\n')
         .all(|byte| matches!(byte, b' ' | b'\t'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roman_value_reads_thousands() {
+        assert_eq!(roman_value(b"mm"), Some(2000));
+    }
+
+    // A roman run long enough to overflow the thousands accumulator is not a valid enumerator: the
+    // checked add yields `None` rather than panicking under overflow checks.
+    #[test]
+    fn roman_value_rejects_oversized_run() {
+        let run = vec![b'm'; 3_000_000];
+        assert_eq!(roman_value(&run), None);
+    }
 }

--- a/crates/carta-readers/src/latex.rs
+++ b/crates/carta-readers/src/latex.rs
@@ -2585,7 +2585,7 @@ fn substitute_macro(body: &str, args: &[String]) -> String {
     while let Some(c) = chars.next() {
         if c == '#' {
             match chars.peek() {
-                Some(d) if d.is_ascii_digit() => {
+                Some(d) if matches!(d, '1'..='9') => {
                     let idx = (*d as usize) - ('1' as usize);
                     chars.next();
                     if let Some(arg) = args.get(idx) {
@@ -3071,6 +3071,14 @@ mod tests {
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
         }
+    }
+
+    // `#0` is not a parameter reference: only `#1`…`#9` are. A `#0` in a macro body is emitted
+    // verbatim rather than triggering an out-of-range parameter lookup.
+    #[test]
+    fn substitute_macro_preserves_non_parameter_hash_zero() {
+        let expanded = substitute_macro("a#0b", &["Y".to_owned()]);
+        assert_eq!(expanded, "a#0b");
     }
 
     // A numbered display environment is captured as display math whose body preserves the full


### PR DESCRIPTION
## Summary

Guards two arithmetic operations on document-controlled values that panic release builds (`overflow-checks = true`): a LaTeX `#0` macro parameter underflowed the index computation, and a multi-million-character roman enumerator overflowed the `i32` accumulator. Both now degrade gracefully (`#0` is emitted verbatim; an oversized run is not an enumerator), with regression tests.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.