### PR TITLE
test: cover byte-container readers with a corpus/binary tree

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -11,10 +11,11 @@ Hand-authored test inputs that drive both layers of the test suite:
 corpus/
   exclusions.tsv          target<TAB>feature pairs a writer does not yet implement
   ast/<feature>/*.json    drives WRITER tests — one full Document per file
-  text/<format>/*.<ext>   drives READER tests — one construct family per file
+  text/<format>/*.<ext>   drives READER tests — one construct family per file (UTF-8 text)
+  binary/<format>/*.<ext> drives READER tests for byte-container formats — read as raw bytes
 ```
 
-The **subdirectory is the tag**: under `ast/` it is the document *feature*; under `text/` it is the source *format*. The filename stem is the case label. There is no separate manifest; discovery walks the tree.
+The **subdirectory is the tag**: under `ast/` it is the document *feature*; under `text/` and `binary/` it is the source *format*. The filename stem is the case label. There is no separate manifest; discovery walks the tree.
 
 ### `ast/<feature>/`
 
@@ -26,9 +27,13 @@ A writer that cannot yet render a feature lists the `(target, feature)` pair in 
 
 Small source documents, one construct family per file, per reader format. These are the offline reader regression net; exhaustive reader conformance comes from the vendored spec examples (e.g. `vendor/commonmark/spec.txt`), which the conformance suite runs in addition.
 
+### `binary/<format>/`
+
+Reader fixtures for **byte-container** formats — those whose input is a binary archive (e.g. a zipped office/e-book container) or otherwise not valid UTF-8, so a reader takes raw bytes (`carta_core::BytesReader`). This tree is read verbatim as bytes; `text/` is decoded as UTF-8 and would reject such a fixture. Because a binary fixture cannot be written by hand, generate it (assemble the container's parts and zip them deterministically) and commit the bytes — do not emit it via the oracle, which can bake generator metadata into the file. Both layers discover this tree automatically alongside `text/`.
+
 ## Adding a case
 
 1. **Writer case**: add `corpus/ast/<feature>/<label>.json` (a complete Document). If a target cannot render it yet, add the `(target, feature)` line to `exclusions.tsv`.
-2. **Reader case**: add `corpus/text/<format>/<label>.<ext>` covering one construct family.
+2. **Reader case**: add `corpus/text/<format>/<label>.<ext>` covering one construct family — or, for a byte-container format, `corpus/binary/<format>/<label>.<ext>` (raw bytes).
 3. Refresh snapshots: `cargo insta test --accept` (then review the diff), or `cargo insta review`.
 4. Check parity: `tools/conformance-suite/run.sh all` (requires `.oracle/`).

--- a/corpus/binary/rtf/ansi-raw-byte.rtf
+++ b/corpus/binary/rtf/ansi-raw-byte.rtf
@@ -1,0 +1,1 @@
+{\rtf1\ansi café raw high byte.\par}

--- a/crates/carta/tests/common/mod.rs
+++ b/crates/carta/tests/common/mod.rs
@@ -14,7 +14,7 @@ pub(crate) fn corpus_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../corpus")
 }
 
-/// One discovered corpus case.
+/// One discovered corpus case, decoded as UTF-8 text.
 #[derive(Debug)]
 pub(crate) struct Case {
     /// The subdirectory name: a reader format (`text/`) or a writer feature (`ast/`).
@@ -24,8 +24,21 @@ pub(crate) struct Case {
     pub input: String,
 }
 
-/// Every file under `corpus/<kind>/<group>/`, ordered by (group, label) for stable snapshot names.
-pub(crate) fn corpus_cases(kind: &str) -> Vec<Case> {
+/// One discovered corpus case, kept as raw bytes for a byte-container reader format whose fixture is
+/// a binary archive rather than UTF-8 text.
+#[derive(Debug)]
+pub(crate) struct BinaryCase {
+    /// The subdirectory name: a reader format (`binary/<fmt>/`).
+    pub group: String,
+    /// The file stem.
+    pub label: String,
+    pub input: Vec<u8>,
+}
+
+/// `(group, label, path)` for every file under `corpus/<kind>/<group>/`, ordered by (group, label)
+/// for stable snapshot names. Callers read each path as text ([`corpus_cases`]) or raw bytes
+/// ([`corpus_binary_cases`]).
+fn corpus_files(kind: &str) -> Vec<(String, String, PathBuf)> {
     let root = corpus_dir().join(kind);
     let mut groups: Vec<PathBuf> = read_dir_sorted(&root)
         .into_iter()
@@ -33,7 +46,7 @@ pub(crate) fn corpus_cases(kind: &str) -> Vec<Case> {
         .collect();
     groups.sort();
 
-    let mut cases = Vec::new();
+    let mut files = Vec::new();
     for group_dir in groups {
         let group = file_name(&group_dir);
         for file in read_dir_sorted(&group_dir) {
@@ -45,16 +58,48 @@ pub(crate) fn corpus_cases(kind: &str) -> Vec<Case> {
                 .unwrap_or_else(|| panic!("no stem: {}", file.display()))
                 .to_string_lossy()
                 .into_owned();
-            let input = fs::read_to_string(&file)
-                .unwrap_or_else(|error| panic!("read {}: {error}", file.display()));
-            cases.push(Case {
-                group: group.clone(),
-                label,
-                input,
-            });
+            files.push((group.clone(), label, file));
         }
     }
-    cases
+    files
+}
+
+/// Every file under `corpus/<kind>/<group>/` decoded as UTF-8 text, ordered by (group, label).
+pub(crate) fn corpus_cases(kind: &str) -> Vec<Case> {
+    corpus_files(kind)
+        .into_iter()
+        .map(|(group, label, file)| {
+            let input = fs::read_to_string(&file)
+                .unwrap_or_else(|error| panic!("read {}: {error}", file.display()));
+            Case {
+                group,
+                label,
+                input,
+            }
+        })
+        .collect()
+}
+
+/// Every file under `corpus/<kind>/<group>/` read as RAW BYTES, ordered by (group, label). A byte-
+/// container reader format (whose fixture is a binary archive, not UTF-8 text) keeps its cases here,
+/// since [`corpus_cases`]'s `read_to_string` would reject them. Returns empty when the `kind` tree is
+/// absent — the binary corpus exists only once a byte-container reader ships.
+pub(crate) fn corpus_binary_cases(kind: &str) -> Vec<BinaryCase> {
+    if !corpus_dir().join(kind).is_dir() {
+        return Vec::new();
+    }
+    corpus_files(kind)
+        .into_iter()
+        .map(|(group, label, file)| {
+            let input =
+                fs::read(&file).unwrap_or_else(|error| panic!("read {}: {error}", file.display()));
+            BinaryCase {
+                group,
+                label,
+                input,
+            }
+        })
+        .collect()
 }
 
 /// A writer exclusion: a target plus either a whole feature directory or one case within it.

--- a/crates/carta/tests/golden_reader.rs
+++ b/crates/carta/tests/golden_reader.rs
@@ -12,8 +12,8 @@
 
 mod common;
 
-use carta::{ReaderOptions, WriterOptions};
-use common::corpus_cases;
+use carta::{Output, ReaderOptions, WriterOptions};
+use common::{corpus_binary_cases, corpus_cases};
 
 #[test]
 fn reader_ast_snapshots() {
@@ -30,6 +30,36 @@ fn reader_ast_snapshots() {
             &WriterOptions::default(),
         )
         .unwrap_or_else(|error| panic!("convert {}/{} -> json: {error}", case.group, case.label));
+        insta::assert_snapshot!(format!("{}__{}", case.group, case.label), json);
+    }
+}
+
+/// Reader golden tests for byte-container formats: snapshot carta's JSON AST for each
+/// `corpus/binary/<fmt>/*` case. These fixtures are binary archives (not UTF-8 text), so they are
+/// read as raw bytes and fed through the byte-input `convert` path rather than `convert_text`. The
+/// suite is dormant until a byte-container reader ships (the `corpus/binary` tree is then created).
+#[test]
+fn reader_binary_ast_snapshots() {
+    let readers = carta::supported_input_formats();
+    for case in corpus_binary_cases("binary") {
+        if !readers.contains(&case.group.as_str()) {
+            continue;
+        }
+        let output = carta::convert(
+            &case.group,
+            "json",
+            &case.input,
+            &ReaderOptions::default(),
+            &WriterOptions::default(),
+        )
+        .unwrap_or_else(|error| panic!("convert {}/{} -> json: {error}", case.group, case.label));
+        let json = match output {
+            Output::Text(json) => json,
+            Output::Bytes(_) => panic!(
+                "json target must yield text for {}/{}",
+                case.group, case.label
+            ),
+        };
         insta::assert_snapshot!(format!("{}__{}", case.group, case.label), json);
     }
 }

--- a/crates/carta/tests/snapshots/golden_reader__rtf__ansi-raw-byte.snap
+++ b/crates/carta/tests/snapshots/golden_reader__rtf__ansi-raw-byte.snap
@@ -1,0 +1,5 @@
+---
+source: crates/carta/tests/golden_reader.rs
+expression: json
+---
+{"pandoc-api-version":[1,23,1,2],"meta":{},"blocks":[{"t":"Para","c":[{"t":"Str","c":"café"},{"t":"Space"},{"t":"Str","c":"raw"},{"t":"Space"},{"t":"Str","c":"high"},{"t":"Space"},{"t":"Str","c":"byte."}]}]}

--- a/tools/conformance-suite/README.md
+++ b/tools/conformance-suite/README.md
@@ -105,6 +105,10 @@ Two deliberate scoping choices:
 Add inputs to the shared corpus, not here:
 
 - a reader construct → `corpus/text/<fmt>/<label>.<ext>`
+- a **byte-container** reader construct (a format whose fixtures are binary archives or otherwise not
+  UTF-8 text) → `corpus/binary/<fmt>/<label>.<ext>`. This tree is read as raw bytes (so a binary
+  fixture that `corpus/text/`'s UTF-8 decoding would reject lives here); the reader surface
+  auto-discovers it, needing no `FORMATS=` entry.
 - an extension toggle → `corpus/text-ext/<spec>/<label>.<ext>`, where `<spec>` is the exact `-f`
   string (e.g. `commonmark+mark`, `markdown-blank_before_header`). The `extensions` surface
   **requires** one such directory for every extension the reader honors.

--- a/tools/conformance-suite/surfaces/reader.sh
+++ b/tools/conformance-suite/surfaces/reader.sh
@@ -30,6 +30,26 @@ for fmt in $FORMATS; do
   tally_group
 done
 
+# Byte-container reader formats keep their fixtures under corpus/binary/<fmt>/ (binary archives that
+# are not UTF-8 text, e.g. zipped office/e-book containers, or any file carrying raw high bytes). Each
+# is diffed exactly like a text reader — carta and pandoc both read the file by path — just discovered
+# from the binary tree, so a byte-container reader needs no entry in the FORMATS list above.
+if [ -d "$CORPUS/binary" ]; then
+  for fmt_dir in "$CORPUS"/binary/*; do
+    [ -d "$fmt_dir" ] || continue
+    fmt="$(basename "$fmt_dir")"
+    [ $# -gt 0 ] && [ "$1" != "$fmt" ] && continue
+    conf_reset "reader-$fmt"
+    for input in "$fmt_dir"/*; do
+      [ -f "$input" ] || continue
+      [ -n "$CASE" ] && [ "$(stem "$input")" != "$CASE" ] && continue
+      run_diff json "reader/$fmt/$(basename "$input")" "$input" "-f $fmt -t json" "-f $fmt -t json"
+    done
+    report reader "$fmt"
+    tally_group
+  done
+fi
+
 # Extension-toggle cases: each `corpus/text-ext/<spec>/*` directory is named for the full format
 # spec (e.g. `commonmark+strikeout`, `markdown+citations`) it should be parsed with, for both carta
 # and pandoc. The specs build on the markdown-family readers, which the commonmark group compiles, so


### PR DESCRIPTION
## Summary

Add a `corpus/binary/` fixture tree read as raw bytes so byte-container readers (a zipped office/e-book package, or any non-UTF-8 input) get offline golden and conformance coverage, which the text tree's UTF-8 decoding could not hold.

## Related issues

None.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and followed its rules.
- [x] All checks and tests pass locally.
- [x] I added or updated tests for the change, if needed.
- [x] If this changes support for a format or extension, I updated `README.md` and/or `docs/STATUS.md`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the changelog is generated from them, so no manual `CHANGELOG.md` edit is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCQA7Gukq2FE5QPQ1NPTPk