### PR TITLE
ci: allowlist the release app in the CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -47,7 +47,8 @@ jobs:
           path-to-document: https://github.com/mfkrause/carta/blob/main/CLA.md
           path-to-signatures: signatures/version1/cla.json
           branch: cla-signatures
-          allowlist: mfkrause,dependabot[bot],github-actions[bot],release-plz[bot]
+          # carta-release[bot] is the GitHub App release-plz authenticates as.
+          allowlist: mfkrause,dependabot[bot],github-actions[bot],carta-release[bot]
           custom-notsigned-prcomment: >
             Thank you for your contribution! Before it can be merged, you need to
             sign the [Contributor License Agreement](https://github.com/mfkrause/carta/blob/main/CLA.md)


### PR DESCRIPTION
The CLA allowlist named `release-plz[bot]`, but release PRs are authored by `carta-release[bot]` — the GitHub App the release workflow authenticates as — so the CLA bot prompted for a signature on #89. Replace the never-matching entry with the actual app identity.