### PR TITLE
chore: add CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,57 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: signature check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # pull_request_target grants a write token on PRs from forks; safe here because
+    # this job never checks out or executes PR code.
+    if: (github.event_name == 'issue_comment' && (contains(github.event.comment.body, 'recheck') || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))) || github.event_name == 'pull_request_target'
+    steps:
+      - name: Ensure signature branch exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if ! gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/cla-signatures" --silent 2>/dev/null; then
+            base_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/$DEFAULT_BRANCH" --jq .sha)
+            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref=refs/heads/cla-signatures -f sha="$base_sha"
+          fi
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: https://github.com/mfkrause/carta/blob/main/CLA.md
+          path-to-signatures: signatures/version1/cla.json
+          branch: cla-signatures
+          allowlist: mfkrause,dependabot[bot],github-actions[bot],release-plz[bot]
+          custom-notsigned-prcomment: >
+            Thank you for your contribution! Before it can be merged, you need to
+            sign the [Contributor License Agreement](https://github.com/mfkrause/carta/blob/main/CLA.md)
+            (a one-time step covering all your future contributions). Please read it,
+            then sign by posting the comment below.
+          lock-pullrequest-aftermerge: false
+      - name: Label signed PR
+        if: (github.event_name == 'pull_request_target' || github.event.issue.pull_request) && github.event.action != 'closed' && (github.event.pull_request.user.type || github.event.issue.user.type) != 'Bot'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          gh label create cla-signed --repo "$GITHUB_REPOSITORY" \
+            --color 0e8a16 --description "All contributors have signed the CLA" --force
+          gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" -f "labels[]=cla-signed"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,21 +6,27 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-permissions:
-  actions: write
-  contents: write
-  issues: write
-  pull-requests: write
-  statuses: write
+# Signature recording and the branch bootstrap both write to the cla-signatures
+# branch; serialize runs so concurrent signings don't conflict. A queued run that
+# gets superseded is recoverable with a `recheck` comment.
+concurrency:
+  group: cla
+  cancel-in-progress: false
 
 jobs:
   cla:
     name: signature check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: write # re-runs the failed PR check after a signature lands
+      contents: write # commits signature records to the cla-signatures branch
+      issues: write # creates the cla-signed label
+      pull-requests: write # posts and edits the signing prompt comment
+      statuses: write # sets the CLA commit status on the PR
     # pull_request_target grants a write token on PRs from forks; safe here because
     # this job never checks out or executes PR code.
-    if: (github.event_name == 'issue_comment' && (contains(github.event.comment.body, 'recheck') || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))) || github.event_name == 'pull_request_target'
+    if: (github.event_name == 'issue_comment' && github.event.issue.pull_request && (contains(github.event.comment.body, 'recheck') || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))) || github.event_name == 'pull_request_target'
     steps:
       - name: Ensure signature branch exists
         env:
@@ -31,6 +37,9 @@ jobs:
             base_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/$DEFAULT_BRANCH" --jq .sha)
             gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref=refs/heads/cla-signatures -f sha="$base_sha"
           fi
+      # Upstream was archived 2026-03 (v2.6.1 final). The SHA pin makes the code
+      # immutable, so the remaining risk is runtime rot, not tampering; migrate to a
+      # credible successor once one exists.
       - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,243 @@
+# carta Contributor License Agreement
+
+Thank you for your interest in contributing to carta (the "Project"), maintained
+by Maximilian Krause (the "Maintainer").
+
+This document contains two agreements:
+
+- **Part A — Individual Contributor License Agreement.** Signed by every
+  contributor, once, by posting a comment on their first pull request (see the
+  end of Part A).
+- **Part B — Corporate Contributor License Agreement.** Executed by a company
+  or other legal entity whose employees or contractors contribute, by email
+  (see the end of Part B). Individual contributors sign Part A either way;
+  Part B additionally covers the entity's rights in their contributions.
+
+Posting the signing comment on a pull request executes **Part A only**.
+
+**Plain-language summary (not a substitute for the terms below):** You keep
+ownership of your contribution. You give the Maintainer a broad license to use
+it, including the right to distribute it under other licenses — this is what
+allows the Maintainer to offer carta under commercial terms in addition to the
+AGPL. You confirm the contribution is your own work and you are allowed to
+submit it.
+
+## Part A — Individual Contributor License Agreement
+
+This agreement documents the rights granted by contributors to the Maintainer.
+It is for your protection as a contributor as well as the protection of the
+Maintainer and the Project's users; it does not change your rights to use your
+own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your present and
+future Contributions submitted to the Project. Except for the licenses granted
+herein to the Maintainer and recipients of software distributed by the
+Maintainer, You reserve all right, title, and interest in and to Your
+Contributions.
+
+### A.1 Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by
+the copyright owner that is entering into this agreement with the Maintainer.
+For legal entities, the entity making a Contribution and all other entities
+that control, are controlled by, or are under common control with that entity
+are considered to be a single Contributor.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to the Maintainer for inclusion in, or documentation of, the Project.
+For the purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Maintainer or the Maintainer's
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that are
+managed by, or on behalf of, the Maintainer for the purpose of discussing and
+improving the Project, but excluding communication that is conspicuously marked
+or otherwise designated in writing by You as "Not a Contribution."
+
+"Maintainer" shall include the Maintainer's successors and permitted assigns,
+including any legal entity to which the Maintainer transfers stewardship of the
+Project.
+
+### A.2 Grant of Copyright License
+
+Subject to the terms and conditions of this agreement, You hereby grant to the
+Maintainer and to recipients of software distributed by the Maintainer a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works. For clarity, this includes the right to license and
+distribute Your Contributions and derivative works thereof under any license
+terms the Maintainer chooses, including copyleft, permissive, or proprietary
+commercial license terms.
+
+### A.3 Grant of Patent License
+
+Subject to the terms and conditions of this agreement, You hereby grant to the
+Maintainer and to recipients of software distributed by the Maintainer a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Project, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Project to which such Contribution(s) was submitted.
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Project to which You have contributed, constitutes direct
+or contributory patent infringement, then any patent licenses granted to that
+entity under this agreement for that Contribution or Project shall terminate as
+of the date such litigation is filed.
+
+### A.4 Authority
+
+You represent that You are legally entitled to grant the above licenses. If
+Your employer(s) has rights to intellectual property that You create that
+includes Your Contributions, You represent that You have received permission to
+make Contributions on behalf of that employer, that Your employer has waived
+such rights for Your Contributions to the Project, or that Your employer has
+executed the Corporate Contributor License Agreement in Part B of this document
+covering Your Contributions.
+
+### A.5 Original Work
+
+You represent that each of Your Contributions is Your original creation (see
+section A.7 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license or
+other restriction (including, but not limited to, related patents and
+trademarks) of which You are personally aware and which are associated with any
+part of Your Contributions.
+
+### A.6 No Obligation of Support
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+### A.7 Third-Party Submissions
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to the Maintainer separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third party: [named here]".
+
+### A.8 Notification
+
+You agree to notify the Maintainer of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any respect.
+
+### A.9 Governing Law
+
+This agreement is governed by the laws of the Federal Republic of Germany,
+excluding its conflict-of-law provisions. If any provision of this agreement is
+held to be unenforceable, the remaining provisions remain in full force and
+effect.
+
+### Signing Part A
+
+To sign this agreement, post the following comment on your pull request:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature is recorded once and covers all your future contributions to the
+Project.
+
+## Part B — Corporate Contributor License Agreement
+
+This agreement is for corporations or other legal entities whose employees or
+contractors contribute to the Project. It allows an entity to authorize
+Contributions submitted by its designated employees and to grant the licenses
+below for those Contributions.
+
+### B.1 Definitions
+
+"You" (or "Your") shall mean the legal entity that is entering into this
+agreement with the Maintainer, together with all other entities that control,
+are controlled by, or are under common control with that entity.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by Your designated employees or contractors to the Maintainer for inclusion in,
+or documentation of, the Project.
+
+"Maintainer" shall include the Maintainer's successors and permitted assigns,
+including any legal entity to which the Maintainer transfers stewardship of the
+Project.
+
+### B.2 Grant of Copyright License
+
+Subject to the terms and conditions of this agreement, You hereby grant to the
+Maintainer and to recipients of software distributed by the Maintainer a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works. For clarity, this includes the right to license and
+distribute Your Contributions and derivative works thereof under any license
+terms the Maintainer chooses, including copyleft, permissive, or proprietary
+commercial license terms.
+
+### B.3 Grant of Patent License
+
+Subject to the terms and conditions of this agreement, You hereby grant to the
+Maintainer and to recipients of software distributed by the Maintainer a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Project, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Project to which such Contribution(s) was submitted.
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Project to which You have contributed, constitutes direct
+or contributory patent infringement, then any patent licenses granted to that
+entity under this agreement for that Contribution or Project shall terminate as
+of the date such litigation is filed.
+
+### B.4 Authority
+
+You represent that You are legally entitled to grant the above licenses. You
+represent that each employee or contractor designated on Schedule A (or in a
+subsequent written notice to the Maintainer) is authorized to submit
+Contributions on Your behalf.
+
+### B.5 Original Work
+
+You represent that each of Your Contributions is Your or Your designated
+employees' original creation. You represent that Your Contribution submissions
+include complete details of any third-party license or other restriction
+(including, but not limited to, related patents and trademarks) of which You
+are aware and which are associated with any part of Your Contributions.
+
+### B.6 No Obligation of Support
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Unless required by applicable law or
+agreed to in writing, You provide Your Contributions on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+### B.7 Notification
+
+You agree to notify the Maintainer of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any respect,
+and to update the schedule of designated employees when it changes.
+
+### B.8 Governing Law
+
+This agreement is governed by the laws of the Federal Republic of Germany,
+excluding its conflict-of-law provisions. If any provision of this agreement is
+held to be unenforceable, the remaining provisions remain in full force and
+effect.
+
+### Executing Part B
+
+To execute this agreement, send a signed copy to <max@kuatsu.de>, including:
+
+- Entity name, registered address, and jurisdiction of incorporation
+- Name, title, and signature of the person authorized to sign for the entity
+- Point of contact (name and email) for notices under this agreement
+- Schedule A: initial list of designated employees/contractors (names and
+  GitHub usernames)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,5 +69,21 @@ Use the issue templates — they prompt for the input, the exact command, and th
 vs. actual output, which is what makes a report actionable. Security issues follow a
 separate, private process described in [`SECURITY.md`](.github/SECURITY.md).
 
-By contributing, you agree that your contributions are licensed under the same terms as
-the project (see [`LICENSE`](LICENSE)).
+## Contributor License Agreement
+
+Before your first pull request can be merged, you need to sign the
+[Contributor License Agreement](CLA.md). It's a one-time step: a bot will
+prompt you on your first PR, and you sign by posting a single comment. You keep
+full ownership of your contribution.
+
+**Why a CLA?** Being upfront about this: carta is licensed under the AGPL-3.0,
+and its maintainer also uses it in their own commercial software and may license it commercially to companies that can't use
+AGPL software. The CLA grants the maintainer the right to distribute your
+contribution under such commercial terms. This model is
+what funds carta's development. The public version is available under the
+AGPL. If you're not comfortable with this, we absolutely understand! Issues,
+discussions, and bug reports are just as valuable and need no signature.
+
+If you contribute on behalf of your employer, your employer may also need to
+execute the Corporate CLA (Part B of [`CLA.md`](CLA.md)); see the instructions
+at the end of that part.


### PR DESCRIPTION
Adds a Contributor License Agreement (CLA) to the repo, which is required before any external contributors can open PRs, given the existing commercial usage of carta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Contributor License Agreement covering individual and corporate contributions.
  * Updated contribution guidelines with instructions for reviewing and signing the agreement.

* **Chores**
  * Added automated pull request checks to verify CLA signatures.
  * Pull requests are labeled after the required agreement is signed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->