### PR TITLE
feat(html-writer): inline external resources for self-contained HTML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -93,6 +93,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -116,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "carta"
 version = "0.0.4"
 dependencies = [
@@ -128,6 +140,7 @@ dependencies = [
  "criterion",
  "insta",
  "serde_json",
+ "ureq",
 ]
 
 [[package]]
@@ -322,7 +335,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -389,7 +402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -420,6 +433,17 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -465,6 +489,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "id-arena"
@@ -594,6 +634,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +712,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,7 +735,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -773,6 +868,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,10 +891,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -869,6 +970,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +1024,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -937,6 +1084,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +1114,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -975,12 +1131,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1095,6 +1324,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ carta -f ipynb -t markdown --extract-media=media notebook.ipynb -o notebook.md
 # embed a document's images into a container format, searching extra directories for them
 carta -f commonmark -t docx --resource-path=assets:img input.md -o output.docx
 
+# produce a self-contained HTML file with every image inlined as a data: URI
+carta -f commonmark -t html -s --embed-resources input.md -o output.html
+
 # transform the document through a JSON filter before writing (repeatable, applied in order)
 carta -f commonmark -t html -F ./my-filter.py input.md -o output.html
 

--- a/crates/carta-core/src/lib.rs
+++ b/crates/carta-core/src/lib.rs
@@ -230,6 +230,9 @@ pub struct HighlightOptions {
 }
 
 /// Options controlling a [`Writer`]. Extended (not resignatured) as real options land.
+// Each independent output toggle is its own field; grouping them would only obscure the
+// one-option-one-field mapping a caller sets them through.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct WriterOptions {

--- a/crates/carta-writers/src/embed.rs
+++ b/crates/carta-writers/src/embed.rs
@@ -1,0 +1,753 @@
+//! Inlining external resources into a finished HTML document to make it self-contained.
+//!
+//! A rendered page references its images, stylesheets, and scripts by URL. This pass rewrites those
+//! references in place so the document carries every resource within itself: an image becomes a
+//! `data:` URI, a linked stylesheet or external script becomes an inline `<style>`/`<script>` element,
+//! and a `url(...)` inside CSS becomes a `data:` URI too. The bytes for each reference come from a
+//! caller-supplied resolver — reading a file, fetching a URL, consulting a bag — so this module holds
+//! no I/O: it only finds the references and splices the resolved bytes back in.
+//!
+//! The pass runs over the final markup, after line wrapping, so a reference that spans a wrapped line
+//! is inlined exactly where it sits and the surrounding layout is left untouched.
+
+use carta_core::media::base64_encode;
+
+/// A resolved resource: its bytes and, when the resolver could determine one, its MIME type.
+#[derive(Debug, Clone)]
+pub struct Resource {
+    /// The resource's raw bytes.
+    pub bytes: Vec<u8>,
+    /// The resource's MIME type, when known.
+    pub mime: Option<String>,
+}
+
+/// Inline every external resource an HTML document references, producing a self-contained page.
+///
+/// Each referenced URL is offered to `resolve`, which returns the resource's bytes and MIME type, or
+/// `None` to leave the reference as written (an unresolved or unreachable resource stays external).
+/// Images and other media are inlined as `data:` URIs; a linked stylesheet becomes an inline `<style>`
+/// and an external script an inline `<script>`; `url(...)` references inside `<style>` blocks and
+/// inlined stylesheets are inlined too. A reference that is already a `data:` URI, a fragment, or
+/// empty is left alone.
+pub fn inline_resources(html: &str, mut resolve: impl FnMut(&str) -> Option<Resource>) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut i = 0;
+    while i < html.len() {
+        let Some(rel) = html.get(i..).and_then(|rest| rest.find('<')) else {
+            out.push_str(sub(html, i, html.len()));
+            break;
+        };
+        let lt = i + rel;
+        out.push_str(sub(html, i, lt));
+        i = handle_tag(html, lt, &mut out, &mut resolve);
+    }
+    out
+}
+
+/// Handle the markup beginning at the `<` at `lt`, appending the (possibly rewritten) result to `out`
+/// and returning the index just past what was consumed. A construct this pass does not touch —
+/// a comment, a declaration, a plain tag — is copied through verbatim.
+fn handle_tag(
+    html: &str,
+    lt: usize,
+    out: &mut String,
+    resolve: &mut impl FnMut(&str) -> Option<Resource>,
+) -> usize {
+    // Comments, declarations, and processing instructions are copied to their `>` untouched.
+    if let Some(after) = markup_prefix_end(html, lt) {
+        out.push_str(sub(html, lt, after));
+        return after;
+    }
+    let Some(tag) = parse_start_tag(html, lt) else {
+        // A lone `<` that opens no tag is literal text.
+        out.push('<');
+        return lt + 1;
+    };
+    match tag.name.as_str() {
+        // Style and script hold raw text (their body is not parsed as markup), so both consume through
+        // their closing tag. A stylesheet link and a sourced script are replaced whole; other cases
+        // rewrite in place.
+        "style" => inline_style_element(html, &tag, out, resolve),
+        "script" => inline_script_element(html, &tag, out, resolve),
+        "link" if is_stylesheet_link(&tag) => inline_link_element(html, &tag, out, resolve),
+        _ => {
+            rewrite_media_tag(html, &tag, out, resolve);
+            tag.end
+        }
+    }
+}
+
+/// The attributes whose value names a resource to inline, per element. Each names a single URL;
+/// `srcset`, being a responsive candidate list rather than a lone reference, is deliberately left
+/// alone so its descriptors and multiple sources survive untouched.
+fn resource_attrs(element: &str) -> &'static [&'static str] {
+    match element {
+        "img" => &["src", "data-src", "poster"],
+        "video" | "audio" => &["src", "poster"],
+        "source" | "input" | "embed" | "track" | "iframe" => &["src"],
+        _ => &[],
+    }
+}
+
+/// Rewrite the resource-bearing attributes of a media element in place, splicing each resolved
+/// reference back as a `data:` URI while leaving the rest of the tag — its spacing, attribute order,
+/// and every other attribute — byte-for-byte as it was. A media element additionally gains the
+/// assistive-technology annotation of [`aria_prefix`], since an inlined graphic carries no external
+/// source to describe it.
+fn rewrite_media_tag(
+    html: &str,
+    tag: &StartTag,
+    out: &mut String,
+    resolve: &mut impl FnMut(&str) -> Option<Resource>,
+) {
+    let wanted = resource_attrs(&tag.name);
+    let bears_resource = tag
+        .attrs
+        .iter()
+        .any(|attr| wanted.contains(&attr.name.as_str()));
+    if !bears_resource {
+        // Not a media element, or one carrying none of its resource attributes (an `<img>` with only a
+        // `srcset`, say): copy it through verbatim, annotation and all.
+        out.push_str(sub(html, tag.lt, tag.end));
+        return;
+    }
+    // Collect the value replacements, in source order, then splice them across the original tag text.
+    let mut edits: Vec<(usize, usize, String)> = Vec::new();
+    // The assistive-technology annotation is inserted right after the element name, before the first
+    // attribute, so it precedes everything the tag already carries.
+    let name_end = tag.lt + 1 + tag.name.len();
+    let prefix = aria_prefix(tag);
+    if !prefix.is_empty() {
+        edits.push((name_end, name_end, prefix));
+    }
+    for attr in &tag.attrs {
+        let Some((start, end)) = attr.value_span else {
+            continue;
+        };
+        if !wanted.contains(&attr.name.as_str()) {
+            continue;
+        }
+        let value = sub(html, start, end);
+        let replaced = inline_url("", value, resolve).unwrap_or_else(|| value.to_owned());
+        if replaced != value {
+            edits.push((start, end, replaced));
+        }
+    }
+    splice(html, tag.lt, tag.end, &edits, out);
+}
+
+/// The assistive-technology attributes a media element gains when its resources are inlined, ready to
+/// insert right after the element name: `role="img"` unless the element already carries a `role`, and
+/// an `aria-label` mirroring its `alt` attribute (value and all, including a valueless one) when it has
+/// one. Empty when the element needs neither.
+fn aria_prefix(tag: &StartTag) -> String {
+    let mut prefix = String::new();
+    if !tag.has_attr("role") {
+        prefix.push_str(" role=\"img\"");
+    }
+    if let Some(alt) = tag.attr_entry("alt") {
+        match &alt.value {
+            Some(value) => {
+                prefix.push_str(" aria-label=\"");
+                prefix.push_str(value);
+                prefix.push('"');
+            }
+            None => prefix.push_str(" aria-label"),
+        }
+    }
+    prefix
+}
+
+/// Resolve one URL to a `data:` URI, or `None` to leave it as written. A reference that is empty, a
+/// fragment, or already a `data:` URI is left alone; anything else is joined against `base` and offered
+/// to the resolver.
+fn inline_url(
+    base: &str,
+    url: &str,
+    resolve: &mut impl FnMut(&str) -> Option<Resource>,
+) -> Option<String> {
+    if skip_reference(url) {
+        return None;
+    }
+    let target = join_url(base, url);
+    let resource = resolve(&target)?;
+    Some(data_uri(resource.mime.as_deref(), &resource.bytes))
+}
+
+/// A `data:` URI carrying `bytes` inline: the MIME type — or `application/octet-stream` when none is
+/// known — then the bytes as unbroken base64.
+fn data_uri(mime: Option<&str>, bytes: &[u8]) -> String {
+    let mime = mime.unwrap_or("application/octet-stream");
+    format!("data:{mime};base64,{}", base64_encode(bytes))
+}
+
+/// A `<style>` element: emit its start tag unchanged, then its CSS body with every `url(...)` inlined,
+/// then its closing tag. Returns the index past `</style>`.
+fn inline_style_element(
+    html: &str,
+    tag: &StartTag,
+    out: &mut String,
+    resolve: &mut impl FnMut(&str) -> Option<Resource>,
+) -> usize {
+    let (body, end) = raw_text_body(html, tag.end, "style");
+    out.push_str(sub(html, tag.lt, tag.end));
+    out.push_str(&inline_css("", body, resolve));
+    out.push_str(sub(html, tag.end + body.len(), end));
+    end
+}
+
+/// A `<script>` element: when it sources an external file, replace the whole element with an inline
+/// script carrying the fetched code (keeping only a `type` attribute, as a self-contained script needs
+/// no `src`); otherwise leave it untouched. Returns the index past `</script>`.
+fn inline_script_element(
+    html: &str,
+    tag: &StartTag,
+    out: &mut String,
+    resolve: &mut impl FnMut(&str) -> Option<Resource>,
+) -> usize {
+    let (_body, end) = raw_text_body(html, tag.end, "script");
+    match tag
+        .attr("src")
+        .and_then(|src| inline_text_resource(src, resolve))
+    {
+        Some(code) => {
+            out.push_str("<script");
+            if let Some(kind) = tag.attr("type") {
+                out.push_str(" type=\"");
+                out.push_str(kind);
+                out.push('"');
+            }
+            out.push('>');
+            out.push_str(&code);
+            out.push_str("</script>");
+        }
+        None => out.push_str(sub(html, tag.lt, end)),
+    }
+    end
+}
+
+/// A `<link rel="stylesheet">`: replace it with an inline `<style>` carrying the fetched stylesheet,
+/// its own `url(...)` references inlined relative to the stylesheet's location. A stylesheet that will
+/// not resolve is left as the original link. Returns the index past the link tag.
+fn inline_link_element(
+    html: &str,
+    tag: &StartTag,
+    out: &mut String,
+    resolve: &mut impl FnMut(&str) -> Option<Resource>,
+) -> usize {
+    match tag
+        .attr("href")
+        .filter(|href| !skip_reference(href))
+        .and_then(|href| Some((href, inline_text_resource(href, resolve)?)))
+    {
+        Some((href, css)) => {
+            out.push_str("<style type=\"text/css\">");
+            out.push_str(&inline_css(href, &css, resolve));
+            out.push_str("</style>");
+        }
+        None => out.push_str(sub(html, tag.lt, tag.end)),
+    }
+    tag.end
+}
+
+/// Fetch a text resource (a stylesheet or script) and decode it as UTF-8, replacing any invalid bytes.
+fn inline_text_resource(
+    url: &str,
+    resolve: &mut impl FnMut(&str) -> Option<Resource>,
+) -> Option<String> {
+    let resource = resolve(url)?;
+    Some(String::from_utf8_lossy(&resource.bytes).into_owned())
+}
+
+/// Rewrite every `url(...)` in a CSS body to a `data:` URI, resolving each relative reference against
+/// `base` — the location of the stylesheet the CSS came from, or empty for a `<style>` block that sits
+/// in the document itself.
+fn inline_css(base: &str, css: &str, resolve: &mut impl FnMut(&str) -> Option<Resource>) -> String {
+    let mut out = String::with_capacity(css.len());
+    let mut i = 0;
+    while i < css.len() {
+        let Some(rel) = css.get(i..).and_then(|rest| find_ci(rest, "url(")) else {
+            out.push_str(sub(css, i, css.len()));
+            break;
+        };
+        let open = i + rel + "url(".len();
+        let Some(close_rel) = css.get(open..).and_then(|rest| rest.find(')')) else {
+            out.push_str(sub(css, i, css.len()));
+            break;
+        };
+        let close = open + close_rel;
+        out.push_str(sub(css, i, open));
+        let raw = sub(css, open, close);
+        let url = unquote(raw.trim());
+        match inline_url(base, url, resolve) {
+            Some(data) => out.push_str(&data),
+            None => out.push_str(raw),
+        }
+        out.push(')');
+        i = close + 1;
+    }
+    out
+}
+
+/// A parsed HTML start tag: its lowercased element name, its attributes with their value spans, and
+/// the byte range it occupies in the source (`lt`..`end`).
+struct StartTag {
+    name: String,
+    attrs: Vec<TagAttr>,
+    lt: usize,
+    end: usize,
+}
+
+impl StartTag {
+    /// The value of the named attribute, if it carries one.
+    fn attr(&self, name: &str) -> Option<&str> {
+        self.attr_entry(name).and_then(|attr| attr.value.as_deref())
+    }
+
+    /// The named attribute, whether or not it carries a value.
+    fn attr_entry(&self, name: &str) -> Option<&TagAttr> {
+        self.attrs.iter().find(|attr| attr.name == name)
+    }
+
+    /// Whether the tag carries the named attribute (with or without a value).
+    fn has_attr(&self, name: &str) -> bool {
+        self.attr_entry(name).is_some()
+    }
+}
+
+/// One attribute of a start tag: its lowercased name, its value text, and the absolute byte span of
+/// that value's inner content (without the surrounding quotes) in the source.
+struct TagAttr {
+    name: String,
+    value: Option<String>,
+    value_span: Option<(usize, usize)>,
+}
+
+/// Whether a `<link>` requests a stylesheet — its `rel` names `stylesheet` among space-separated tokens.
+fn is_stylesheet_link(tag: &StartTag) -> bool {
+    tag.attr("rel").is_some_and(|rel| {
+        rel.split_whitespace()
+            .any(|token| token.eq_ignore_ascii_case("stylesheet"))
+    })
+}
+
+/// If the `<` at `lt` opens a comment, a `<!...>` declaration, or a `<?...?>` instruction, the index
+/// just past its terminator; otherwise `None`. These are copied through without interpretation.
+fn markup_prefix_end(html: &str, lt: usize) -> Option<usize> {
+    let rest = html.get(lt..)?;
+    if let Some(after) = rest.strip_prefix("<!--") {
+        let close = after.find("-->").map_or(html.len(), |p| lt + 4 + p + 3);
+        return Some(close);
+    }
+    if rest.starts_with("<!") || rest.starts_with("<?") {
+        let close = rest
+            .get(2..)
+            .and_then(|r| r.find('>'))
+            .map_or(html.len(), |p| lt + 2 + p + 1);
+        return Some(close);
+    }
+    None
+}
+
+/// Parse the start tag whose `<` sits at `lt`. Returns `None` when the character does not open a
+/// well-formed start tag (a stray `<`, or an end tag `</…>`), leaving the caller to treat it as text.
+fn parse_start_tag(html: &str, lt: usize) -> Option<StartTag> {
+    let bytes = html.as_bytes();
+    let mut p = lt + 1;
+    // A name must start with an ASCII letter; anything else (including `/`) is not a start tag here.
+    if !matches!(bytes.get(p), Some(b) if b.is_ascii_alphabetic()) {
+        return None;
+    }
+    let name_start = p;
+    while matches!(bytes.get(p), Some(b) if b.is_ascii_alphanumeric() || *b == b'-' || *b == b':') {
+        p += 1;
+    }
+    let name = sub(html, name_start, p).to_ascii_lowercase();
+
+    let mut attrs = Vec::new();
+    loop {
+        p = skip_whitespace(bytes, p);
+        match bytes.get(p) {
+            None => return None,
+            Some(b'>') => {
+                return Some(StartTag {
+                    name,
+                    attrs,
+                    lt,
+                    end: p + 1,
+                });
+            }
+            Some(b'/') => {
+                if matches!(bytes.get(p + 1), Some(b'>')) {
+                    return Some(StartTag {
+                        name,
+                        attrs,
+                        lt,
+                        end: p + 2,
+                    });
+                }
+                p += 1;
+            }
+            Some(_) => {
+                let attr_start = p;
+                while matches!(bytes.get(p), Some(b) if !b.is_ascii_whitespace() && *b != b'=' && *b != b'>' && *b != b'/')
+                {
+                    p += 1;
+                }
+                if p == attr_start {
+                    // No progress on a character that starts no name (a stray `=` or quote): step over
+                    // it so the scan cannot stall.
+                    p += 1;
+                    continue;
+                }
+                let attr_name = sub(html, attr_start, p).to_ascii_lowercase();
+                let after_name = skip_whitespace(bytes, p);
+                let (value, value_span, next) = if matches!(bytes.get(after_name), Some(b'=')) {
+                    read_value(html, skip_whitespace(bytes, after_name + 1))
+                } else {
+                    (None, None, p)
+                };
+                attrs.push(TagAttr {
+                    name: attr_name,
+                    value,
+                    value_span,
+                });
+                p = next;
+            }
+        }
+    }
+}
+
+/// Read an attribute value starting at `p`: a quoted string (returning its inner span), or an unquoted
+/// run up to whitespace or `>`. Returns the value text, its inner byte span, and the index past it.
+fn read_value(html: &str, p: usize) -> (Option<String>, Option<(usize, usize)>, usize) {
+    let bytes = html.as_bytes();
+    match bytes.get(p) {
+        Some(&quote @ (b'"' | b'\'')) => {
+            let start = p + 1;
+            let mut q = start;
+            while matches!(bytes.get(q), Some(&b) if b != quote) {
+                q += 1;
+            }
+            let value = sub(html, start, q).to_owned();
+            let end = if bytes.get(q).is_some() { q + 1 } else { q };
+            (Some(value), Some((start, q)), end)
+        }
+        Some(_) => {
+            let start = p;
+            let mut q = start;
+            while matches!(bytes.get(q), Some(b) if !b.is_ascii_whitespace() && *b != b'>') {
+                q += 1;
+            }
+            (Some(sub(html, start, q).to_owned()), Some((start, q)), q)
+        }
+        None => (None, None, p),
+    }
+}
+
+/// The raw-text body of an element that began at `start`, up to (but not including) its case-insensitive
+/// closing tag, together with the index just past that closing tag. A missing close runs to end of input.
+fn raw_text_body<'a>(html: &'a str, start: usize, element: &str) -> (&'a str, usize) {
+    let closer = format!("</{element}");
+    let rest = sub(html, start, html.len());
+    match find_ci(rest, &closer) {
+        Some(rel) => {
+            let body_end = start + rel;
+            let after_name = body_end + closer.len();
+            let close_end = html
+                .get(after_name..)
+                .and_then(|r| r.find('>'))
+                .map_or(html.len(), |p| after_name + p + 1);
+            (sub(html, start, body_end), close_end)
+        }
+        None => (rest, html.len()),
+    }
+}
+
+/// Copy `html[lt..end]` to `out`, applying each `(start, end, replacement)` edit — non-overlapping and
+/// in ascending order — to the value spans within it.
+fn splice(html: &str, lt: usize, end: usize, edits: &[(usize, usize, String)], out: &mut String) {
+    let mut cursor = lt;
+    for (start, stop, replacement) in edits {
+        if *start < cursor || *stop > end {
+            continue;
+        }
+        out.push_str(sub(html, cursor, *start));
+        out.push_str(replacement);
+        cursor = *stop;
+    }
+    out.push_str(sub(html, cursor, end));
+}
+
+/// Whether a reference names nothing to fetch: empty, a page fragment, or an inline `data:` payload.
+fn skip_reference(url: &str) -> bool {
+    let url = url.trim();
+    url.is_empty() || url.starts_with('#') || url.starts_with("data:")
+}
+
+/// Resolve a possibly relative reference against the location of the document it appears in. An
+/// absolute URL (with a scheme or a protocol-relative `//`) stands as written; a root-relative path is
+/// joined to the base's origin; anything else is joined to the base's directory. An empty base leaves a
+/// relative reference untouched, so the resolver reads it against its own working directory.
+fn join_url(base: &str, url: &str) -> String {
+    if base.is_empty() || url.contains("://") || url.starts_with("//") {
+        return url.to_owned();
+    }
+    if let Some(path) = url.strip_prefix('/') {
+        if let Some(origin) = origin_of(base) {
+            return format!("{origin}/{path}");
+        }
+        return url.to_owned();
+    }
+    let Some((dir, _)) = base.rsplit_once('/') else {
+        return url.to_owned();
+    };
+    format!("{dir}/{url}")
+}
+
+/// The scheme-and-host origin of an absolute URL (`https://host`), for joining a root-relative path.
+fn origin_of(base: &str) -> Option<&str> {
+    let scheme_end = base.find("://")?;
+    let after = scheme_end + 3;
+    let host_len = base.get(after..)?.find('/').unwrap_or(base.len() - after);
+    base.get(..after + host_len)
+}
+
+/// Strip one pair of matching quotes from a CSS `url()` argument, if present.
+fn unquote(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    match (bytes.first(), bytes.last()) {
+        (Some(&a @ (b'"' | b'\'')), Some(&b)) if a == b && value.len() >= 2 => {
+            sub(value, 1, value.len() - 1)
+        }
+        _ => value,
+    }
+}
+
+/// Advance past ASCII whitespace from `p`.
+fn skip_whitespace(bytes: &[u8], mut p: usize) -> usize {
+    while matches!(bytes.get(p), Some(b) if b.is_ascii_whitespace()) {
+        p += 1;
+    }
+    p
+}
+
+/// The byte offset of `needle` in `haystack`, compared ASCII-case-insensitively.
+fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
+    let (hay, need) = (haystack.as_bytes(), needle.as_bytes());
+    if need.is_empty() {
+        return Some(0);
+    }
+    hay.windows(need.len())
+        .position(|window| window.eq_ignore_ascii_case(need))
+}
+
+/// A panic-free substring: `s[start..end]`, or `""` if the range is not a valid boundary pair. The
+/// callers derive their bounds from byte scans over ASCII delimiters, so the fallback is never taken.
+fn sub(s: &str, start: usize, end: usize) -> &str {
+    s.get(start..end).unwrap_or("")
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    use super::{Resource, inline_resources};
+
+    /// A resolver that hands back fixed bytes and MIME for a known set of references and `None` for
+    /// anything else, recording which references it was asked for.
+    fn resolver<'a>(
+        table: &'a [(&'static str, &'static [u8], Option<&'static str>)],
+    ) -> impl FnMut(&str) -> Option<Resource> + 'a {
+        move |url: &str| {
+            table
+                .iter()
+                .find(|(name, _, _)| *name == url)
+                .map(|(_, bytes, mime)| Resource {
+                    bytes: bytes.to_vec(),
+                    mime: mime.map(str::to_owned),
+                })
+        }
+    }
+
+    #[test]
+    fn img_src_becomes_a_data_uri_and_gains_the_aria_annotation() {
+        let html = r#"<p><img src="pic.png" alt="x" /></p>"#;
+        let out = inline_resources(html, resolver(&[("pic.png", b"PNGX", Some("image/png"))]));
+        assert_eq!(
+            out,
+            r#"<p><img role="img" aria-label="x" src="data:image/png;base64,UE5HWA==" alt="x" /></p>"#
+        );
+    }
+
+    #[test]
+    fn img_without_alt_gains_role_only() {
+        let html = r#"<img src="pic.png">"#;
+        let out = inline_resources(html, resolver(&[("pic.png", b"PNGX", Some("image/png"))]));
+        assert_eq!(
+            out,
+            r#"<img role="img" src="data:image/png;base64,UE5HWA==">"#
+        );
+    }
+
+    #[test]
+    fn img_keeping_an_existing_role_only_gains_the_aria_label() {
+        let html = r#"<img role="button" src="pic.png" alt="y">"#;
+        let out = inline_resources(html, resolver(&[("pic.png", b"X", Some("image/png"))]));
+        assert_eq!(
+            out,
+            r#"<img aria-label="y" role="button" src="data:image/png;base64,WA==" alt="y">"#
+        );
+    }
+
+    #[test]
+    fn unresolved_and_data_src_keep_their_value_but_gain_role() {
+        // The src value is left as written (unresolved, or already a data: URI), but an inlined graphic
+        // is still annotated. A non-media `<a>` is untouched, fragment href and all.
+        let html =
+            r##"<img src="gone.png"><img src="data:image/png;base64,AAAA"><a href="#top">x</a>"##;
+        let out = inline_resources(html, resolver(&[]));
+        assert_eq!(
+            out,
+            r##"<img role="img" src="gone.png"><img role="img" src="data:image/png;base64,AAAA"><a href="#top">x</a>"##
+        );
+    }
+
+    #[test]
+    fn other_attributes_and_spacing_are_preserved_byte_for_byte() {
+        // The annotation is inserted after the name; the src value changes; id, the odd spacing, and
+        // the alt attribute stay put.
+        let html = "<img   id=\"a\"  src='pic.png'   alt=\"y\">";
+        let out = inline_resources(html, resolver(&[("pic.png", b"hi", Some("image/gif"))]));
+        assert_eq!(
+            out,
+            "<img role=\"img\" aria-label=\"y\"   id=\"a\"  src='data:image/gif;base64,aGk='   alt=\"y\">"
+        );
+    }
+
+    #[test]
+    fn image_with_only_a_srcset_is_left_untouched() {
+        // A responsive candidate list is not a lone reference: it is left alone, and an image that
+        // carries no resource attribute the pass handles gains no annotation.
+        let html = r#"<img srcset="a.png 1x, b.png 2x">"#;
+        let out = inline_resources(
+            html,
+            resolver(&[
+                ("a.png", b"A", Some("image/png")),
+                ("b.png", b"B", Some("image/png")),
+            ]),
+        );
+        assert_eq!(out, html);
+    }
+
+    #[test]
+    fn style_block_inlines_css_url() {
+        let html = "<style>.a{background:url(pic.png)}</style>";
+        let out = inline_resources(html, resolver(&[("pic.png", b"PNGX", Some("image/png"))]));
+        assert_eq!(
+            out,
+            "<style>.a{background:url(data:image/png;base64,UE5HWA==)}</style>"
+        );
+    }
+
+    #[test]
+    fn quoted_css_url_is_inlined_unquoted() {
+        let html = r#"<style>.a{background:url("pic.png")}</style>"#;
+        let out = inline_resources(html, resolver(&[("pic.png", b"PNGX", Some("image/png"))]));
+        assert_eq!(
+            out,
+            "<style>.a{background:url(data:image/png;base64,UE5HWA==)}</style>"
+        );
+    }
+
+    #[test]
+    fn stylesheet_link_becomes_inline_style_with_resolved_urls() {
+        // The stylesheet's own url() resolves relative to the stylesheet's directory.
+        let html = r#"<link rel="stylesheet" href="css/site.css">"#;
+        let out = inline_resources(
+            html,
+            resolver(&[
+                (
+                    "css/site.css",
+                    b".a{background:url(bg.png)}",
+                    Some("text/css"),
+                ),
+                ("css/bg.png", b"PNGX", Some("image/png")),
+            ]),
+        );
+        assert_eq!(
+            out,
+            r#"<style type="text/css">.a{background:url(data:image/png;base64,UE5HWA==)}</style>"#
+        );
+    }
+
+    #[test]
+    fn script_src_becomes_inline_script_keeping_only_type() {
+        let html = r#"<script defer src="app.js" type="text/javascript" id="z"></script>"#;
+        let out = inline_resources(
+            html,
+            resolver(&[("app.js", b"console.log(1)", Some("text/javascript"))]),
+        );
+        assert_eq!(
+            out,
+            r#"<script type="text/javascript">console.log(1)</script>"#
+        );
+    }
+
+    #[test]
+    fn script_without_type_drops_all_attributes() {
+        let html = r#"<script src="app.js"></script>"#;
+        let out = inline_resources(html, resolver(&[("app.js", b"x", None)]));
+        assert_eq!(out, "<script>x</script>");
+    }
+
+    #[test]
+    fn inline_script_body_is_left_alone() {
+        let html = "<script>var a = 1 < 2;</script>";
+        let out = inline_resources(html, resolver(&[]));
+        assert_eq!(out, html);
+    }
+
+    #[test]
+    fn comment_content_is_not_interpreted() {
+        let html = r#"<!-- <img src="pic.png"> --><img src="pic.png">"#;
+        let out = inline_resources(html, resolver(&[("pic.png", b"X", Some("image/png"))]));
+        assert_eq!(
+            out,
+            r#"<!-- <img src="pic.png"> --><img role="img" src="data:image/png;base64,WA==">"#
+        );
+    }
+
+    #[test]
+    fn unresolved_stylesheet_link_is_left_as_the_link() {
+        let html = r#"<link rel="stylesheet" href="missing.css">"#;
+        let out = inline_resources(html, resolver(&[]));
+        assert_eq!(out, html);
+    }
+
+    #[test]
+    fn non_stylesheet_link_is_untouched() {
+        let html = r#"<link rel="icon" href="fav.png">"#;
+        let out = inline_resources(html, resolver(&[("fav.png", b"X", Some("image/png"))]));
+        assert_eq!(out, html);
+    }
+
+    #[test]
+    fn absolute_css_url_is_resolved_against_its_own_origin() {
+        let html = r#"<link rel="stylesheet" href="https://h.example/a/site.css">"#;
+        let out = inline_resources(
+            html,
+            resolver(&[
+                (
+                    "https://h.example/a/site.css",
+                    b"a{background:url(/img/bg.png)}",
+                    Some("text/css"),
+                ),
+                ("https://h.example/img/bg.png", b"PNGX", Some("image/png")),
+            ]),
+        );
+        assert_eq!(
+            out,
+            r#"<style type="text/css">a{background:url(data:image/png;base64,UE5HWA==)}</style>"#
+        );
+    }
+}

--- a/crates/carta-writers/src/html.rs
+++ b/crates/carta-writers/src/html.rs
@@ -1401,12 +1401,13 @@ fn emit_token(out: &mut String, token: &Token) {
 }
 
 fn image(attr: &Attr, inlines: &[Inline], target: &Target, flavor: Flavor) -> String {
+    let alt = to_plain_text(inlines);
     // An EPUB page always carries an `alt` attribute — empty when the image has no description — as
     // its XHTML profile expects; the other html flavors omit it when there is nothing to say.
     let alt_attr = if inlines.is_empty() && !matches!(flavor, Flavor::Epub3 | Flavor::Epub2) {
         String::new()
     } else {
-        format!("{BREAK}alt=\"{}\"", escape_attr(&to_plain_text(inlines)))
+        format!("{BREAK}alt=\"{}\"", escape_attr(&alt))
     };
     let source = match flavor {
         Flavor::Slides => "data-src",
@@ -2106,6 +2107,56 @@ mod char_width_tests {
         assert_eq!(char_width('\u{7}'), 0); // bell (Control)
         assert_eq!(char_width('\u{4E00}'), 2); // CJK ideograph (wide)
         assert_eq!(char_width('\u{1F600}'), 2); // grinning face emoji (wide)
+    }
+}
+
+#[cfg(test)]
+mod image_tests {
+    use super::HtmlWriter;
+    use carta_ast::{Block, Document, Inline, Target, Text};
+    use carta_core::{WrapMode, Writer, WriterOptions};
+
+    fn image_block(url: &str, alt: &str) -> Block {
+        let alt_inlines = if alt.is_empty() {
+            Vec::new()
+        } else {
+            vec![Inline::Str(alt.into())]
+        };
+        Block::Para(vec![Inline::Image(
+            Box::default(),
+            alt_inlines,
+            Box::new(Target {
+                url: url.into(),
+                title: Text::default(),
+            }),
+        )])
+    }
+
+    fn render(url: &str, alt: &str) -> String {
+        let document = Document {
+            blocks: vec![image_block(url, alt)],
+            ..Document::default()
+        };
+        let mut options = WriterOptions::default();
+        options.wrap = WrapMode::None;
+        HtmlWriter.write(&document, &options).expect("render html")
+    }
+
+    // The writer emits a plain `<img>` carrying the reference as written; assistive-technology
+    // annotation and reference inlining both belong to the separate self-contained pass over the
+    // finished markup, so the writer's output does not vary on it.
+
+    #[test]
+    fn image_carries_its_alt_text() {
+        assert_eq!(
+            render("pic.png", "alt text"),
+            "<p><img src=\"pic.png\" alt=\"alt text\" /></p>"
+        );
+    }
+
+    #[test]
+    fn image_without_alt_omits_the_attribute() {
+        assert_eq!(render("pic.png", ""), "<p><img src=\"pic.png\" /></p>");
     }
 }
 

--- a/crates/carta-writers/src/lib.rs
+++ b/crates/carta-writers/src/lib.rs
@@ -63,6 +63,8 @@ pub mod commonmark;
 pub mod docx;
 #[cfg(feature = "dokuwiki")]
 pub mod dokuwiki;
+#[cfg(feature = "html")]
+pub mod embed;
 #[cfg(feature = "epub")]
 pub mod epub;
 #[cfg(feature = "html")]
@@ -106,6 +108,8 @@ pub use commonmark::CommonmarkWriter;
 pub use docx::DocxWriter;
 #[cfg(feature = "dokuwiki")]
 pub use dokuwiki::DokuwikiWriter;
+#[cfg(feature = "html")]
+pub use embed::{Resource, inline_resources};
 #[cfg(feature = "epub")]
 pub use epub::{Epub2Writer, Epub3Writer};
 #[cfg(feature = "highlight")]

--- a/crates/carta/Cargo.toml
+++ b/crates/carta/Cargo.toml
@@ -31,7 +31,11 @@ default = ["full", "cli"]
 # yields the tool; library-only users set `default-features = false` to drop it (and `clap`). It pulls
 # the standalone and metadata-file machinery the CLI drives — pair with format features (or `full`) to
 # choose what the binary can convert.
-cli = ["dep:clap", "standalone", "metadata-file"]
+cli = ["dep:clap", "standalone", "metadata-file", "fetch"]
+# Fetch remote resources over HTTP(S) when inlining them for self-contained HTML (`--embed-resources`):
+# carries the HTTP client. Without it, only local and already-inline resources are inlined and a remote
+# reference is left external. Part of `cli` so the installed tool is self-contained-capable by default.
+fetch = ["dep:ureq"]
 full = ["read-commonmark", "read-json", "read-native", "read-html", "read-csv", "read-tsv", "read-opml", "read-rst", "read-ipynb", "read-mediawiki", "read-dokuwiki", "read-jira", "read-man", "read-latex", "read-org", "write-html", "write-html4", "write-json", "write-plain", "write-native", "write-latex", "write-commonmark", "write-markdown", "write-gfm", "write-rst", "write-mediawiki", "write-typst", "write-dokuwiki", "write-jira", "write-asciidoc", "write-man", "write-opml", "write-org", "write-beamer", "write-revealjs", "write-ipynb", "write-epub", "write-docx", "highlight", "standalone", "metadata-file"]
 # Syntax highlighting for code blocks, plus the CLI's language/style listings and idiomatic mode. Turns
 # the feature on in any compiled writers and carries the tokenizer catalog for the listing/print flags.
@@ -96,6 +100,9 @@ carta-writers = { path = "../carta-writers", version = "0.0.4", default-features
 serde_json = { workspace = true, optional = true }
 # CLI-only; kept out of a library build via the optional `cli` feature.
 clap = { workspace = true, optional = true }
+# The HTTP client used to fetch remote resources for self-contained HTML. Gated behind `fetch`; a
+# rustls TLS stack keeps the build free of a system OpenSSL dependency.
+ureq = { version = "3", default-features = false, features = ["rustls"], optional = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/carta/src/lib.rs
+++ b/crates/carta/src/lib.rs
@@ -39,6 +39,12 @@ pub use carta_core::HighlightOptions;
 #[cfg(feature = "highlight")]
 pub use carta_highlight::{Highlighter, Theme, builtin_style, languages, styles};
 
+/// The post-render pass that inlines an HTML page's external resources as `data:` URIs and inline
+/// `<style>`/`<script>` elements, together with the resolved-resource type it consumes. Drives the
+/// CLI's self-contained HTML output.
+#[cfg(feature = "write-html")]
+pub use carta_writers::{Resource, inline_resources};
+
 /// Converts text `input` from format `from` to text in format `to`.
 ///
 /// A shortcut over [`convert`] for the common case where both formats are text-shaped. Each format

--- a/crates/carta/src/main.rs
+++ b/crates/carta/src/main.rs
@@ -288,9 +288,11 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     if cli.self_contained {
         eprintln!("carta: --self-contained is deprecated; use --embed-resources --standalone");
     }
-    // Media embedding inlines resources as `data:` URIs, and only the HTML family renders them, so
-    // the request is dropped for any other target (as a container packs its media a different way).
-    let embed_resources = (cli.embed_resources || cli.self_contained) && renders_html(to);
+    // Media embedding inlines resources as `data:` URIs, and only the HTML family (`html`, `html4`,
+    // `html5`) renders them, so the request is dropped for any other target (as a container packs its
+    // media a different way).
+    #[cfg(feature = "write-html")]
+    let embed_resources = (cli.embed_resources || cli.self_contained) && to.starts_with("html");
 
     let mut writer_options = WriterOptions::default();
     writer_options.standalone = cli.standalone || cli.self_contained;
@@ -467,12 +469,6 @@ fn embeds_resources(to: &str) -> bool {
 /// Whether the target format is DOCX (any extension toggles follow the base name).
 fn is_docx(to: &str) -> bool {
     to.starts_with("docx")
-}
-
-/// Whether the target renders the HTML family (`html`, `html4`, `html5`), the outputs whose media
-/// self-contained mode inlines as `data:` URIs. The base name carries any `+ext`/`-ext` toggles.
-fn renders_html(to: &str) -> bool {
-    to.starts_with("html")
 }
 
 /// Assemble the EPUB writer options from the command line: stylesheets, cover image, embedded fonts,

--- a/crates/carta/src/main.rs
+++ b/crates/carta/src/main.rs
@@ -18,6 +18,8 @@ use carta::{
     DocxOptions, EpubOptions, Error, MathMethod, MediaBag, Output, ReaderOptions, Result, WrapMode,
     WriterOptions, media, read_document, render_document,
 };
+#[cfg(feature = "write-html")]
+use carta::{Resource, inline_resources};
 use clap::{ArgAction, Parser};
 
 mod datadir;
@@ -70,6 +72,16 @@ struct Cli {
     /// by the platform's path separator (`:` on Unix, `;` on Windows); repeatable.
     #[arg(long = "resource-path", value_name = "SEARCHPATH")]
     resource_path: Vec<String>,
+    /// Inline a document's referenced media into HTML output as `data:` URIs, producing a
+    /// self-contained file with no external resource dependencies. Local resources are read from disk
+    /// (honoring `--resource-path`); references that cannot be read are left as written. Ignored for
+    /// non-HTML output.
+    #[arg(long = "embed-resources")]
+    embed_resources: bool,
+    /// Deprecated alias for `--embed-resources --standalone`: produce a self-contained standalone
+    /// HTML file.
+    #[arg(long = "self-contained")]
+    self_contained: bool,
     /// Produce a standalone document, wrapping the body in the format's template.
     #[arg(short = 's', long = "standalone")]
     standalone: bool,
@@ -272,8 +284,16 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     let to_base = carta::parse_format_spec(to)?.0;
     let data_dir = datadir::resolve(cli.data_dir.as_deref());
 
+    // `--self-contained` is the deprecated spelling of `--embed-resources --standalone`.
+    if cli.self_contained {
+        eprintln!("carta: --self-contained is deprecated; use --embed-resources --standalone");
+    }
+    // Media embedding inlines resources as `data:` URIs, and only the HTML family renders them, so
+    // the request is dropped for any other target (as a container packs its media a different way).
+    let embed_resources = (cli.embed_resources || cli.self_contained) && renders_html(to);
+
     let mut writer_options = WriterOptions::default();
-    writer_options.standalone = cli.standalone;
+    writer_options.standalone = cli.standalone || cli.self_contained;
     if let Some((source, dir, ext)) = resolve_template(cli, &to_base, data_dir.as_deref())? {
         writer_options.template = Some(source);
         writer_options.template_dir = Some(dir);
@@ -301,7 +321,7 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     }
 
     // A template (default or `--template`) emits verbatim; a bare fragment gets one trailing newline.
-    let verbatim = cli.standalone || cli.template.is_some();
+    let verbatim = writer_options.standalone || cli.template.is_some();
 
     let (mut document, resources) = read_document(from, &input, &ReaderOptions::default())?;
 
@@ -326,15 +346,38 @@ fn convert_document(from: &str, to: &str, cli: &Cli) -> Result<()> {
     // container packs its media (so resources a filter introduces are still gathered).
     filters::run(&mut document, &cli.filter, &to_base, data_dir.as_deref())?;
 
-    // A container format embeds the resources it references; pull the local ones off disk so the
-    // writer can pack them.
+    // A container format embeds the resources it references, so pull the local ones off disk here for
+    // the writer to carry. HTML self-contained mode instead inlines resources after rendering (the
+    // post-render pass below), which lets it reach raw-HTML and stylesheet references the tree omits.
     if cli.extract_media.is_none() && embeds_resources(to) {
         let search_path = resource_search_path(cli);
         media::embed_referenced_media(&mut document.blocks, &mut resources, |reference| {
             resolve_resource(reference, &search_path)
         });
     }
+
+    // Self-contained HTML inlines resources after rendering, resolving each reference the finished
+    // page carries; the bag travels alongside so a reader-carried resource resolves without disk I/O.
+    #[cfg(feature = "write-html")]
+    let embed_bag = if embed_resources && cli.extract_media.is_none() {
+        resources.clone()
+    } else {
+        MediaBag::new()
+    };
+
     let output = render_document(to, document, resources, &writer_options)?;
+
+    #[cfg(feature = "write-html")]
+    let output = match output {
+        Output::Text(html) if embed_resources && cli.extract_media.is_none() => {
+            let search_path = resource_search_path(cli);
+            Output::Text(inline_resources(&html, |reference| {
+                resolve_embed(reference, &embed_bag, &search_path)
+            }))
+        }
+        output => output,
+    };
+
     write_output(cli.output.as_deref(), &output, verbatim)
 }
 
@@ -426,6 +469,12 @@ fn is_docx(to: &str) -> bool {
     to.starts_with("docx")
 }
 
+/// Whether the target renders the HTML family (`html`, `html4`, `html5`), the outputs whose media
+/// self-contained mode inlines as `data:` URIs. The base name carries any `+ext`/`-ext` toggles.
+fn renders_html(to: &str) -> bool {
+    to.starts_with("html")
+}
+
 /// Assemble the EPUB writer options from the command line: stylesheets, cover image, embedded fonts,
 /// the Dublin Core metadata fragment, the container subdirectory, the chapter split level, and the
 /// reproducible-build timestamp. Each referenced file is read from disk here.
@@ -502,6 +551,102 @@ fn resolve_resource(reference: &str, search_path: &[PathBuf]) -> Option<Vec<u8>>
     search_path
         .iter()
         .find_map(|dir| fs::read(dir.join(reference)).ok())
+}
+
+/// Resolve a reference the self-contained HTML pass encounters into its bytes and MIME type, in order:
+/// a resource the reader carried in the bag, then a local file found along `search_path`, then — with
+/// the `fetch` feature — a resource retrieved over HTTP(S). A reference that resolves nowhere is left
+/// external (the pass keeps it as written).
+#[cfg(feature = "write-html")]
+fn resolve_embed(reference: &str, bag: &MediaBag, search_path: &[PathBuf]) -> Option<Resource> {
+    if let Some(item) = bag.get(reference) {
+        return Some(Resource {
+            bytes: item.bytes.clone(),
+            mime: item.mime.clone(),
+        });
+    }
+    if is_remote_url(reference) {
+        return fetch_remote(reference);
+    }
+    let bytes = resolve_resource(reference, search_path)?;
+    Some(Resource {
+        bytes,
+        mime: mime_for_path(reference),
+    })
+}
+
+/// Whether a reference is retrieved over the network rather than read from disk.
+#[cfg(feature = "write-html")]
+fn is_remote_url(reference: &str) -> bool {
+    reference.starts_with("http://") || reference.starts_with("https://")
+}
+
+/// The MIME type a reference's file extension implies, for the `data:` URI that inlines it. Covers the
+/// resource kinds a self-contained page embeds — images, fonts, media, and stylesheets; an
+/// unrecognized extension yields `None`, leaving the generic binary type to stand in.
+#[cfg(feature = "write-html")]
+fn mime_for_path(reference: &str) -> Option<String> {
+    let path = reference.split(['?', '#']).next().unwrap_or(reference);
+    let extension = Path::new(path).extension()?.to_str()?.to_ascii_lowercase();
+    let mime = match extension.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "ico" => "image/x-icon",
+        "bmp" => "image/bmp",
+        "css" => "text/css",
+        "js" | "mjs" => "text/javascript",
+        "woff" => "font/woff",
+        "woff2" => "font/woff2",
+        "ttf" => "font/ttf",
+        "otf" => "font/otf",
+        "eot" => "application/vnd.ms-fontobject",
+        "pdf" => "application/pdf",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "mp3" => "audio/mpeg",
+        "ogg" => "audio/ogg",
+        "wav" => "audio/wav",
+        _ => return None,
+    };
+    Some(mime.to_owned())
+}
+
+/// Retrieve a resource over HTTP(S) for inlining, returning its bytes and the MIME type its
+/// `Content-Type` reports. A network failure, an error status, or an unreadable body is reported and
+/// the reference is left external.
+#[cfg(all(feature = "write-html", feature = "fetch"))]
+fn fetch_remote(url: &str) -> Option<Resource> {
+    // A self-contained page may legitimately embed large media, so lift the read ceiling well above
+    // the client's conservative default rather than truncate a big resource mid-download.
+    const LIMIT: u64 = 128 * 1024 * 1024;
+    match ureq::get(url).call() {
+        Ok(mut response) => {
+            let mime = response.body().mime_type().map(str::to_owned);
+            match response.body_mut().with_config().limit(LIMIT).read_to_vec() {
+                Ok(bytes) => Some(Resource { bytes, mime }),
+                Err(error) => {
+                    eprintln!("carta: could not read {url}: {error}");
+                    None
+                }
+            }
+        }
+        Err(error) => {
+            eprintln!("carta: could not fetch {url}: {error}");
+            None
+        }
+    }
+}
+
+/// Without the `fetch` feature the tool retrieves no remote resource; the reference is reported and
+/// left external.
+#[cfg(all(feature = "write-html", not(feature = "fetch")))]
+fn fetch_remote(url: &str) -> Option<Resource> {
+    eprintln!("carta: cannot fetch {url}: built without network support");
+    None
 }
 
 /// Writes every resource in `media` to a file under `dir` (`<dir>/<name>`, creating parent

--- a/crates/carta/tests/cli.rs
+++ b/crates/carta/tests/cli.rs
@@ -278,3 +278,124 @@ fn extract_media_writes_files_and_rewrites_references() {
     let written = fs::read(&extracted).expect("extracted media file");
     assert_eq!(written, bytes);
 }
+
+#[cfg(feature = "write-html")]
+#[test]
+fn embed_resources_inlines_local_images_as_data_uris() {
+    // A resource resolved through the search path is inlined; `--resource-path` is honored just as
+    // it is for the container writers.
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("embed-resources");
+    let assets = dir.join("assets");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&assets).expect("create asset dir");
+    fs::write(assets.join("logo.png"), b"PNGDATA-abc").expect("write asset");
+
+    let resource_arg = format!("--resource-path={}", assets.display());
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "--embed-resources",
+            resource_arg.as_str(),
+            "--wrap=none",
+        ],
+        "![logo](logo.png)\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(
+        result.stdout,
+        "<p><img role=\"img\" aria-label=\"logo\" \
+         src=\"data:image/png;base64,UE5HREFUQS1hYmM=\" alt=\"logo\" /></p>\n"
+    );
+}
+
+#[cfg(feature = "write-markdown")]
+#[test]
+fn embed_resources_is_ignored_for_non_html_output() {
+    // The flag only affects the HTML family; a Markdown target leaves the reference as written.
+    let result = run(
+        &["-f", "commonmark", "-t", "markdown", "--embed-resources"],
+        "![logo](logo.png)\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "![logo](logo.png)\n");
+}
+
+#[cfg(all(feature = "write-html", feature = "fetch"))]
+#[test]
+fn embed_resources_fetches_a_remote_image_over_http() {
+    use std::io::Read;
+    use std::net::TcpListener;
+
+    // A loopback server stands in for a remote host: a reference with an `http://` scheme is fetched
+    // and inlined just like a local one, exercising the network path without leaving the machine.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+    let addr = listener.local_addr().expect("local addr");
+    let handle = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept connection");
+        // Drain the request line and headers up to the blank line; the body of a GET is empty.
+        let mut request = Vec::new();
+        let mut byte = [0u8; 1];
+        while stream.read(&mut byte).unwrap_or(0) == 1 {
+            request.push(byte[0]);
+            if request.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        let body = b"PNGDATA-xyz";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write headers");
+        stream.write_all(body).expect("write body");
+    });
+
+    let url = format!("http://{addr}/logo.png");
+    let markdown = format!("![logo]({url})\n");
+    let result = run(
+        &[
+            "-f",
+            "commonmark",
+            "-t",
+            "html",
+            "--embed-resources",
+            "--wrap=none",
+        ],
+        &markdown,
+    );
+    handle.join().expect("server thread");
+
+    assert!(result.success, "stderr: {}", result.stderr);
+    assert_eq!(
+        result.stdout,
+        "<p><img role=\"img\" aria-label=\"logo\" \
+         src=\"data:image/png;base64,UE5HREFUQS14eXo=\" alt=\"logo\" /></p>\n"
+    );
+}
+
+#[cfg(feature = "write-html")]
+#[test]
+fn self_contained_implies_standalone_and_warns() {
+    let result = run(
+        &["-f", "commonmark", "-t", "html", "--self-contained"],
+        "# Title\n",
+    );
+    assert!(result.success, "stderr: {}", result.stderr);
+    // The deprecated spelling still works but points at the current one.
+    assert!(
+        result.stderr.contains("--self-contained is deprecated"),
+        "stderr: {}",
+        result.stderr
+    );
+    // It implies standalone output: the body is wrapped in the full document template.
+    assert!(
+        result.stdout.contains("<!DOCTYPE html>"),
+        "stdout: {}",
+        result.stdout
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,8 @@ allow = [
   "Unicode-DFS-2016",
   "CC0-1.0",
   "MPL-2.0",
+  # Covers the bundled Mozilla root-certificate data the HTTP client's TLS stack ships.
+  "CDLA-Permissive-2.0",
 ]
 # The workspace's own crates carry the project license, AGPL-3.0-only. Allow it for these
 # first-party crates only — copyleft dependencies stay disallowed.

--- a/tools/conformance-suite/README.md
+++ b/tools/conformance-suite/README.md
@@ -76,7 +76,7 @@ tools/fetch-pandoc-tests.sh    # .oracle/tests/test (native corpus + command tes
 | `extensions` | structural gate: every reader-honored extension has an oracle-parity case | `crates/carta-core` (the variant table), the reader source, and `corpus/text-ext/` |
 | `templates` | `-f markdown -t TARGET --template=T`, compared byte-for-byte (verbatim output, no trailing-newline tolerance) | self-contained `corpus/templates/<case>/` (an owned template + body/metadata + optional flags) across eight targets |
 | `standalone` | structural parity of each format's default `-s` scaffold (title block, preamble): proves both sides carry the same content and metadata, NOT a byte diff | `corpus/ast/<feature>/*` rendered standalone per target |
-| `media` | both sides of the media bag: `--extract-media` rewrites the document and writes embedded resources, diffing the rewritten output and the extracted file tree | `corpus/text/ipynb/*.ipynb` |
+| `media` | both sides of the media bag: `--extract-media` rewrites the document and writes embedded resources (diffing the rewritten output and the extracted file tree), re-embedding renders back to a notebook, and `--embed-resources` inlines each bagged image into HTML as a `data:` URI | `corpus/text/ipynb/*.ipynb` |
 | `epub` | carta's EPUB writer two ways — structurally against the oracle (unpack + diff text entries) and against the EPUB spec with EPUBCheck | `corpus/ast/<feature>/*` (epub3 and epub2) |
 | `docx` | carta's DOCX writer structurally: unpack both Office Open XML packages and diff each content-bearing part after canonicalizing the XML | `corpus/ast/<feature>/*` |
 

--- a/tools/conformance-suite/surfaces/media.sh
+++ b/tools/conformance-suite/surfaces/media.sh
@@ -85,4 +85,46 @@ done
 report media reembed
 tally_group
 
+# Embed path: render each notebook to HTML with --embed-resources so every bagged image inlines as a
+# data: URI, and diff the two HTML outputs. Wrapping is disabled to keep the comparison on the inlined
+# content rather than fill-column line breaks. To hold the group on the embedding behavior alone, a
+# notebook whose plain (unembedded) HTML already diverges — an unrelated writer gap, e.g. math
+# rendering — is skipped rather than counted against this surface.
+conf_reset "media-embed"
+for input in "$dir"/*; do
+  [ -f "$input" ] || continue
+  label="media/embed/$(basename "$input")"
+  repro="repro: \$TOOL -f ipynb -t html --embed-resources --wrap=none <$input"
+  ofile="$WORK/.embed.oracle" xfile="$WORK/.embed.ox" efile="$WORK/.embed.err"
+  obase="$WORK/.embed.oracle.plain" xbase="$WORK/.embed.ox.plain"
+  if ! "$ORACLE" -f ipynb -t html --wrap=none <"$input" >"$obase" 2>/dev/null \
+    || ! "$OX" -f ipynb -t html --wrap=none <"$input" >"$xbase" 2>/dev/null; then
+    SKIP=$((SKIP + 1))
+    continue
+  fi
+  # Only cases the two tools already render identically without embedding isolate the inlining.
+  if ! compare_text "$obase" "$xbase" >/dev/null; then
+    SKIP=$((SKIP + 1))
+    continue
+  fi
+  if ! "$ORACLE" -f ipynb -t html --embed-resources --wrap=none <"$input" >"$ofile" 2>/dev/null; then
+    SKIP=$((SKIP + 1))
+    continue
+  fi
+  if ! "$OX" -f ipynb -t html --embed-resources --wrap=none <"$input" >"$xfile" 2>"$efile"; then
+    note_err "$label" "$repro
+$(head -n 3 "$efile")"
+    continue
+  fi
+  if detail=$(compare_text "$ofile" "$xfile"); then
+    PASS=$((PASS + 1))
+  else
+    note_fail "$label" "$repro
+embedded HTML differs:
+$detail"
+  fi
+done
+report media embed
+tally_group
+
 exit "$SUITE_RC"


### PR DESCRIPTION
## Summary

Make `--embed-resources` produce a truly self-contained HTML page — a post-render pass inlines every referenced image, stylesheet, script, and CSS `url()` as a `data:` URI, fetching remote resources over HTTP(S) so no external dependency remains.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--embed-resources` to produce self-contained HTML with images, stylesheets, scripts, and other resources embedded as data URIs.
  * Local resources can be resolved from configured paths, with optional remote resource fetching.
* **Bug Fixes**
  * Improved image accessibility and omitted empty `alt` attributes where appropriate.
* **Compatibility**
  * Retained `--self-contained` as a deprecated alias, including a warning.
* **Documentation & Tests**
  * Updated usage documentation and expanded coverage for local, remote, and non-HTML output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->